### PR TITLE
ImGui mouse improvements

### DIFF
--- a/ChairLoader/ChairLoaderImGui.cpp
+++ b/ChairLoader/ChairLoaderImGui.cpp
@@ -69,6 +69,19 @@ void ChairLoaderImGui::PreUpdate(bool haveFocus) {
 	if (haveFocus && io.WantSetMousePos)
 		gEnv->pHardwareMouse->SetHardwareMouseClientPosition(io.MousePos.x, io.MousePos.y);
 
+	if (!m_ImGuiUsesMouse && io.WantCaptureMouse)
+	{
+		// Show cursor
+		gEnv->pHardwareMouse->IncrementCounter();
+	}
+	else if (m_ImGuiUsesMouse && !io.WantCaptureMouse)
+	{
+		// Hide cursor
+		gEnv->pHardwareMouse->DecrementCounter();
+	}
+
+	m_ImGuiUsesMouse = io.WantCaptureMouse;
+
 	ImGui::NewFrame();
 }
 

--- a/ChairLoader/ChairLoaderImGui.h
+++ b/ChairLoader/ChairLoaderImGui.h
@@ -15,6 +15,8 @@ public:
 	void PostUpdate();
 	inline std::thread::id GetRenderThreadId() { return m_RenderThreadId; }
 
+	static bool HasExclusiveMouseInput();
+
 private:
 	static constexpr int BUFFER_SIZE_INCREMENT = 5000;
 	static constexpr float MOUSE_WHEEL_DELTA = 120.0f;

--- a/ChairLoader/ChairLoaderImGui.h
+++ b/ChairLoader/ChairLoaderImGui.h
@@ -21,6 +21,7 @@ private:
 
 	ITexture *m_pFontAtlas = nullptr;
 	std::thread::id m_RenderThreadId;
+	bool m_ImGuiUsesMouse = false;
 
 	void InitBackend();
 	void CreateFontsTexture();

--- a/ChairLoader/ChairLoaderImGui.h
+++ b/ChairLoader/ChairLoaderImGui.h
@@ -20,12 +20,15 @@ private:
 	static constexpr float MOUSE_WHEEL_DELTA = 120.0f;
 
 	ITexture *m_pFontAtlas = nullptr;
+	HCURSOR m_hGameCursor = nullptr;
 	std::thread::id m_RenderThreadId;
 	bool m_ImGuiUsesMouse = false;
+	ImGuiMouseCursor m_LastMouseCursor = ImGuiMouseCursor_None;
 
 	void InitBackend();
 	void CreateFontsTexture();
 	void HookPresent();
+	void UpdateMouseCursor();
 	void SubmitRenderData();
 
 	static ImGuiKey KeyIdToImGui(EKeyId keyId);

--- a/Common/Prey/CrySystem/HardwareMouse.h
+++ b/Common/Prey/CrySystem/HardwareMouse.h
@@ -5,7 +5,11 @@
 
 class ITexture;
 
-class CHardwareMouse : IRendererEventListener, IInputEventListener, IHardwareMouse, ISystemEventListener
+class CHardwareMouse :
+	public IRendererEventListener,
+	public IInputEventListener,
+	public IHardwareMouse,
+	public ISystemEventListener
 {
 public:
 	std::list<IHardwareMouseEventListener *> m_listHardwareMouseEventListeners;

--- a/Common/Prey/CrySystem/HardwareMouse.h
+++ b/Common/Prey/CrySystem/HardwareMouse.h
@@ -7,6 +7,7 @@ class ITexture;
 
 class CHardwareMouse : IRendererEventListener, IInputEventListener, IHardwareMouse, ISystemEventListener
 {
+public:
 	std::list<IHardwareMouseEventListener *> m_listHardwareMouseEventListeners;
 	ITexture *m_pCursorTexture;
 	int m_iReferenceCounter;
@@ -24,4 +25,6 @@ class CHardwareMouse : IRendererEventListener, IInputEventListener, IHardwareMou
 	bool m_hide;
 	bool m_calledShowHWMouse;
 	int m_debugHardwareMouse;
+
+	static inline auto FEvent = PreyFunction<void(CHardwareMouse* const _this, int iX, int iY, EHARDWAREMOUSEEVENT eHardwareMouseEvent, int wheelDelta)>(0xDA37B0);
 };


### PR DESCRIPTION
1) Exclusive mouse input to ImGui when hovering a window. But in-game, camera control takes priority. Otherwise invisible mouse cursor hits top bar or screen edges and input switches to ImGui, making playing the game impossible.
2) Support for mouse cursors. Hovering an ImGui window switches to default Windows cursor or a cursor requested by ImGui. Unhovering switches back to game's cursor.