### PR TITLE
Add profiling tools

### DIFF
--- a/ChairLoader.sln
+++ b/ChairLoader.sln
@@ -5,7 +5,7 @@ VisualStudioVersion = 16.0.32002.261
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "ChairLoader", "ChairLoader\ChairLoader.vcxproj", "{4983A09C-D87D-4050-AE0F-7B8EC5B9EAF1}"
 EndProject
-Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "ChairLoaderXMLMerger", "ChairLoaderXMLLoader\ChairLoaderXMLMerger.vcxproj", "{6B5E7880-80D0-457E-BEBA-8674E574538A}"
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "ChairLoaderXMLLoader", "ChairLoaderXMLLoader\ChairLoaderXMLMerger.vcxproj", "{6B5E7880-80D0-457E-BEBA-8674E574538A}"
 EndProject
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "ChairLoaderLoader", "ChairLoaderLoader\ChairLoaderLoader.vcxproj", "{7E920E20-6B96-4302-8B15-05B385E650AB}"
 EndProject

--- a/ChairLoader/ChairLoader.cpp
+++ b/ChairLoader/ChairLoader.cpp
@@ -3,6 +3,7 @@
 #include "ChairLoader.h"
 #include "ChairloaderUtils.h"
 #include "ChairloaderGui.h"
+#include "Profiler.h"
 
 ChairLoader *gCL = nullptr;
 
@@ -16,8 +17,10 @@ ChairLoader::ChairLoader() {
 
 	HookGameUpdate(moduleBase);
 	LoadConfigFile();
+	m_MainThreadId = std::this_thread::get_id();
 	m_ImGui = std::make_unique<ChairLoaderImGui>();
 	gui = new ChairloaderGui(chairloader);
+	g_pProfiler = new Profiler();
 }
 
 ChairLoader::~ChairLoader()

--- a/ChairLoader/ChairLoader.h
+++ b/ChairLoader/ChairLoader.h
@@ -17,9 +17,13 @@ public:
 	// After CGame::Update
 	void PostUpdate(bool haveFocus, unsigned int updateFlags);
 
+	inline std::thread::id GetMainThreadId() { return m_MainThreadId; }
+	inline std::thread::id GetRenderThreadId() { return m_ImGui->GetRenderThreadId(); }
+
 private:
 	std::unique_ptr<ChairLoaderImGui> m_ImGui;
 	FILE *m_pConsoleFile = nullptr;
+	std::thread::id m_MainThreadId;
 	preyFunctions::CGamePrivate::_Update m_CGameUpdate = nullptr;
 	int m_GuiToggleKey = 0;
 	int m_FreeCamKey = 0;

--- a/ChairLoader/ChairLoader.vcxproj
+++ b/ChairLoader/ChairLoader.vcxproj
@@ -254,6 +254,7 @@
     <ClInclude Include="CharLoaderImGui.h" />
     <ClInclude Include="framework.h" />
     <ClInclude Include="GUIUtils.h" />
+    <ClInclude Include="ImGui\imgui_widget_flamegraph.h" />
     <ClInclude Include="mem.h" />
     <ClInclude Include="pch.h" />
     <ClInclude Include="PerfOverlay.h" />
@@ -282,7 +283,11 @@
     <ClInclude Include="Prey\CrySystem\HardwareMouse.h" />
     <ClInclude Include="Prey\CrySystem\ISystem.h" />
     <ClInclude Include="Prey\CrySystem\ITimer.h" />
+    <ClInclude Include="Prey\CrySystem\Profiling.h" />
+    <ClInclude Include="Prey\CryThreading\IJobManager.h" />
     <ClInclude Include="proc.h" />
+    <ClInclude Include="Profiler.h" />
+    <ClInclude Include="VTableHook.h" />
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="ChairLoader.cpp" />
@@ -290,6 +295,7 @@
     <ClCompile Include="ChairloaderUtils.cpp" />
     <ClCompile Include="CharLoaderImGui.cpp" />
     <ClCompile Include="dllmain.cpp" />
+    <ClCompile Include="ImGui\imgui_widget_flamegraph.cpp" />
     <ClCompile Include="mem.cpp" />
     <ClCompile Include="pch.cpp">
       <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">Create</PrecompiledHeader>
@@ -303,6 +309,8 @@
     <ClCompile Include="preyFunctions.cpp" />
     <ClCompile Include="PreyDllObjects.cpp" />
     <ClCompile Include="proc.cpp" />
+    <ClCompile Include="Profiler.cpp" />
+    <ClCompile Include="VTableHook.cpp" />
   </ItemGroup>
   <ItemGroup>
     <Text Include="codeArchive.txt" />

--- a/ChairLoader/ChairLoader.vcxproj
+++ b/ChairLoader/ChairLoader.vcxproj
@@ -179,7 +179,7 @@
     <ClCompile>
       <WarningLevel>Level3</WarningLevel>
       <SDLCheck>true</SDLCheck>
-      <PreprocessorDefinitions>PREYTESTTRAINER_EXPORTS;_WINDOWS;_USRDLL;_HAS_ITERATOR_DEBUGGING=0;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>PREYTESTTRAINER_EXPORTS;_WINDOWS;_USRDLL;_HAS_ITERATOR_DEBUGGING=0;DEBUG_BUILD;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
       <PrecompiledHeader>Use</PrecompiledHeader>
       <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>
@@ -256,6 +256,7 @@
     <ClInclude Include="GUIUtils.h" />
     <ClInclude Include="mem.h" />
     <ClInclude Include="pch.h" />
+    <ClInclude Include="PerfOverlay.h" />
     <ClInclude Include="preyFunctions.h" />
     <ClInclude Include="preyDllObjects.h" />
     <ClInclude Include="Prey\CryCore\BaseTypes.h" />
@@ -298,6 +299,7 @@
       <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Release|x64'">Create</PrecompiledHeader>
       <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Library|x64'">Create</PrecompiledHeader>
     </ClCompile>
+    <ClCompile Include="PerfOverlay.cpp" />
     <ClCompile Include="preyFunctions.cpp" />
     <ClCompile Include="PreyDllObjects.cpp" />
     <ClCompile Include="proc.cpp" />

--- a/ChairLoader/ChairLoader.vcxproj.filters
+++ b/ChairLoader/ChairLoader.vcxproj.filters
@@ -177,6 +177,9 @@
     <ClInclude Include="GUIUtils.h">
       <Filter>Chairloader</Filter>
     </ClInclude>
