### PR TITLE
Add ChairLoader Loader

### DIFF
--- a/ChairLoader.sln
+++ b/ChairLoader.sln
@@ -7,6 +7,8 @@ Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "ChairLoader", "ChairLoader\
 EndProject
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "ChairLoaderXMLMerger", "ChairLoaderXMLMerger\ChairLoaderXMLMerger.vcxproj", "{6B5E7880-80D0-457E-BEBA-8674E574538A}"
 EndProject
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "ChairLoaderLoader", "ChairLoaderLoader\ChairLoaderLoader.vcxproj", "{7E920E20-6B96-4302-8B15-05B385E650AB}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|x64 = Debug|x64
@@ -41,6 +43,18 @@ Global
 		{6B5E7880-80D0-457E-BEBA-8674E574538A}.Release|x64.Build.0 = Release|x64
 		{6B5E7880-80D0-457E-BEBA-8674E574538A}.Release|x86.ActiveCfg = Release|Win32
 		{6B5E7880-80D0-457E-BEBA-8674E574538A}.Release|x86.Build.0 = Release|Win32
+		{7E920E20-6B96-4302-8B15-05B385E650AB}.Debug|x64.ActiveCfg = Debug|x64
+		{7E920E20-6B96-4302-8B15-05B385E650AB}.Debug|x64.Build.0 = Debug|x64
+		{7E920E20-6B96-4302-8B15-05B385E650AB}.Debug|x86.ActiveCfg = Debug|Win32
+		{7E920E20-6B96-4302-8B15-05B385E650AB}.Debug|x86.Build.0 = Debug|Win32
+		{7E920E20-6B96-4302-8B15-05B385E650AB}.Library|x64.ActiveCfg = Debug|x64
+		{7E920E20-6B96-4302-8B15-05B385E650AB}.Library|x64.Build.0 = Debug|x64
+		{7E920E20-6B96-4302-8B15-05B385E650AB}.Library|x86.ActiveCfg = Debug|Win32
+		{7E920E20-6B96-4302-8B15-05B385E650AB}.Library|x86.Build.0 = Debug|Win32
+		{7E920E20-6B96-4302-8B15-05B385E650AB}.Release|x64.ActiveCfg = Release|x64
+		{7E920E20-6B96-4302-8B15-05B385E650AB}.Release|x64.Build.0 = Release|x64
+		{7E920E20-6B96-4302-8B15-05B385E650AB}.Release|x86.ActiveCfg = Release|Win32
+		{7E920E20-6B96-4302-8B15-05B385E650AB}.Release|x86.Build.0 = Release|Win32
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/ChairLoaderLoader/ChairLoaderLoader.vcxproj
+++ b/ChairLoaderLoader/ChairLoaderLoader.vcxproj
@@ -1,0 +1,168 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup Label="ProjectConfigurations">
+    <ProjectConfiguration Include="Debug|Win32">
+      <Configuration>Debug</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|Win32">
+      <Configuration>Release</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Debug|x64">
+      <Configuration>Debug</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|x64">
+      <Configuration>Release</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+  </ItemGroup>
+  <PropertyGroup Label="Globals">
+    <VCProjectVersion>16.0</VCProjectVersion>
+    <Keyword>Win32Proj</Keyword>
+    <ProjectGuid>{7e920e20-6b96-4302-8b15-05b385e650ab}</ProjectGuid>
+    <RootNamespace>ChairLoaderLoader</RootNamespace>
+    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
+    <ConfigurationType>DynamicLibrary</ConfigurationType>
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <PlatformToolset>v142</PlatformToolset>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
+    <ConfigurationType>DynamicLibrary</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <PlatformToolset>v142</PlatformToolset>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
+    <ConfigurationType>DynamicLibrary</ConfigurationType>
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <PlatformToolset>v142</PlatformToolset>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
+    <ConfigurationType>DynamicLibrary</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <PlatformToolset>v142</PlatformToolset>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
+  <ImportGroup Label="ExtensionSettings">
+  </ImportGroup>
+  <ImportGroup Label="Shared">
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <PropertyGroup Label="UserMacros" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <LinkIncremental>true</LinkIncremental>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <LinkIncremental>false</LinkIncremental>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <LinkIncremental>true</LinkIncremental>
+    <TargetName>mswsock</TargetName>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <LinkIncremental>false</LinkIncremental>
+    <TargetName>mswsock</TargetName>
+  </PropertyGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <SDLCheck>true</SDLCheck>
+      <PreprocessorDefinitions>WIN32;_DEBUG;CHAIRLOADERLOADER_EXPORTS;_WINDOWS;_USRDLL;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <ConformanceMode>true</ConformanceMode>
+      <PrecompiledHeader>Use</PrecompiledHeader>
+      <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>
+    </ClCompile>
+    <Link>
+      <SubSystem>Windows</SubSystem>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <EnableUAC>false</EnableUAC>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
+      <IntrinsicFunctions>true</IntrinsicFunctions>
+      <SDLCheck>true</SDLCheck>
+      <PreprocessorDefinitions>WIN32;NDEBUG;CHAIRLOADERLOADER_EXPORTS;_WINDOWS;_USRDLL;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <ConformanceMode>true</ConformanceMode>
+      <PrecompiledHeader>Use</PrecompiledHeader>
+      <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>
+    </ClCompile>
+    <Link>
+      <SubSystem>Windows</SubSystem>
+      <EnableCOMDATFolding>true</EnableCOMDATFolding>
+      <OptimizeReferences>true</OptimizeReferences>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <EnableUAC>false</EnableUAC>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <SDLCheck>false</SDLCheck>
+      <PreprocessorDefinitions>_DEBUG;CHAIRLOADERLOADER_EXPORTS;_WINDOWS;_USRDLL;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <ConformanceMode>true</ConformanceMode>
+      <PrecompiledHeader>NotUsing</PrecompiledHeader>
+      <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>
+      <AdditionalIncludeDirectories>%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+    </ClCompile>
+    <Link>
+      <SubSystem>Windows</SubSystem>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <EnableUAC>false</EnableUAC>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
+      <IntrinsicFunctions>true</IntrinsicFunctions>
+      <SDLCheck>false</SDLCheck>
+      <PreprocessorDefinitions>NDEBUG;CHAIRLOADERLOADER_EXPORTS;_WINDOWS;_USRDLL;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <ConformanceMode>true</ConformanceMode>
+      <PrecompiledHeader>NotUsing</PrecompiledHeader>
+      <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>
+      <AdditionalIncludeDirectories>%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+    </ClCompile>
+    <Link>
+      <SubSystem>Windows</SubSystem>
+      <EnableCOMDATFolding>true</EnableCOMDATFolding>
+      <OptimizeReferences>true</OptimizeReferences>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <EnableUAC>false</EnableUAC>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemGroup>
+    <ClInclude Include="framework.h" />
+    <ClInclude Include="mswsock_proxy.h" />
+  </ItemGroup>
+  <ItemGroup>
+    <ClCompile Include="dllmain.cpp" />
+    <ClCompile Include="mswsock_proxy.cpp" />
+  </ItemGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
+  <ImportGroup Label="ExtensionTargets">
+  </ImportGroup>
+</Project>