+    <ClInclude Include="PerfOverlay.h">
+      <Filter>Chairloader</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="PreyDllObjects.cpp">
@@ -207,6 +210,9 @@
       <Filter>Chairloader</Filter>
     </ClCompile>
     <ClCompile Include="CharLoaderImGui.cpp">
+      <Filter>Chairloader</Filter>
+    </ClCompile>
+    <ClCompile Include="PerfOverlay.cpp">
       <Filter>Chairloader</Filter>
     </ClCompile>
   </ItemGroup>

--- a/ChairLoader/ChairLoader.vcxproj.filters
+++ b/ChairLoader/ChairLoader.vcxproj.filters
@@ -13,9 +13,6 @@
       <UniqueIdentifier>{67DA6AB6-F800-4c08-8B7A-83BB121AAD01}</UniqueIdentifier>
       <Extensions>rc;ico;cur;bmp;dlg;rc2;rct;bin;rgs;gif;jpg;jpeg;jpe;resx;tiff;tif;png;wav;mfcribbon-ms</Extensions>
     </Filter>
-    <Filter Include="Imgui">
-      <UniqueIdentifier>{b6742d2c-deaa-4dfa-be54-e516a1d6c39e}</UniqueIdentifier>
-    </Filter>
     <Filter Include="Chairloader">
       <UniqueIdentifier>{a2d95cdf-123a-4241-be9e-e51ecde3c772}</UniqueIdentifier>
     </Filter>
@@ -45,6 +42,12 @@
     </Filter>
     <Filter Include="Prey\CryNetwork">
       <UniqueIdentifier>{c5d7683f-e49b-4ae4-b5df-83e5e018756f}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Prey\CryThreading">
+      <UniqueIdentifier>{fc931bb6-3df7-4d31-af25-f2d448b06228}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="ImGui">
+      <UniqueIdentifier>{b6742d2c-deaa-4dfa-be54-e516a1d6c39e}</UniqueIdentifier>
     </Filter>
   </ItemGroup>
   <ItemGroup>
@@ -180,6 +183,21 @@
     <ClInclude Include="PerfOverlay.h">
       <Filter>Chairloader</Filter>
     </ClInclude>
+    <ClInclude Include="Profiler.h">
+      <Filter>Chairloader</Filter>
+    </ClInclude>
+    <ClInclude Include="Prey\CryThreading\IJobManager.h">
+      <Filter>Prey\CryThreading</Filter>
+    </ClInclude>
+    <ClInclude Include="VTableHook.h">
+      <Filter>Chairloader</Filter>
+    </ClInclude>
+    <ClInclude Include="ImGui\imgui_widget_flamegraph.h">
+      <Filter>ImGui</Filter>
+    </ClInclude>
+    <ClInclude Include="Prey\CrySystem\Profiling.h">
+      <Filter>Prey\CrySystem</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="PreyDllObjects.cpp">
@@ -214,6 +232,15 @@
     </ClCompile>
     <ClCompile Include="PerfOverlay.cpp">
       <Filter>Chairloader</Filter>
+    </ClCompile>
+    <ClCompile Include="Profiler.cpp">
+      <Filter>Chairloader</Filter>
+    </ClCompile>
+    <ClCompile Include="VTableHook.cpp">
+      <Filter>Chairloader</Filter>
+    </ClCompile>
+    <ClCompile Include="ImGui\imgui_widget_flamegraph.cpp">
+      <Filter>ImGui</Filter>
     </ClCompile>
   </ItemGroup>
   <ItemGroup>

--- a/ChairLoader/ChairloaderGui.h
+++ b/ChairLoader/ChairloaderGui.h
@@ -11,6 +11,7 @@
 #include "ChairloaderGUIConsole.h"
 #include "GUIUtils.h"
 #include "PerfOverlay.h"
+#include "Profiler.h"
 // #include <stack>
 //TODO: INCLUDE LISTENER/HANDLER FUNCTIONS
 
@@ -27,6 +28,7 @@ private:
             showLogHistory = false,
             showDemoWindow = false,
             showStyleManager = false,
+            showProfilerDialog = false,
             freeCam = false,
             devMode = false;
     };
@@ -41,6 +43,7 @@ private:
     ChairloaderGUIEntityManager entityManager;
     ChairloaderGUIConsole console;
     PerfOverlay perfOverlay;
+    ProfilerDialog profilerDialog;
     // std::vector<std::string> modsWithDrawFuncs;
     std::vector<std::tuple<std::function<void()>, std::string>> drawFuncs;
     std::mutex drawHandleMutex;
@@ -77,6 +80,8 @@ public:
                     ImGui::Separator();
 
                     if (ImGui::BeginMenu("Performance")) {
+                        ImGui::MenuItem("Profiler", nullptr, &control.showProfilerDialog);
+                        ImGui::Separator();
                         perfOverlay.ShowMenu();
                         ImGui::EndMenu();
                     }
@@ -125,7 +130,11 @@ public:
                 playerManager.draw(&control.showPlayerManager);
             if(control.showConsole)
                 console.Draw(&control.showConsole);
-            
+
+            if (control.showProfilerDialog) {
+                profilerDialog.Show(&control.showProfilerDialog);
+            }
+
             drawHandleMutex.unlock();
             
         }

--- a/ChairLoader/ChairloaderGui.h
+++ b/ChairLoader/ChairloaderGui.h
@@ -10,6 +10,7 @@
 #include "ChairloaderGUIPlayerManager.h"
 #include "ChairloaderGUIConsole.h"
 #include "GUIUtils.h"
+#include "PerfOverlay.h"
 // #include <stack>
 //TODO: INCLUDE LISTENER/HANDLER FUNCTIONS
 
@@ -39,6 +40,7 @@ private:
     ChairloaderGUIPlayerManager playerManager; 
     ChairloaderGUIEntityManager entityManager;
     ChairloaderGUIConsole console;
+    PerfOverlay perfOverlay;
     // std::vector<std::string> modsWithDrawFuncs;
     std::vector<std::tuple<std::function<void()>, std::string>> drawFuncs;
     std::mutex drawHandleMutex;