--- a/ChairLoaderLoader/ChairLoaderLoader.vcxproj.filters
+++ b/ChairLoaderLoader/ChairLoaderLoader.vcxproj.filters
@@ -1,0 +1,33 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup>
+    <Filter Include="Source Files">
+      <UniqueIdentifier>{4FC737F1-C7A5-4376-A066-2A32D752A2FF}</UniqueIdentifier>
+      <Extensions>cpp;c;cc;cxx;c++;cppm;ixx;def;odl;idl;hpj;bat;asm;asmx</Extensions>
+    </Filter>
+    <Filter Include="Header Files">
+      <UniqueIdentifier>{93995380-89BD-4b04-88EB-625FBE52EBFB}</UniqueIdentifier>
+      <Extensions>h;hh;hpp;hxx;h++;hm;inl;inc;ipp;xsd</Extensions>
+    </Filter>
+    <Filter Include="Resource Files">
+      <UniqueIdentifier>{67DA6AB6-F800-4c08-8B7A-83BB121AAD01}</UniqueIdentifier>
+      <Extensions>rc;ico;cur;bmp;dlg;rc2;rct;bin;rgs;gif;jpg;jpeg;jpe;resx;tiff;tif;png;wav;mfcribbon-ms</Extensions>
+    </Filter>
+  </ItemGroup>
+  <ItemGroup>
+    <ClInclude Include="framework.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="mswsock_proxy.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+  </ItemGroup>
+  <ItemGroup>
+    <ClCompile Include="dllmain.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="mswsock_proxy.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+  </ItemGroup>
+</Project>

--- a/ChairLoaderLoader/dllmain.cpp
+++ b/ChairLoaderLoader/dllmain.cpp
@@ -1,0 +1,50 @@
+#include <windows.h>
+#include <detours/detours.h>
+#include "mswsock_proxy.h"
+
+namespace {
+constexpr uintptr_t OFFSET_CGAME_INIT = 0x16D0A90;
+
+class CGame;
+class IGameFramework;
+using CGame_Init = char(__fastcall *)(CGame *thisPtr, IGameFramework *pFramework);
+
+CGame_Init pfnGameInit;
+
+char __fastcall CGameInitHook(CGame *thisPtr, IGameFramework *pFramework) {
+    int ret = pfnGameInit(thisPtr, pFramework);
+    LoadLibraryA("ChairLoader.dll");
+    return ret;
+}
+
+void InstallHooks() {
+    HMODULE prey = LoadLibraryA("PreyDll.dll");
+    pfnGameInit = reinterpret_cast<CGame_Init>((uintptr_t)prey + OFFSET_CGAME_INIT);
+    DetourTransactionBegin();
+    DetourUpdateThread(GetCurrentThread());
+    DetourAttach(&(LPVOID &)pfnGameInit, (PBYTE)CGameInitHook);
+    DetourTransactionCommit();
+}
+}
+
+BOOL APIENTRY DllMain( HMODULE hModule,
+                       DWORD  ul_reason_for_call,
+                       LPVOID lpReserved
+                     )
+{
+    switch (ul_reason_for_call)
+    {
+    case DLL_PROCESS_ATTACH:
+        MSWSProxy_Init();
+        InstallHooks();
+        break;
+    case DLL_THREAD_ATTACH:
+    case DLL_THREAD_DETACH:
+        break;
+    case DLL_PROCESS_DETACH:
+        MSWSProxy_Shutdown();
+        break;
+    }
+    return TRUE;
+}
+