@@ -73,6 +75,12 @@ public:
                     ImGui::Separator();
                     ImGui::MenuItem("Show Log History", nullptr, &control.showLogHistory);
                     ImGui::Separator();
+
+                    if (ImGui::BeginMenu("Performance")) {
+                        perfOverlay.ShowMenu();
+                        ImGui::EndMenu();
+                    }
+
                     ImGui::MenuItem("Show ImGui Demo", NULL, &control.showDemoWindow);
                     ImGui::MenuItem("Show Style Editor", NULL, &control.showStyleManager);
                     // ImGui::ShowStyleEditor();
@@ -130,6 +138,8 @@ public:
             //TODO: run other GUI handlers in here 
             drawHandleMutex.unlock();
         }
+
+        perfOverlay.Update();
     }
     bool addDrawFunction(std::string modName, std::function<void()> drawFunction) {
         if (std::find_if(drawFuncs.begin(), drawFuncs.end(), [modName](std::tuple < std::function<void()>, std::string>& e) {return std::get<1>(e) == modName; }) == drawFuncs.end()) {

--- a/ChairLoader/CharLoaderImGui.cpp
+++ b/ChairLoader/CharLoaderImGui.cpp
@@ -6,6 +6,7 @@
 #include <Prey/CryRenderer/IRenderer.h>
 #include <Prey/CryRenderer/Renderer.h>
 #include <Prey/CryRenderer/Texture.h>
+#include <Prey/CrySystem/Profiling.h>
 
 ChairLoaderImGui *ChairLoaderImGui::m_pInstance = nullptr;
 
@@ -34,6 +35,7 @@ ChairLoaderImGui::~ChairLoaderImGui() {
 }
 
 void ChairLoaderImGui::PreUpdate(bool haveFocus) {
+	CRY_PROFILE_MARKER("ImGui::NewFrame");
 	ImGuiIO &io = ImGui::GetIO();
 
 	// Setup display size (every frame to accommodate for window resizing)
@@ -52,6 +54,7 @@ void ChairLoaderImGui::PreUpdate(bool haveFocus) {
 }
 
 void ChairLoaderImGui::PostUpdate() {
+	CRY_PROFILE_MARKER("ImGui::Render");
 	ImGui::Render();
 	SubmitRenderData();
 }
@@ -394,6 +397,7 @@ bool ChairLoaderImGui::RT_Initialize() {
 
 void ChairLoaderImGui::RT_Render() {
 	// Based on ImGui_ImplDX11_RenderDrawData
+	CRY_PROFILE_MARKER("ImGui");
 	RenderThreadData &data = m_pInstance->m_RTData;
 	RenderLists *list = nullptr;
 
@@ -674,6 +678,7 @@ HRESULT ChairLoaderImGui::Present(IDXGISwapChain *pChain, UINT SyncInterval, UIN
 	RenderThreadData &data = m_pInstance->m_RTData;
 
 	if (!data.bIsInitialized) {
+		m_pInstance->m_RenderThreadId = std::this_thread::get_id();
 		if (m_pInstance->RT_Initialize()) {
 			data.bIsReady = true;
 		} else {

--- a/ChairLoader/CharLoaderImGui.h
+++ b/ChairLoader/CharLoaderImGui.h
@@ -12,17 +12,19 @@ public:
 	~ChairLoaderImGui();
 	void PreUpdate(bool haveFocus);
 	void PostUpdate();
+	inline std::thread::id GetRenderThreadId() { return m_RenderThreadId; }
 
 private:
 	static constexpr int BUFFER_SIZE_INCREMENT = 5000;
 	static constexpr float MOUSE_WHEEL_DELTA = 120.0f;
 
+	ITexture *m_pFontAtlas = nullptr;
+	std::thread::id m_RenderThreadId;
+
 	void InitBackend();
 	void CreateFontsTexture();
 	void HookPresent();
 	void SubmitRenderData();
-
-	ITexture *m_pFontAtlas = nullptr;
 
 	static ImGuiKey KeyIdToImGui(EKeyId keyId);
 

--- a/ChairLoader/ImGui/imgui_widget_flamegraph.cpp
+++ b/ChairLoader/ImGui/imgui_widget_flamegraph.cpp
@@ -1,0 +1,152 @@
+// The MIT License(MIT)
+//
+// Copyright(c) 2019 Sandy Carter
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+#include "pch.h"
+#include "imgui_widget_flamegraph.h"
+
+#include "imgui.h"
+#ifndef IMGUI_DEFINE_MATH_OPERATORS
+#define IMGUI_DEFINE_MATH_OPERATORS
+#endif
+#include "imgui_internal.h"
+
+void ImGuiWidgetFlameGraph::PlotFlame(const char* label, void (*values_getter)(float* start, float* end, ImU8* level, const char** caption, const void* data, int idx), const void* data, int values_count, int values_offset, const char* overlay_text, float scale_min, float scale_max, ImVec2 graph_size)
+{
+    ImGuiWindow* window = ImGui::GetCurrentWindow();
+    if (window->SkipItems)
+        return;
+
+    ImGuiContext& g = *GImGui;
+    const ImGuiStyle& style = g.Style;
+
+    // Find the maximum depth
+    ImU8 maxDepth = 0;
+    for (int i = values_offset; i < values_count; ++i)
+    {
+        ImU8 depth;
+        values_getter(nullptr, nullptr, &depth, nullptr, data, i);
+        maxDepth = ImMax(maxDepth, depth);
+    }
+
+    const auto blockHeight = ImGui::GetTextLineHeight() + (style.FramePadding.y * 2);
+    const ImVec2 label_size = ImGui::CalcTextSize(label, NULL, true);
+    if (graph_size.x == 0.0f)
+        graph_size.x = ImGui::CalcItemWidth();
+    if (graph_size.y == 0.0f)
+        graph_size.y = label_size.y + (style.FramePadding.y * 3) + blockHeight * (maxDepth + 1);
+
+    const ImRect frame_bb(window->DC.CursorPos, window->DC.CursorPos + graph_size);
+    const ImRect inner_bb(frame_bb.Min + style.FramePadding, frame_bb.Max - style.FramePadding);
+    const ImRect total_bb(frame_bb.Min, frame_bb.Max + ImVec2(label_size.x > 0.0f ? style.ItemInnerSpacing.x + label_size.x : 0.0f, 0));
+    ImGui::ItemSize(total_bb, style.FramePadding.y);
+    if (!ImGui::ItemAdd(total_bb, 0, &frame_bb))
+        return;
+
+    // Determine scale from values if not specified
+    if (scale_min == FLT_MAX || scale_max == FLT_MAX)
+    {
+        float v_min = FLT_MAX;
+        float v_max = -FLT_MAX;
+        for (int i = values_offset; i < values_count; i++)
+        {
+            float v_start, v_end;
+            values_getter(&v_start, &v_end, nullptr, nullptr, data, i);
+            if (v_start == v_start) // Check non-NaN values
+                v_min = ImMin(v_min, v_start);
+            if (v_end == v_end) // Check non-NaN values
+                v_max = ImMax(v_max, v_end);
+        }
+        if (scale_min == FLT_MAX)
+            scale_min = v_min;
+        if (scale_max == FLT_MAX)
+            scale_max = v_max;
+    }
+
+    ImGui::RenderFrame(frame_bb.Min, frame_bb.Max, ImGui::GetColorU32(ImGuiCol_FrameBg), true, style.FrameRounding);
+
+    bool any_hovered = false;
+    if (values_count - values_offset >= 1)
+    {
+        const ImU32 col_base = ImGui::GetColorU32(ImGuiCol_PlotHistogram) & 0x77FFFFFF;
+        const ImU32 col_hovered = ImGui::GetColorU32(ImGuiCol_PlotHistogramHovered) & 0x77FFFFFF;
+        const ImU32 col_outline_base = ImGui::GetColorU32(ImGuiCol_PlotHistogram) & 0x7FFFFFFF;
+        const ImU32 col_outline_hovered = ImGui::GetColorU32(ImGuiCol_PlotHistogramHovered) & 0x7FFFFFFF;
+
+        for (int i = values_offset; i < values_count; ++i)
+        {
+            float stageStart, stageEnd;
+            ImU8 depth;
+            const char* caption;
+
+            values_getter(&stageStart, &stageEnd, &depth, &caption, data, i);
+
+            auto duration = scale_max - scale_min;
+            if (duration == 0)
+            {
+                return;
+            }
+
+            auto start = stageStart - scale_min;
+            auto end = stageEnd - scale_min;
+
+            auto startX = static_cast<float>(start / (double)duration);
+            auto endX = static_cast<float>(end / (double)duration);
+
+            float width = inner_bb.Max.x - inner_bb.Min.x;
+            float height = blockHeight * (maxDepth - depth + 1) - style.FramePadding.y;
+
+            auto pos0 = inner_bb.Min + ImVec2(startX * width, height);
+            auto pos1 = inner_bb.Min + ImVec2(endX * width, height + blockHeight);
+
+            bool v_hovered = false;
+            if (ImGui::IsMouseHoveringRect(pos0, pos1))
+            {
+                ImGui::SetTooltip("%s: %8.4g", caption, stageEnd - stageStart);
+                v_hovered = true;
+                any_hovered = v_hovered;
+            }
+
+            window->DrawList->AddRectFilled(pos0, pos1, v_hovered ? col_hovered : col_base);
+            window->DrawList->AddRect(pos0, pos1, v_hovered ? col_outline_hovered : col_outline_base);
+            auto textSize = ImGui::CalcTextSize(caption);
+            auto boxSize = (pos1 - pos0);
+            auto textOffset = ImVec2(0.0f, 0.0f);
+            if (textSize.x < boxSize.x)
+            {
+                textOffset = ImVec2(0.5f, 0.5f) * (boxSize - textSize);
+                ImGui::RenderText(pos0 + textOffset, caption);
+            }
+        }
+
+        // Text overlay
+        if (overlay_text)
+            ImGui::RenderTextClipped(ImVec2(frame_bb.Min.x, frame_bb.Min.y + style.FramePadding.y), frame_bb.Max, overlay_text, NULL, NULL, ImVec2(0.5f,0.0f));
+
+        if (label_size.x > 0.0f)
+            ImGui::RenderText(ImVec2(frame_bb.Max.x + style.ItemInnerSpacing.x, inner_bb.Min.y), label);
+    }
+
+    if (!any_hovered && ImGui::IsItemHovered())
+    {
+        ImGui::SetTooltip("Total: %8.4g", scale_max - scale_min);
+    }
+}

--- a/ChairLoader/ImGui/imgui_widget_flamegraph.h
+++ b/ChairLoader/ImGui/imgui_widget_flamegraph.h
@@ -1,0 +1,37 @@
+// https://github.com/bwrsandman/imgui-flame-graph
+// v 1.00
+//
+// The MIT License(MIT)
+//
+// Copyright(c) 2019 Sandy Carter
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+// History :
+// 2019-10-22 First version
+
+#pragma once
+
+#include <climits>
+
+#include <imgui.h>
+
+namespace ImGuiWidgetFlameGraph {
+    IMGUI_API void PlotFlame(const char* label, void (*values_getter)(float* start, float* end, ImU8* level, const char** caption, const void* data, int idx), const void* data, int values_count, int values_offset = 0, const char* overlay_text = NULL, float scale_min = FLT_MAX, float scale_max = FLT_MAX, ImVec2 graph_size = ImVec2(0, 0));
+}

--- a/ChairLoader/PerfOverlay.cpp
+++ b/ChairLoader/PerfOverlay.cpp
@@ -1,0 +1,53 @@
+#include "pch.h"
+#include <Prey/CrySystem/ITimer.h>
+#include "PerfOverlay.h"
+#include "ChairloaderUtils.h"
+
+PerfOverlay::PerfOverlay() {
+#ifdef DEBUG_BUILD
+	m_bEnabled = true;
+	m_bFrameTime = true;
+#endif
+}
+
+void PerfOverlay::Update() {
+	if (!m_bEnabled) {
+		return;
+	}
+
+	ImGuiWindowFlags window_flags =
+		ImGuiWindowFlags_NoDecoration | ImGuiWindowFlags_AlwaysAutoResize |
+		ImGuiWindowFlags_NoSavedSettings | ImGuiWindowFlags_NoFocusOnAppearing |
+		ImGuiWindowFlags_NoNav | ImGuiWindowFlags_NoInputs | ImGuiWindowFlags_NoBackground;
+	ImGui::SetNextWindowPos(ImVec2(10, 20), ImGuiCond_Always, ImVec2(0, 0));
+
+	if (ImGui::Begin("PerfOverlay", nullptr, window_flags)) {
+		// A bit of filtering so it doesn't jump around
+		float frametime = chairloader->preyEnvironmentPointers->pTimer->GetRealFrameTime();
+		m_LastFrameTime = FILTER_K * frametime + (1 - FILTER_K) * m_LastFrameTime;
+
+		ImGui::Text("FPS: %5.1f", 1.0f / m_LastFrameTime);
+
+		if (m_bFrameTime) {
+			ImGui::Text("Frametime: %6.3f ms", m_LastFrameTime * 1000.0);
+		}
+	}
+
+	ImGui::End();
+}
+
+void PerfOverlay::ShowMenu() {
+	// TODO: Should save these somewhere
+	ImGui::MenuItem("Enable overlay", nullptr, &m_bEnabled);
+	ImGui::BeginDisabled(!m_bEnabled);
+	ImGui::MenuItem("Show frame time", nullptr, &m_bFrameTime);
+	ImGui::EndDisabled();
+}
+
+void PerfOverlay::SetEnabled(bool state) {
+	m_bEnabled = state;
+}
+
+void PerfOverlay::SetFrameTimeVisible(bool state) {
+	m_bFrameTime = state;
+}

--- a/ChairLoader/PerfOverlay.h
+++ b/ChairLoader/PerfOverlay.h
@@ -1,0 +1,17 @@
+#pragma once
+
+class PerfOverlay {
+public:
+	PerfOverlay();
+
+	void Update();
+	void ShowMenu();
+	void SetEnabled(bool state);
+	void SetFrameTimeVisible(bool state);
+
+private:
+	static constexpr float FILTER_K = 0.2f;
+	bool m_bEnabled = false;
+	bool m_bFrameTime = false;
+	float m_LastFrameTime = 0;
+};

--- a/ChairLoader/Prey/CrySystem/Profiling.h
+++ b/ChairLoader/Prey/CrySystem/Profiling.h
@@ -1,0 +1,20 @@
+#pragma once
+#include <Prey/CryThreading/IJobManager.h>
+#include "ChairloaderUtils.h"
+
+namespace CryProfile {
+class CScopedProfileMarker {
+public:
+	CScopedProfileMarker(const char *name) {
+		chairloader->preyEnvironmentPointers->pJobManager->PushProfilingMarker(name);
+	}
+
+	~CScopedProfileMarker() {
+		chairloader->preyEnvironmentPointers->pJobManager->PopProfilingMarker();
+	}
+};
+}
+
+#define CRYPROF_CAT_(a, b) a ## b
+#define CRYPROF_CAT(a, b)  CRYPROF_CAT_(a, b)
+#define CRY_PROFILE_MARKER(name) CryProfile::CScopedProfileMarker CRYPROF_CAT(profMarker, __LINE__)(name)

--- a/ChairLoader/Prey/CryThreading/IJobManager.h
+++ b/ChairLoader/Prey/CryThreading/IJobManager.h
@@ -1,0 +1,65 @@
+#pragma once
+#include <functional>
+
+class CTimeValue;
+
+namespace JobManager {
+
+enum EBackEndType
+{
+	eBET_Thread = 0x0,
+	eBET_Fallback = 0x1,
+	eBET_Blocking = 0x2,
+};
+
+enum TPriorityLevel
+{
+	eHighPriority = 0x0,
+	eRegularPriority = 0x1,
+	eLowPriority = 0x2,
+	eStreamPriority = 0x3,
+	eNumPriorityLevel = 0x4,
+};
+
+class IBackend;
+class CJobDelegator;
+struct SJobStringHandle;
+struct SJobState;
+struct SJobProfilingData;
+struct SJobFinishedConditionVariable;
+
+class IJobManager
+{
+public:
+	static constexpr size_t VTBL_PushProfilingMarker = 17;
+	static constexpr size_t VTBL_PopProfilingMarker = 18;
+
+	virtual ~IJobManager() = 0;
+	virtual void Init(unsigned int) = 0;
+	virtual void AddJob(CJobDelegator *, SJobStringHandle *const) = 0;
+	virtual void AddLambdaJob(const char *, const std::function<void __cdecl(void)> *, TPriorityLevel, SJobState *) = 0;
+	virtual bool WaitForJob(SJobState *) = 0;
+	virtual SJobStringHandle *GetJobHandle(const char *, void(void *)) = 0;
+	virtual SJobStringHandle *GetJobHandle(const char *, const unsigned int, void(void *)) = 0;
+	virtual void ShutDown() = 0;
+	virtual IBackend *GetBackEnd(EBackEndType) = 0;
+	virtual bool InvokeAsJob(SJobStringHandle *const) = 0;
+	virtual bool InvokeAsJob(const char *) = 0;
+	virtual void SetJobFilter(const char *) = 0;
+	virtual void SetJobSystemEnabled(int) = 0;
+	virtual unsigned int GetWorkerThreadId() = 0;
+	virtual SJobProfilingData *GetProfilingData(unsigned __int16) = 0;
+	virtual unsigned __int16 ReserveProfilingData() = 0;
+	virtual void Update(int) = 0;
+	virtual void PushProfilingMarker(const char *) = 0;
+	virtual void PopProfilingMarker() = 0;
+	virtual unsigned int GetNumWorkerThreads() = 0;
+	virtual unsigned __int16 AllocateSemaphore(const volatile void *) = 0;
+	virtual void DeallocateSemaphore(unsigned __int16, const volatile void *) = 0;
+	virtual bool AddRefSemaphore(unsigned __int16, const volatile void *) = 0;
+	virtual SJobFinishedConditionVariable *GetSemaphore(unsigned __int16, const volatile void *) = 0;
+	virtual void DumpJobList() = 0;
+	virtual void SetFrameStartTime(const CTimeValue *) = 0;
+};
+
+}

--- a/ChairLoader/Profiler.cpp
+++ b/ChairLoader/Profiler.cpp
@@ -1,0 +1,365 @@
+#include "pch.h"
+#include <Prey/CryThreading/IJobManager.h>
+#include <Prey/CrySystem/Profiling.h>
+#include "Profiler.h"
+#include "ChairLoader.h"
+#include "ChairloaderUtils.h"
+#include "ImGui/imgui_widget_flamegraph.h"
+
+Profiler *g_pProfiler = nullptr;
+
+namespace {
+
+//! One profiling marker
+struct Node {
+	char name[Profiler::MAX_MARKER_NAME];
+	int64_t startTime = 0;
+	int64_t endTime = 0;
+	int16_t parent = -1;
+	int16_t children[Profiler::MAX_DIRECT_CHILDREN];
+	int8_t childCount = 0;
+};
+
+//! Tree of markers
+struct ProfileData {
+	std::vector<Node> nodes;
+	mutable std::mutex mutex;
+	int16_t currentNode = -1;
+
+	void Clear() {
+		nodes.clear();
+		currentNode = -1;
+	}
+
+	bool IsReady() const {
+		return !nodes.empty() && nodes[0].endTime != 0;
+	}
+};
+
+// Thread-specific data
+struct ThreadProfile {
+	ProfileData datas[Profiler::DATA_COUNT];
+	int currentData = 0;
+};
+
+ThreadProfile g_Profiles[2];
+thread_local int g_ProfileIdx = -1;
+
+int64_t g_TicksPerSecond;
+int64_t g_TickOffset;
+double g_SecsPerTick;
+
+int64_t GetCPUTickCount() {
+	LARGE_INTEGER li;
+	QueryPerformanceCounter(&li);
+	return li.QuadPart;
+}
+
+void UpdateTicksPerSecond() {
+	LARGE_INTEGER li;
+	if (QueryPerformanceFrequency(&li)) {
+		g_TicksPerSecond = li.QuadPart;
+	} else {
+		assert(false && "QueryPerformanceFrequency failed");
+		g_TicksPerSecond = 1000000;
+	}
+
+	g_SecsPerTick = 1.0 / g_TicksPerSecond;
+}
+
+//! @returns profile datas for calling thread.
+ThreadProfile *GetProfileForThisThread() {
+	int idx = g_ProfileIdx;
+
+	if (idx == -1) {
+		std::thread::id threadId = std::this_thread::get_id();
+		if (threadId == gCL->GetMainThreadId()) {
+			idx = Profiler::MAIN_THREAD;
+		} else if (threadId == gCL->GetRenderThreadId()) {
+			idx = Profiler::RENDER_THREAD;
+		} else {
+			// Thread is not profiled
+			g_ProfileIdx = -2;
+			return nullptr;
+		}
+
+		g_ProfileIdx = idx;
+	} else if (idx == -2) {
+		return nullptr;
+	}
+
+	return &g_Profiles[idx];
+}
+
+void PushProfilingMarker(JobManager::IJobManager *_this, char *name) {
+	int64_t startTime = GetCPUTickCount();
+	ThreadProfile *pProfile = GetProfileForThisThread();
+
+	if (!pProfile) {
+		return;
+	}
+
+	ProfileData &data = pProfile->datas[pProfile->currentData];
+	std::unique_lock lock(data.mutex);
+
+	if (data.nodes.size() >= Profiler::MAX_NODES_CHILDREN) {
+		printf("PushProfilingMarker: too many nodes\n");
+		return;
+	}
+
+	if (data.currentNode == -1) {
+		// Now adding the root node
+		data.Clear();
+	}
+
+	// Add new node
+	int16_t newNodeIdx = (int16_t)data.nodes.size();
+	Node &newNode = data.nodes.emplace_back();
+
+	// Add the node to the parent
+	if (data.currentNode != -1) {
+		Node &parent = data.nodes[data.currentNode];
+		
+		if (parent.childCount == Profiler::MAX_DIRECT_CHILDREN) {
+			printf("PushProfilingMarker: too many children\n");
+			return;
+		}
+
+		parent.children[parent.childCount] = newNodeIdx;
+		parent.childCount++;
+	}
+
+	// Fill node data
+	memcpy(newNode.name, name, Profiler::MAX_MARKER_NAME);
+	newNode.startTime = startTime;
+	newNode.parent = data.currentNode;
+
+	// Update current node
+	data.currentNode = newNodeIdx;
+}
+
+void PopProfilingMarker(JobManager::IJobManager *_this, char *name) {
+	ThreadProfile *pProfile = GetProfileForThisThread();
+
+	if (!pProfile) {
+		return;
+	}
+
+	ProfileData &data = pProfile->datas[pProfile->currentData];
+	std::unique_lock lock(data.mutex);
+
+	if (data.currentNode == -1) {
+		return;
+	}
+
+	Node &nodeToPop = data.nodes[data.currentNode];
+	data.currentNode = nodeToPop.parent;
+	nodeToPop.endTime = GetCPUTickCount();
+
+	if (nodeToPop.parent == -1) {
+		// Next time use other data
+		pProfile->currentData = (pProfile->currentData + 1) % Profiler::DATA_COUNT;
+	}
+}
+
+void PushProfilingMarker_Disabled(JobManager::IJobManager *_this, char *name) {}
+void PopProfilingMarker_Disabled(JobManager::IJobManager *_this) {}
+
+void RecursiveProcessNode(const ProfileData &data, Profiler::ProcessedProfileData &procData,
+						  const Node &node, Profiler::ProcessedNode *pParent, int depth) {
+	int16_t procNodeIdx = (int16_t)data.nodes.size();
+	Profiler::ProcessedNode &procNode = procData.nodes.emplace_back();
+
+	if (pParent) {
+		pParent->children[pParent->childCount] = procNodeIdx;
+		pParent->childCount++;
+	}
+
+	memcpy(procNode.name, node.name, sizeof(node.name));
+	procNode.startTime = (float)((node.startTime - g_TickOffset) * g_SecsPerTick * 1000.0);
+	procNode.endTime = (float)((node.endTime - g_TickOffset) * g_SecsPerTick * 1000.0);
+	procNode.depth = depth;
+	procNode.childCount = node.childCount;
+	procData.minTime = std::min(procData.minTime, procNode.startTime);
+	procData.maxTime = std::max(procData.maxTime, procNode.endTime);
+
+	for (int i = 0; i < node.childCount; i++) {
+		RecursiveProcessNode(data, procData, data.nodes[node.children[i]], &procNode, depth + 1);
+	}
+}
+
+void ProfilerValueGetter(float *startTimestamp, float *endTimestamp, ImU8 *level, const char **caption, const void *pUser, int idx) {
+	auto data = reinterpret_cast<const Profiler::ProcessedProfileData *>(pUser);
+	auto &node = data->nodes[idx];
+	if (startTimestamp) {
+		*startTimestamp = node.startTime;
+	}
+	if (endTimestamp) {
+		*endTimestamp = node.endTime;
+	}
+	if (level) {
+		*level = node.depth;
+	}
+	if (caption) {
+		*caption = node.name;
+	}
+}
+
+} // namespace
+
+Profiler::Profiler() {
+	UpdateTicksPerSecond();
+	m_JobManagerHook.HookObject(chairloader->preyEnvironmentPointers->pJobManager);
+	g_TickOffset = GetCPUTickCount();
+}
+
+void Profiler::SetEnabled(bool state) {
+	if (state) {
+		Enable();
+	} else {
+		Disable();
+	}
+}
+
+void Profiler::Enable() {
+	if (m_bEnabled) {
+		return;
+	}
+
+	if (gCL->GetRenderThreadId() == std::thread::id()) {
+		printf("Render thread ID must be set before profiler is enabled\n");
+		return;
+	}
+
+	m_JobManagerHook.HookMethod(JobManager::IJobManager::VTBL_PushProfilingMarker, &PushProfilingMarker);
+	m_JobManagerHook.HookMethod(JobManager::IJobManager::VTBL_PopProfilingMarker, &PopProfilingMarker);
+	m_bEnabled = true;
+}
+
+void Profiler::Disable() {
+	if (!m_bEnabled) {
+		return;
+	}
+
+	m_JobManagerHook.HookMethod(JobManager::IJobManager::VTBL_PushProfilingMarker, &PushProfilingMarker_Disabled);
+	m_JobManagerHook.HookMethod(JobManager::IJobManager::VTBL_PopProfilingMarker, &PopProfilingMarker_Disabled);
+	m_bEnabled = false;
+}
+
+bool Profiler::GetDataForThread(int threadIdx, ProcessedProfileData &outData) {
+	const ThreadProfile &profile = g_Profiles[threadIdx];
+	int curData = profile.currentData + 1;
+
+	// Try to find a data that is not locked and is ready
+	for (int i = 0; i < DATA_COUNT; i++) {
+		int idx = (curData + i + 1) % DATA_COUNT;
+		const ProfileData &profData = profile.datas[idx];
+		std::unique_lock lock(profData.mutex, std::defer_lock);
+
+		if (!lock.try_lock() || !profData.IsReady()) {
+			continue;
+		}
+
+		outData.Clear();
+		RecursiveProcessNode(profData, outData, profData.nodes[0], nullptr, 0);
+		return true;
+	}
+
+	return false;
+}
+
+void ProfilerDialog::Show(bool *pIsOpen) {
+	CRY_PROFILE_MARKER("Profiler Dialog");
+	if (!*pIsOpen) {
+		return;
+	}
+
+	if (ImGui::Begin("Profiler", pIsOpen)) {
+		bool isEnabled = g_pProfiler->IsEnabled();
+		if (ImGui::Checkbox("Enable", &isEnabled)) {
+			g_pProfiler->SetEnabled(isEnabled);
+		}
+		
+		if (g_pProfiler->IsEnabled()) {
+			ImGui::SameLine();
+			ImGui::TextColored(ImColor(255, 0, 0), "Profiler is running");
+
+			if (m_bFreeze) {
+				ImGui::SameLine();
+				ImGui::TextColored(ImColor(255, 255, 0), "Graph frozen");
+			}
+		}
+
+		if (ImGui::BeginTabBar("Tab Bar")) {
+			if (ImGui::BeginTabItem("Flame Graph")) {
+				ShowFlameGraph();
+				ImGui::EndTabItem();
+			}
+
+			if (ImGui::BeginTabItem("ReadMe")) {
+				ShowReadMe();
+				ImGui::EndTabItem();
+			}
+
+			ImGui::EndTabBar();
+		}
+	}
+
+	ImGui::End();
+}
+
+void ProfilerDialog::ShowFlameGraph() {
+	bool update = m_FramesLeft == 0 && !m_bFreeze;
+
+	ImGui::Checkbox("Freeze", &m_bFreeze);
+	ImGui::SameLine();
+
+	update = ImGui::Button("Refresh") || update;
+	ImGui::SameLine();
+
+	ImGui::PushItemWidth(200);
+	if (ImGui::SliderInt("Throttle", &m_ThrottleFrames, 0, 60)) {
+		m_ThrottleFrames = std::max(m_ThrottleFrames, 0);
+		m_FramesLeft = 0;
+	}
+	ImGui::PopItemWidth();
+
+	if (g_pProfiler->IsEnabled() && update) {
+		g_pProfiler->GetDataForThread(Profiler::MAIN_THREAD, m_MainThreadData);
+		g_pProfiler->GetDataForThread(Profiler::RENDER_THREAD, m_RenderThreadData);
+		m_GraphMinTime = std::min(m_MainThreadData.minTime, m_RenderThreadData.minTime);
+		m_GraphMaxTime = std::max(m_MainThreadData.maxTime, m_RenderThreadData.maxTime);
+	}
+
+	ShowFlameGraphForThread(m_MainThreadData, "Main Thread");
+	ShowFlameGraphForThread(m_RenderThreadData, "Render Thread");
+
+	m_FramesLeft--;
+	if (m_FramesLeft == -1) {
+		m_FramesLeft = m_ThrottleFrames;
+	}
+}
+
+void ProfilerDialog::ShowFlameGraphForThread(Profiler::ProcessedProfileData &data, const char *threadName) {
+
+	char label[128];
+	snprintf(label, sizeof(label), "##%s", threadName);
+	ImVec2 vMin = ImGui::GetWindowContentRegionMin();
+	ImVec2 vMax = ImGui::GetWindowContentRegionMax();
+
+	ImGuiWidgetFlameGraph::PlotFlame(label, &ProfilerValueGetter, &data,
+		(int)data.nodes.size(), 0, threadName, m_GraphMinTime, m_GraphMaxTime, ImVec2(vMax.x - vMin.x, 0));
+}
+
+void ProfilerDialog::ShowReadMe() {
+	ImGui::Text("1) Flame graph times are in ms.");
+	ImGui::Text("2) Profiler uses markers left in the game as well as custom ones\n   added to ChairLoader functions.");
+	ImGui::Text("3) Enabling profiler will have some additional overhead but\n   it should be negligible compared to functions that need markers.");
+	ImGui::Text("4) Timings will jump around every frame. Use \"freeze\" or \"throttle\"\n   to make the graph readable.");
+}
+
+void Profiler::ProcessedProfileData::Clear() {
+	nodes.clear();
+	minTime = FLT_MAX;
+	maxTime = FLT_MIN;
+}

--- a/ChairLoader/Profiler.h
+++ b/ChairLoader/Profiler.h
@@ -1,0 +1,62 @@
+#pragma once
+#include "VTableHook.h"
+
+class Profiler {
+public:
+	static constexpr int MAIN_THREAD = 0;
+	static constexpr int RENDER_THREAD = 1;
+
+	static constexpr int MAX_MARKER_NAME = 256;		//!< Maximum marker name length. Engine limit.
+	static constexpr int MAX_DIRECT_CHILDREN = 24;	//!< Maximum immediate children of a node. Just a sane limit.
+	static constexpr int MAX_NODES_CHILDREN = 32767;//!< Maximum number of nodes. int16_t limit.
+	static constexpr int DATA_COUNT = 4;			//!< Number of profile data to keep at the same time.
+
+	struct ProcessedNode {
+		char name[Profiler::MAX_MARKER_NAME];
+		float startTime = 0;
+		float endTime = 0;
+		int depth = 0;
+		int16_t children[MAX_DIRECT_CHILDREN];
+		int8_t childCount = 0;
+	};
+
+	struct ProcessedProfileData {
+		std::vector<ProcessedNode> nodes;
+		float minTime = FLT_MAX;
+		float maxTime = FLT_MIN;
+
+		void Clear();
+	};
+
+	Profiler();
+	inline bool IsEnabled() { return m_bEnabled; }
+	void SetEnabled(bool state);
+	void Enable();
+	void Disable();
+	bool GetDataForThread(int threadIdx, ProcessedProfileData &data);
+
+private:
+	bool m_bEnabled = false;
+	float m_NextTicksUpdate = 0;
+	VTableHook m_JobManagerHook;
+};
+
+class ProfilerDialog {
+public:
+	void Show(bool *pIsOpen);
+
+private:
+	Profiler::ProcessedProfileData m_MainThreadData;
+	Profiler::ProcessedProfileData m_RenderThreadData;
+	bool m_bFreeze = false;
+	int m_ThrottleFrames = 0;;
+	int m_FramesLeft = 0;
+	float m_GraphMinTime = 0;
+	float m_GraphMaxTime = 0;
+
+	void ShowFlameGraph();
+	void ShowFlameGraphForThread(Profiler::ProcessedProfileData &data, const char *threadName);
+	void ShowReadMe();
+};
+
+extern Profiler *g_pProfiler;

--- a/ChairLoader/VTableHook.cpp
+++ b/ChairLoader/VTableHook.cpp
@@ -1,0 +1,22 @@
+#include "pch.h"
+#include <cstdlib>
+#include <cstring>
+#include "VTableHook.h"
+
+void VTableHook::HookObject(uintptr_t obj) {
+	uintptr_t *vtable = *((uintptr_t **)obj);
+	m_pMemory = new uintptr_t[DATA_BEFORE_START + VTABLE_SIZE];
+	memcpy(m_pMemory, vtable - DATA_BEFORE_START, DATA_BEFORE_START + VTABLE_SIZE);
+	*((uintptr_t **)obj) = m_pMemory + DATA_BEFORE_START;
+}
+
+uintptr_t VTableHook::HookMethod(size_t idx, uintptr_t newMethod)
+{
+	size_t memidx = DATA_BEFORE_START + idx;
+	uintptr_t old = m_pMemory[memidx];
+	void (*debug)() = (void (*)())old;
+	(void)debug;
+	m_pMemory[memidx] = newMethod;
+	return old;
+}
+

--- a/ChairLoader/VTableHook.h
+++ b/ChairLoader/VTableHook.h
@@ -1,0 +1,31 @@
+#pragma once
+#include <cstdint>
+
+//! Class for changing virtual functions on per-object basis.
+//! Makes a copy of the object's vtable. Objects that have multiple
+//! vtables will need multiple VTableHook instances.
+class VTableHook {
+public:
+	//! Initializes the hook for specified object.
+	void HookObject(uintptr_t obj);
+
+	//! Replaces and object's method in vtable with a different one. 
+	uintptr_t HookMethod(size_t idx, uintptr_t newMethod);
+
+	template <typename T>
+	void HookObject(T *obj) {
+		HookObject(reinterpret_cast<uintptr_t>(obj));
+	}
+
+	template <typename T>
+	T *HookMethod(size_t idx, T *newMethod) {
+		uintptr_t oldNethod = HookMethod(idx, reinterpret_cast<uintptr_t>(newMethod));
+		return reinterpret_cast<T *>(oldNethod);
+	}
+
+private:
+	static constexpr size_t DATA_BEFORE_START = 32;
+	static constexpr size_t VTABLE_SIZE = 512;
+
+	uintptr_t *m_pMemory = nullptr;
+};

--- a/ChairLoader/preyDllObjects.h
+++ b/ChairLoader/preyDllObjects.h
@@ -60,6 +60,11 @@ class ITimer;
 class IRenderer;
 class ITexture;
 class IHardwareMouse;
+
+namespace JobManager {
+class IJobManager;
+}
+
 enum class EWinVersion {
 	WinUndetected = 0,
 	Win2000 = 1,
@@ -125,7 +130,7 @@ class gameEnvironmentPointers {
 		void *pAuxGeomRenderer		;
 		IHardwareMouse *pHardwareMouse		;
 		void* pMaterialEffects		;
-		void* pJobManager			;
+		JobManager::IJobManager* pJobManager;
 		void* pOverloadSceneManager	;
 		void* pFlashUI				;
 		void* pServiceNetwork		;


### PR DESCRIPTION
Adds an overlay with FPS and frame time. Can be enabled in the menu, enabled automatically in debug builds
Adds a profiler that reuses game's profiling markers. Custom ones can be added by including `<Prey/CrySystem/Profiling.h>` and adding `CRY_PROFILE_MARKER("Function name");` to the function to profile.
Flame graph uses [imgui-flame-graph](https://github.com/bwrsandman/imgui-flame-graph) widget.