--- a/ChairLoaderLoader/mswsock_proxy.cpp
+++ b/ChairLoaderLoader/mswsock_proxy.cpp
@@ -1,0 +1,78 @@
+#define _WINSOCKAPI_
+#include <cassert>
+#include <winsock2.h>
+#include <Windows.h>
+#include "mswsock_proxy.h"
+
+#define DLLEXPORT __declspec(dllexport)
+
+struct sockaddr;
+
+namespace {
+
+using FnGetAcceptExSockaddrs = void (__stdcall *)(PVOID lpOutputBuffer, DWORD dwReceiveDataLength, DWORD dwLocalAddressLength,
+	DWORD dwRemoteAddressLength, struct sockaddr **LocalSockaddr, LPINT LocalSockaddrLength,
+	struct sockaddr **RemoteSockaddr, LPINT RemoteSockaddrLength);
+
+using FnAcceptEx = BOOL(__stdcall *)(SOCKET sListenSocket, SOCKET sAcceptSocket, PVOID lpOutputBuffer,
+	DWORD dwReceiveDataLength, DWORD dwLocalAddressLength, DWORD dwRemoteAddressLength, LPDWORD lpdwBytesReceived,
+	LPOVERLAPPED lpOverlapped);
+
+HMODULE hWS = nullptr;
+FnGetAcceptExSockaddrs pfn_GetAcceptExSockaddrs = nullptr;
+FnAcceptEx pfn_AcceptEx = nullptr;
+}
+
+
+void MSWSProxy_Init() {
+	hWS = LoadLibraryA("C:\\Windows\\System32\\mswsock.DLL");
+	assert(hWS);
+	pfn_GetAcceptExSockaddrs = reinterpret_cast<FnGetAcceptExSockaddrs>(GetProcAddress(hWS, "GetAcceptExSockaddrs"));
+	pfn_AcceptEx = reinterpret_cast<FnAcceptEx>(GetProcAddress(hWS, "AcceptEx"));
+}
+
+void MSWSProxy_Shutdown() {
+	
+	FreeLibrary(hWS);
+}
+
+extern "C" {
+	DLLEXPORT
+		VOID
+		PASCAL FAR
+		GetAcceptExSockaddrs(
+			_In_reads_bytes_(dwReceiveDataLength + dwLocalAddressLength + dwRemoteAddressLength) PVOID lpOutputBuffer,
+			_In_ DWORD dwReceiveDataLength,
+			_In_ DWORD dwLocalAddressLength,
+			_In_ DWORD dwRemoteAddressLength,
+			_Outptr_result_bytebuffer_(*LocalSockaddrLength) struct sockaddr **LocalSockaddr,
+			_Out_ LPINT LocalSockaddrLength,
+			_Outptr_result_bytebuffer_(*RemoteSockaddrLength) struct sockaddr **RemoteSockaddr,
+			_Out_ LPINT RemoteSockaddrLength
+		) {
+		pfn_GetAcceptExSockaddrs(
+			lpOutputBuffer, dwReceiveDataLength,
+			dwLocalAddressLength, dwRemoteAddressLength,
+			LocalSockaddr, LocalSockaddrLength,
+			RemoteSockaddr, RemoteSockaddrLength
+		);
+	}
+
+	DLLEXPORT
+		BOOL
+		PASCAL FAR
+		AcceptEx(
+			_In_ SOCKET sListenSocket,
+			_In_ SOCKET sAcceptSocket,
+			_Out_writes_bytes_to_(dwReceiveDataLength + dwLocalAddressLength + dwRemoteAddressLength,
+				*lpdwBytesReceived) PVOID lpOutputBuffer,
+			_In_ DWORD dwReceiveDataLength,
+			_In_ DWORD dwLocalAddressLength,
+			_In_ DWORD dwRemoteAddressLength,
+			_Out_ LPDWORD lpdwBytesReceived,
+			_Inout_ LPOVERLAPPED lpOverlapped
+		) {
+		return pfn_AcceptEx(sListenSocket, sAcceptSocket, lpOutputBuffer, dwReceiveDataLength,
+			dwLocalAddressLength, dwRemoteAddressLength, lpdwBytesReceived, lpOverlapped);
+	}
+}

--- a/ChairLoaderLoader/mswsock_proxy.h
+++ b/ChairLoaderLoader/mswsock_proxy.h
@@ -1,0 +1,4 @@
+#pragma once
+
+void MSWSProxy_Init();
+void MSWSProxy_Shutdown();


### PR DESCRIPTION
Adds a loader for ChairLoader.dll. Works by proxying mswsock.dll system library. The built file needs to be placed next to `Prey.exe`. As soon as `CGame::Init` is called it loads ChairLoader.dll.