### PR TITLE
Steam API & Achievements

### DIFF
--- a/Chairloader/CMakeLists.txt
+++ b/Chairloader/CMakeLists.txt
@@ -7,6 +7,7 @@ add_subdirectory(Common)
 # Chairloader modules
 add_subdirectory(Core)
 add_subdirectory(CryRender)
+add_subdirectory(Patches)
 add_subdirectory(Tools)
 
 # Chairloader DLLs

--- a/Chairloader/Common/CMakeLists.txt
+++ b/Chairloader/Common/CMakeLists.txt
@@ -7,6 +7,7 @@ set(SOURCE_FILES
 	Chairloader/IChairloaderCryRender.h
 	Chairloader/IChairloaderDll.h
 	Chairloader/IChairloaderModule.h
+	Chairloader/IChairloaderPatches.h
 	Chairloader/IChairloaderTools.h
 	Chairloader/ILogManager.h
 	Chairloader/IModDllManager.h

--- a/Chairloader/Common/Chairloader/IChairloaderDll.h
+++ b/Chairloader/Common/Chairloader/IChairloaderDll.h
@@ -6,6 +6,7 @@ namespace Internal
 
 struct IChairloaderCore;
 struct IChairloaderCryRender;
+struct IChairloaderPatches;
 struct IChairloaderTools;
 
 struct IChairloaderDll : public IChairloader
@@ -13,6 +14,7 @@ struct IChairloaderDll : public IChairloader
 	virtual ~IChairloaderDll() {}
 	virtual IChairloaderCore* GetCore() = 0;
 	virtual IChairloaderCryRender* GetCryRender() = 0;
+	virtual IChairloaderPatches* GetPatches() = 0;
 	virtual IChairloaderTools* GetTools() = 0;
 
 	//! @returns whether it was handled and shouldn't be passed over to the game.

--- a/Chairloader/Common/Chairloader/IChairloaderPatches.h
+++ b/Chairloader/Common/Chairloader/IChairloaderPatches.h
@@ -1,0 +1,19 @@
+#pragma once
+#include <Chairloader/IChairloaderModule.h>
+
+namespace Internal
+{
+
+struct IChairloaderPatches : public IChairloaderModule
+{
+	static std::unique_ptr<IChairloaderPatches> CreateInstance();
+	virtual ~IChairloaderPatches() {}
+
+	//! System initialization
+	virtual void InitSystem() = 0;
+
+	//! Game initialization.
+	virtual void InitGame() = 0;
+};
+
+} // namespace Internal

--- a/Chairloader/Dll/CMakeLists.txt
+++ b/Chairloader/Dll/CMakeLists.txt
@@ -24,6 +24,7 @@ target_link_libraries(Chairloader.Dll PRIVATE
 	Chairloader.Common
 	Chairloader.Core
 	Chairloader.CryRender
+	Chairloader.Patches
 	Chairloader.Tools
 )
 

--- a/Chairloader/Dll/Chairloader.cpp
+++ b/Chairloader/Dll/Chairloader.cpp
@@ -270,6 +270,17 @@ void Chairloader::InitSystem(CSystem* pSystem)
 	// Initialize Core
 	m_pCore->InitSystem();
 
+	// Initialize Patches
+	if (!pSystem->GetICmdLine()->FindArg(eCLAT_Pre, "nopatches"))
+	{
+		m_pPatches = Internal::IChairloaderPatches::CreateInstance();
+		m_pPatches->InitSystem();
+	}
+	else
+	{
+		CryLog("Optional patches disabled via command line");
+	}
+
 	// Initialize Tools
 	Internal::SToolsInitParams toolsParams;
 	toolsParams.bEnableEditor = m_bEditorEnabled;
@@ -310,6 +321,10 @@ void Chairloader::InitGame(CGame* pGame, IGameFramework* pFramework)
 	m_pRender->SetRenderThreadIsIdle(true);
 	m_pCore->InitGame();
 	m_pRender->InitGame();
+
+	if (m_pPatches)
+		m_pPatches->InitGame();
+
 	m_pTools->InitGame();
 	m_pCore->GetDllManager()->CallInitGame();
 	m_pRender->SetRenderThreadIsIdle(false);
@@ -330,6 +345,9 @@ void Chairloader::ShutdownGame()
 	// Destroy tools before ImGui
 	m_pTools = nullptr;
 
+	if (m_pPatches)
+		m_pPatches->ShutdownGame();
+
 	m_pCore->ShutdownGame();
 	m_pFramework = nullptr;
 
@@ -344,6 +362,9 @@ void Chairloader::ShutdownSystem()
 
 	m_pCore->GetDllManager()->CallShutdownSystem();
 	m_pCore->GetDllManager()->UnloadModules();
+
+	if (m_pPatches)
+		m_pPatches->ShutdownGame();
 
 	m_pRender->ShutdownSystem();
 	m_pCore->ShutdownSystem();
@@ -376,6 +397,10 @@ void Chairloader::MainUpdate(unsigned updateFlags)
 {
 	m_pCore->MainUpdate(updateFlags);
 	m_pRender->MainUpdate(updateFlags);
+
+	if (m_pPatches)
+		m_pPatches->MainUpdate(updateFlags);
+
 	m_pTools->MainUpdate(updateFlags);
 
 	if (gCL->gui->IsEnabled())

--- a/Chairloader/Dll/Chairloader.h
+++ b/Chairloader/Dll/Chairloader.h
@@ -83,6 +83,7 @@ public:
 	// IChairloaderDll
 	Internal::IChairloaderCore* GetCore() override { return m_pCore.get(); }
 	Internal::IChairloaderCryRender* GetCryRender() override { return m_pRender.get(); }
+	Internal::IChairloaderPatches* GetPatches() override { return m_pPatches.get(); }
 	Internal::IChairloaderTools* GetTools() override { return m_pTools.get(); }
 	bool HandleKeyPress(const SInputEvent& event) override;
 	void ReloadModDLLs() override;

--- a/Chairloader/Dll/Chairloader.h
+++ b/Chairloader/Dll/Chairloader.h
@@ -3,6 +3,7 @@
 #include <Chairloader/IChairloaderCore.h>
 #include <Chairloader/IChairloaderCryRender.h>
 #include <Chairloader/IChairloaderDll.h>
+#include <Chairloader/IChairloaderPatches.h>
 #include <Chairloader/IChairloaderTools.h>
 #include "WinConsole.h"
 
@@ -50,6 +51,7 @@ private:
     bool m_bTrainerEnabled = false;
 	std::unique_ptr<Internal::IChairloaderCore> m_pCore;
 	std::unique_ptr<Internal::IChairloaderCryRender> m_pRender;
+	std::unique_ptr<Internal::IChairloaderPatches> m_pPatches;
 	std::unique_ptr<Internal::IChairloaderTools> m_pTools;
 	unsigned m_SavedUpdateFlags = 0;
 

--- a/Chairloader/Dll/ImportantClass.h
+++ b/Chairloader/Dll/ImportantClass.h
@@ -38,7 +38,8 @@ public:
     }
 
     ~ImportantListener() override {
-        gEnv->pSystem->GetISystemEventDispatcher()->RemoveListener(this);
+        if (gEnv && gEnv->pSystem)
+            gEnv->pSystem->GetISystemEventDispatcher()->RemoveListener(this);
     }
 
     void OnSystemEventAnyThread(ESystemEvent event, UINT_PTR wparam, UINT_PTR lparam) override;

--- a/Chairloader/Patches/ArkFixedRewardSystem.cpp
+++ b/Chairloader/Patches/ArkFixedRewardSystem.cpp
@@ -1,0 +1,116 @@
+#include "ArkFixedRewardSystem.h"
+
+unsigned ArkFixedRewardSystem::IncrementTrackableValue(unsigned _trackable)
+{
+    int oldVal = m_trackables[_trackable].value;
+    int newVal = oldVal + 1;
+    m_trackables[_trackable].value = newVal;
+    TrackableChanged(_trackable, oldVal, newVal);
+    return newVal;
+}
+
+unsigned ArkFixedRewardSystem::IncrementTrackableValue(uint64_t _associatedMetric)
+{
+    if (_associatedMetric == kNoAssociatedMetric)
+        return 0;
+
+    ArkRewardTrackable* pTrackable = m_trackablesByMetric[_associatedMetric];
+
+    if (!pTrackable)
+        return 0;
+
+    // ???
+    if (pTrackable->value >= 0x0FFF'FFFF)
+        return 0;
+
+    return IncrementTrackableValue(pTrackable->id);
+}
+
+unsigned ArkFixedRewardSystem::UpdateTrackableValueMax(uint64_t _associatedMetric, unsigned _value)
+{
+    if (_associatedMetric == kNoAssociatedMetric)
+        return 0;
+
+    ArkRewardTrackable* pTrackable = m_trackablesByMetric[_associatedMetric];
+
+    if (!pTrackable)
+        return 0;
+
+    int oldVal = pTrackable->value;
+    if (_value > oldVal)
+    {
+        pTrackable->value = _value;
+        TrackableChanged(pTrackable->id, oldVal, _value);
+        return _value;
+    }
+    else
+    {
+        return oldVal;
+    }
+}
+
+void ArkFixedRewardSystem::UnlockReward(unsigned _reward)
+{
+    if (IsSuppressed())
+    {
+        CryLog("[ArkFixedRewardSystem] UnlockReward suppressed (rewardId: {})", _reward);
+        return;
+    }
+
+    CryLog("ArkFixedRewardSystem::UnlockReward: {}", _reward);
+
+    ArkReward& reward = m_rewards[_reward];
+
+    if (!reward.bCriteriaMet)
+    {
+        reward.bCriteriaMet = true;
+
+        // Original code passes this to the reward thread, which will call the handler.
+        // I don't want to deal with threading. It shouldn't block anyway.
+        InternalRewardUnlocked(reward.unlockId);
+        if (m_pHandler)
+            m_pHandler->OnRewardUnlocked(m_userId, reward.unlockId);
+    }
+}
+
+void ArkFixedRewardSystem::TrackableChanged(unsigned trackable, unsigned oldVal, unsigned newVal)
+{
+    if (IsSuppressed())
+    {
+        CryLog("[ArkFixedRewardSystem] TrackChanged reward suppressed (trackableId: {}) (oldValue: {}) (newValue: {})",
+            trackable, oldVal, newVal);
+        return;
+    }
+
+    ArkRewardTrackable* pTrackable = &m_trackables[trackable];
+    CryLog("ArkFixedRewardSystem::TrackableChanged: [{}] {} -> {}", trackable, oldVal, newVal);
+
+    // See if need to unlock any rewards
+    for (ArkReward& reward : m_rewards)
+    {
+        bool needUnlock = false;
+
+        for (ArkRewardTrackableCriteria& criteria : reward.criteria)
+        {
+            if (!criteria.bCriteriaMet &&
+                criteria.trackable == pTrackable &&
+                criteria.trackable->value >= criteria.value)
+            {
+                criteria.bCriteriaMet = true;
+                needUnlock = true;
+            }
+        }
+
+        if (needUnlock)
+        {
+            reward.bCriteriaMet = true;
+
+            // Original code passes this to the reward thread 
+            InternalRewardUnlocked(reward.unlockId);
+        }
+    }
+
+    InternalTrackableUpdated(trackable, oldVal, newVal);
+    if (m_pHandler)
+        m_pHandler->OnChangedTrackable(m_userId, trackable, oldVal, newVal);
+}

--- a/Chairloader/Patches/ArkFixedRewardSystem.h
+++ b/Chairloader/Patches/ArkFixedRewardSystem.h
@@ -1,0 +1,19 @@
+#pragma once
+#include <Prey/CrySystem/Ark/ArkRewardSystem.h>
+
+//! Fixed version of CArkRewardSystem that actually calls
+//! InternalTrackableUpdated and InternalRewardUnlocked.
+//! Unlike the original version, doesn't use RewardsThread.
+class ArkFixedRewardSystem : public CArkRewardSystem
+{
+public:
+    virtual unsigned IncrementTrackableValue(unsigned _trackable) override;
+    virtual unsigned IncrementTrackableValue(uint64_t _associatedMetric) override;
+    virtual unsigned UpdateTrackableValueMax(uint64_t _associatedMetric, unsigned _value) override;
+    virtual void UnlockReward(unsigned _reward) override;
+
+private:
+    //! Original code calls somewhere into gEnv->pSystem->GetIPlatformOS()
+    inline bool IsSuppressed() { return false; }
+    void TrackableChanged(unsigned trackable, unsigned oldVal, unsigned newVal);
+};

--- a/Chairloader/Patches/CMakeLists.txt
+++ b/Chairloader/Patches/CMakeLists.txt
@@ -1,6 +1,8 @@
 set(SOURCE_FILES
 	CMakeLists.txt
 
+	SteamAPI/ArkSteamRewardSystem.cpp
+	SteamAPI/ArkSteamRewardSystem.h
 	SteamAPI/ChairSteamAPI.cpp
 	SteamAPI/ChairSteamAPI.h
 	

--- a/Chairloader/Patches/CMakeLists.txt
+++ b/Chairloader/Patches/CMakeLists.txt
@@ -6,6 +6,8 @@ set(SOURCE_FILES
 	SteamAPI/ChairSteamAPI.cpp
 	SteamAPI/ChairSteamAPI.h
 	
+	ArkFixedRewardSystem.cpp
+	ArkFixedRewardSystem.h
 	ChairloaderPatches.cpp
 	ChairloaderPatches.h
 )

--- a/Chairloader/Patches/CMakeLists.txt
+++ b/Chairloader/Patches/CMakeLists.txt
@@ -1,0 +1,18 @@
+set(SOURCE_FILES
+	CMakeLists.txt
+
+	SteamAPI/ChairSteamAPI.cpp
+	SteamAPI/ChairSteamAPI.h
+	
+	ChairloaderPatches.cpp
+	ChairloaderPatches.h
+)
+
+add_library(Chairloader.Patches STATIC ${SOURCE_FILES})
+target_include_directories(Chairloader.Patches PRIVATE .)
+
+target_link_libraries(Chairloader.Patches PUBLIC
+	Chairloader.Common
+)
+
+source_group(TREE ${CMAKE_CURRENT_SOURCE_DIR} FILES ${SOURCE_FILES})

--- a/Chairloader/Patches/CMakeLists.txt
+++ b/Chairloader/Patches/CMakeLists.txt
@@ -1,6 +1,8 @@
 set(SOURCE_FILES
 	CMakeLists.txt
 
+	SteamAPI/ArkSteamDlcSystem.cpp
+	SteamAPI/ArkSteamDlcSystem.h
 	SteamAPI/ArkSteamRewardSystem.cpp
 	SteamAPI/ArkSteamRewardSystem.h
 	SteamAPI/ChairSteamAPI.cpp

--- a/Chairloader/Patches/ChairloaderPatches.cpp
+++ b/Chairloader/Patches/ChairloaderPatches.cpp
@@ -1,14 +1,46 @@
 #include <Prey/CrySystem/System.h>
+#include <Prey/CryInput/dxinput.h>
 #include <Chairloader/IChairloaderDll.h>
+#include <Chairloader/Hooks/HookTransaction.h>
 #include "SteamAPI/ChairSteamAPI.h"
 #include "ChairloaderPatches.h"
 
+auto g_CleanupVibrationAtExit = PreyFunction<void()>(0x9D85C0);
+FunctionHook<void()> g_CleanupVibrationAtExit_Hook;
+
 auto g_CSystem_InitSoundSystem_Hook = CSystem::FInitSoundSystem.MakeHook();
+auto g_CDXInput_ShutDown_Hook = CDXInput::FShutDown.MakeHook();
+
+void CleanupVibrationAtExit_Hook()
+{
+	// Do nothing. See CDXInput_ShutDown_Hook.
+}
 
 bool CSystem_InitSoundSystem_Hook(CSystem* const _this, const SSystemInitParams& _initParams)
 {
 	static_cast<ChairloaderPatches*>(gChair->GetPatches())->ReplaceArkSystems();
 	return g_CSystem_InitSoundSystem_Hook.InvokeOrig(_this, _initParams);
+}
+
+void CDXInput_ShutDown_Hook(CDXInput* const _this)
+{
+	g_CDXInput_ShutDown_Hook.InvokeOrig(_this);
+
+	// Clean up vibration after DXInput is shut down instead of in std::atexit.
+	// 
+	// This patch was made because XInputSetState call in std::atexit causes
+	// Steam Overlay Renderer to crash when exiting the game.
+	// That crash happens even in Steam version of the game.
+	// 
+	// The patch is here and not in ChairSteamAPI because I think it's a bad idea to
+	// call into external libraries during std::atexit as they may have already been shut down.
+	// The crash may also occur with other game overlays (not confirmed).
+	// 
+	// Crash callstack:
+	// - GameOverlayRenderer64.dll!???
+	// - GameOverlayRenderer64.dll!XInputSetState_Hook
+	// - PreyDll.dll!CleanupVibrationAtExit
+	g_CleanupVibrationAtExit_Hook.InvokeOrig();
 }
 
 std::unique_ptr<Internal::IChairloaderPatches> Internal::IChairloaderPatches::CreateInstance()
@@ -25,7 +57,16 @@ void ChairloaderPatches::ReplaceArkSystems()
 void ChairloaderPatches::InitSystem()
 {
 	g_CSystem_InitSoundSystem_Hook.SetHookFunc(&CSystem_InitSoundSystem_Hook);
+	g_CDXInput_ShutDown_Hook.SetHookFunc(&CDXInput_ShutDown_Hook);
 	m_pSteamAPI = ChairSteamAPI::CreateInstance();
+
+	{
+		// CleanupVibrationAtExit_Hook is called after Chairloader is shut down and
+		// all automatic hooks are removed. So it must use manual hook.
+		HookTransaction tr;
+		g_CleanupVibrationAtExit_Hook.InstallHook(g_CleanupVibrationAtExit.Get(), &CleanupVibrationAtExit_Hook);
+		tr.CommitOrDie();
+	}
 }
 
 void ChairloaderPatches::InitGame()

--- a/Chairloader/Patches/ChairloaderPatches.cpp
+++ b/Chairloader/Patches/ChairloaderPatches.cpp
@@ -1,0 +1,24 @@
+#include <Chairloader/IChairloaderDll.h>
+#include "SteamAPI/ChairSteamAPI.h"
+#include "ChairloaderPatches.h"
+
+std::unique_ptr<Internal::IChairloaderPatches> Internal::IChairloaderPatches::CreateInstance()
+{
+	return std::make_unique<ChairloaderPatches>();
+}
+
+void ChairloaderPatches::InitSystem()
+{
+	m_pSteamAPI = ChairSteamAPI::CreateInstance();
+}
+
+void ChairloaderPatches::InitGame()
+{
+    
+}
+
+void ChairloaderPatches::MainUpdate(unsigned updateFlags)
+{
+	if (m_pSteamAPI)
+		m_pSteamAPI->Update();
+}

--- a/Chairloader/Patches/ChairloaderPatches.cpp
+++ b/Chairloader/Patches/ChairloaderPatches.cpp
@@ -1,14 +1,30 @@
+#include <Prey/CrySystem/System.h>
 #include <Chairloader/IChairloaderDll.h>
 #include "SteamAPI/ChairSteamAPI.h"
 #include "ChairloaderPatches.h"
+
+auto g_CSystem_InitSoundSystem_Hook = CSystem::FInitSoundSystem.MakeHook();
+
+bool CSystem_InitSoundSystem_Hook(CSystem* const _this, const SSystemInitParams& _initParams)
+{
+	static_cast<ChairloaderPatches*>(gChair->GetPatches())->ReplaceArkSystems();
+	return g_CSystem_InitSoundSystem_Hook.InvokeOrig(_this, _initParams);
+}
 
 std::unique_ptr<Internal::IChairloaderPatches> Internal::IChairloaderPatches::CreateInstance()
 {
 	return std::make_unique<ChairloaderPatches>();
 }
 
+void ChairloaderPatches::ReplaceArkSystems()
+{
+	if (m_pSteamAPI)
+		m_pSteamAPI->ReplaceArkSystems();
+}
+
 void ChairloaderPatches::InitSystem()
 {
+	g_CSystem_InitSoundSystem_Hook.SetHookFunc(&CSystem_InitSoundSystem_Hook);
 	m_pSteamAPI = ChairSteamAPI::CreateInstance();
 }
 

--- a/Chairloader/Patches/ChairloaderPatches.h
+++ b/Chairloader/Patches/ChairloaderPatches.h
@@ -1,0 +1,16 @@
+#pragma once
+#include <Chairloader/IChairloaderPatches.h>
+
+class ChairSteamAPI;
+
+class ChairloaderPatches : public Internal::IChairloaderPatches
+{
+public:
+	// Internal::IChairloaderPatches
+	virtual void InitSystem() override;
+	virtual void InitGame() override;
+	virtual void MainUpdate(unsigned updateFlags) override;
+
+private:
+	std::unique_ptr<ChairSteamAPI> m_pSteamAPI;
+};

--- a/Chairloader/Patches/ChairloaderPatches.h
+++ b/Chairloader/Patches/ChairloaderPatches.h
@@ -6,6 +6,9 @@ class ChairSteamAPI;
 class ChairloaderPatches : public Internal::IChairloaderPatches
 {
 public:
+	//! Called before CSystem::InitSoundSystem to replace pArkRewardSystem and pArkDlcSystem.
+	void ReplaceArkSystems();
+
 	// Internal::IChairloaderPatches
 	virtual void InitSystem() override;
 	virtual void InitGame() override;

--- a/Chairloader/Patches/SteamAPI/ArkSteamDlcSystem.cpp
+++ b/Chairloader/Patches/SteamAPI/ArkSteamDlcSystem.cpp
@@ -1,0 +1,24 @@
+#include <Chairloader/SteamAPI/IChairSteamAPI.h>
+#include "SteamAPI/ArkSteamDlcSystem.h"
+
+void ArkSteamDlcSystem::InitEnv(SSystemGlobalEnvironment* _gEnv)
+{
+    CArkDlcSystem::InitEnv(_gEnv);
+    RequestRefresh();
+}
+
+void ArkSteamDlcSystem::Refresh()
+{
+    CArkDlcSystem::Refresh();
+    ISteamApps* pSteamApps = SteamApps();
+
+    for (auto& [name, dlcInfo] : m_dlcPlatformIdMap)
+    {
+        AppId_t steamAppId = std::strtol(dlcInfo.SteamId.c_str(), nullptr, 10);
+        bool isInstalled = pSteamApps->BIsDlcInstalled(steamAppId);
+        UpdateDlcUnlocked(&dlcInfo, isInstalled);
+
+        if (isInstalled)
+            CryLog("[ArkSteamDlcSystem] DLC {} is installed", dlcInfo.Name);
+    }
+}

--- a/Chairloader/Patches/SteamAPI/ArkSteamDlcSystem.cpp
+++ b/Chairloader/Patches/SteamAPI/ArkSteamDlcSystem.cpp
@@ -15,7 +15,7 @@ void ArkSteamDlcSystem::Refresh()
     for (auto& [name, dlcInfo] : m_dlcPlatformIdMap)
     {
         AppId_t steamAppId = std::strtol(dlcInfo.SteamId.c_str(), nullptr, 10);
-        bool isInstalled = pSteamApps->BIsDlcInstalled(steamAppId);
+        bool isInstalled = pSteamApps && pSteamApps->BIsDlcInstalled(steamAppId);
         UpdateDlcUnlocked(&dlcInfo, isInstalled);
 
         if (isInstalled)

--- a/Chairloader/Patches/SteamAPI/ArkSteamDlcSystem.h
+++ b/Chairloader/Patches/SteamAPI/ArkSteamDlcSystem.h
@@ -1,0 +1,10 @@
+#pragma once
+#include <Prey/CrySystem/Ark/ArkDlcSystem.h>
+
+//! IArkDlcSystem implementation using Steam API.
+class ArkSteamDlcSystem final : public CArkDlcSystem
+{
+public:
+    virtual void InitEnv(SSystemGlobalEnvironment* _gEnv) override;
+    virtual void Refresh() override;
+};

--- a/Chairloader/Patches/SteamAPI/ArkSteamRewardSystem.cpp
+++ b/Chairloader/Patches/SteamAPI/ArkSteamRewardSystem.cpp
@@ -1,6 +1,6 @@
 #include <Chairloader/SteamAPI/IChairSteamAPI.h>
 #include <Chairloader/IChairXmlUtils.h>
-#include "ArkSteamRewardSystem.h"
+#include "SteamAPI/ArkSteamRewardSystem.h"
 
 ArkSteamRewardSystem::ArkSteamRewardSystem()
 {
@@ -35,79 +35,6 @@ bool ArkSteamRewardSystem::LoadRewardData(const string& _strRewardFile)
     return true;
 }
 
-unsigned ArkSteamRewardSystem::IncrementTrackableValue(unsigned _trackable)
-{
-    int oldVal = m_trackables[_trackable].value;
-    int newVal = oldVal + 1;
-    m_trackables[_trackable].value = newVal;
-    TrackableChanged(_trackable, oldVal, newVal);
-    return newVal;
-}
-
-unsigned ArkSteamRewardSystem::IncrementTrackableValue(uint64_t _associatedMetric)
-{
-    if (_associatedMetric == kNoAssociatedMetric)
-        return 0;
-
-    ArkRewardTrackable* pTrackable = m_trackablesByMetric[_associatedMetric];
-
-    if (!pTrackable)
-        return 0;
-
-    // ???
-    if (pTrackable->value >= 0x0FFF'FFFF)
-        return 0;
-
-    return IncrementTrackableValue(pTrackable->id);
-}
-
-unsigned ArkSteamRewardSystem::UpdateTrackableValueMax(uint64_t _associatedMetric, unsigned _value)
-{
-    if (_associatedMetric == kNoAssociatedMetric)
-        return 0;
-
-    ArkRewardTrackable* pTrackable = m_trackablesByMetric[_associatedMetric];
-
-    if (!pTrackable)
-        return 0;
-
-    int oldVal = pTrackable->value;
-    if (_value > oldVal)
-    {
-        pTrackable->value = _value;
-        TrackableChanged(pTrackable->id, oldVal, _value);
-        return _value;
-    }
-    else
-    {
-        return oldVal;
-    }
-}
-
-void ArkSteamRewardSystem::UnlockReward(unsigned _reward)
-{
-    if (IsSuppressed())
-    {
-        CryLog("[ArkSteamRewardSystem] UnlockReward suppressed (rewardId: {})", _reward);
-        return;
-    }
-
-    CryLog("ArkSteamRewardSystem::UnlockReward: {}", _reward);
-
-    ArkReward& reward = m_rewards[_reward];
-
-    if (!reward.bCriteriaMet)
-    {
-        reward.bCriteriaMet = true;
-
-        // Original code passes this to the reward thread, which will call the handler.
-        // I don't want to deal with threading. It shouldn't block anyway.
-        InternalRewardUnlocked(reward.unlockId);
-        if (m_pHandler)
-            m_pHandler->OnRewardUnlocked(m_userId, reward.unlockId);
-    }
-}
-
 void ArkSteamRewardSystem::InternalRewardUnlocked(unsigned unlockId)
 {
     // unlockId = ArkReward::unlockId
@@ -124,46 +51,4 @@ void ArkSteamRewardSystem::InternalRewardUnlocked(unsigned unlockId)
     CryLog("[ArkSteamRewardSystem] Unlocking '{}' (id = {}, name = {})", displayName, unlockId, name);
     SteamUserStats()->SetAchievement(name);
     SteamUserStats()->StoreStats();
-}
-
-void ArkSteamRewardSystem::TrackableChanged(unsigned trackable, unsigned oldVal, unsigned newVal)
-{
-    if (IsSuppressed())
-    {
-        CryLog("[ArkSteamRewardSystem] TrackChanged reward suppressed (trackableId: {}) (oldValue: {}) (newValue: {})",
-            trackable, oldVal, newVal);
-        return;
-    }
-
-    ArkRewardTrackable* pTrackable = &m_trackables[trackable];
-    CryLog("ArkSteamRewardSystem::TrackableChanged: [{}] {} -> {}", trackable, oldVal, newVal);
-
-    // See if need to unlock any rewards
-    for (ArkReward& reward : m_rewards)
-    {
-        bool needUnlock = false;
-
-        for (ArkRewardTrackableCriteria& criteria : reward.criteria)
-        {
-            if (!criteria.bCriteriaMet &&
-                criteria.trackable == pTrackable &&
-                criteria.trackable->value >= criteria.value)
-            {
-                criteria.bCriteriaMet = true;
-                needUnlock = true;
-            }
-        }
-
-        if (needUnlock)
-        {
-            reward.bCriteriaMet = true;
-
-            // Original code passes this to the reward thread 
-            InternalRewardUnlocked(reward.unlockId);
-        }
-    }
-
-    InternalTrackableUpdated(trackable, oldVal, newVal);
-    if (m_pHandler)
-        m_pHandler->OnChangedTrackable(m_userId, trackable, oldVal, newVal);
 }

--- a/Chairloader/Patches/SteamAPI/ArkSteamRewardSystem.cpp
+++ b/Chairloader/Patches/SteamAPI/ArkSteamRewardSystem.cpp
@@ -1,0 +1,169 @@
+#include <Chairloader/SteamAPI/IChairSteamAPI.h>
+#include <Chairloader/IChairXmlUtils.h>
+#include "ArkSteamRewardSystem.h"
+
+ArkSteamRewardSystem::ArkSteamRewardSystem()
+{
+    // Replace existing reward system
+    delete gEnv->pArkRewardSystem;
+    gEnv->pArkRewardSystem = this;
+}
+
+bool ArkSteamRewardSystem::LoadRewardData(const string& _strRewardFile)
+{
+    if (!CArkRewardSystem::LoadRewardData(_strRewardFile))
+        return false;
+
+    // Load SteamIDs for rewards
+    pugi::xml_document xmlDoc = gCL->pXmlUtils->LoadXmlFromFile(_strRewardFile);
+    pugi::xml_node root = xmlDoc.child("ArkRewards");
+    pugi::xml_node rewards = root.child("Rewards");
+
+    for (pugi::xml_node reward : rewards.children("Reward"))
+    {
+        unsigned id = reward.attribute("ID").as_uint();
+        if (id >= m_rewards.size())
+        {
+            CryError("ArkSteamRewardSystem: Reward ID {} is invalid (greater than or equal to count = {})", id, m_rewards.size());
+            continue;
+        }
+
+        int steamId = reward.attribute("SteamID").as_int();
+        m_rewards[id].unlockId = steamId;
+    }
+
+    return true;
+}
+
+unsigned ArkSteamRewardSystem::IncrementTrackableValue(unsigned _trackable)
+{
+    int oldVal = m_trackables[_trackable].value;
+    int newVal = oldVal + 1;
+    m_trackables[_trackable].value = newVal;
+    TrackableChanged(_trackable, oldVal, newVal);
+    return newVal;
+}
+
+unsigned ArkSteamRewardSystem::IncrementTrackableValue(uint64_t _associatedMetric)
+{
+    if (_associatedMetric == kNoAssociatedMetric)
+        return 0;
+
+    ArkRewardTrackable* pTrackable = m_trackablesByMetric[_associatedMetric];
+
+    if (!pTrackable)
+        return 0;
+
+    // ???
+    if (pTrackable->value >= 0x0FFF'FFFF)
+        return 0;
+
+    return IncrementTrackableValue(pTrackable->id);
+}
+
+unsigned ArkSteamRewardSystem::UpdateTrackableValueMax(uint64_t _associatedMetric, unsigned _value)
+{
+    if (_associatedMetric == kNoAssociatedMetric)
+        return 0;
+
+    ArkRewardTrackable* pTrackable = m_trackablesByMetric[_associatedMetric];
+
+    if (!pTrackable)
+        return 0;
+
+    int oldVal = pTrackable->value;
+    if (_value > oldVal)
+    {
+        pTrackable->value = _value;
+        TrackableChanged(pTrackable->id, oldVal, _value);
+        return _value;
+    }
+    else
+    {
+        return oldVal;
+    }
+}
+
+void ArkSteamRewardSystem::UnlockReward(unsigned _reward)
+{
+    if (IsSuppressed())
+    {
+        CryLog("[ArkSteamRewardSystem] UnlockReward suppressed (rewardId: {})", _reward);
+        return;
+    }
+
+    CryLog("ArkSteamRewardSystem::UnlockReward: {}", _reward);
+
+    ArkReward& reward = m_rewards[_reward];
+
+    if (!reward.bCriteriaMet)
+    {
+        reward.bCriteriaMet = true;
+
+        // Original code passes this to the reward thread, which will call the handler.
+        // I don't want to deal with threading. It shouldn't block anyway.
+        InternalRewardUnlocked(reward.unlockId);
+        if (m_pHandler)
+            m_pHandler->OnRewardUnlocked(m_userId, reward.unlockId);
+    }
+}
+
+void ArkSteamRewardSystem::InternalRewardUnlocked(unsigned unlockId)
+{
+    // unlockId = ArkReward::unlockId
+    CArkRewardSystem::InternalRewardUnlocked(unlockId);
+
+    const char* name = SteamUserStats()->GetAchievementName(unlockId);
+    if (!name)
+    {
+        CryError("[ArkSteamRewardSystem] Unknown unlockId {}", unlockId);
+        return;
+    }
+
+    const char* displayName = SteamUserStats()->GetAchievementDisplayAttribute(name, "name");
+    CryLog("[ArkSteamRewardSystem] Unlocking '{}' (id = {}, name = {})", displayName, unlockId, name);
+    SteamUserStats()->SetAchievement(name);
+    SteamUserStats()->StoreStats();
+}
+
+void ArkSteamRewardSystem::TrackableChanged(unsigned trackable, unsigned oldVal, unsigned newVal)
+{
+    if (IsSuppressed())
+    {
+        CryLog("[ArkSteamRewardSystem] TrackChanged reward suppressed (trackableId: {}) (oldValue: {}) (newValue: {})",
+            trackable, oldVal, newVal);
+        return;
+    }
+
+    ArkRewardTrackable* pTrackable = &m_trackables[trackable];
+    CryLog("ArkSteamRewardSystem::TrackableChanged: [{}] {} -> {}", trackable, oldVal, newVal);
+
+    // See if need to unlock any rewards
+    for (ArkReward& reward : m_rewards)
+    {
+        bool needUnlock = false;
+
+        for (ArkRewardTrackableCriteria& criteria : reward.criteria)
+        {
+            if (!criteria.bCriteriaMet &&
+                criteria.trackable == pTrackable &&
+                criteria.trackable->value >= criteria.value)
+            {
+                criteria.bCriteriaMet = true;
+                needUnlock = true;
+            }
+        }
+
+        if (needUnlock)
+        {
+            reward.bCriteriaMet = true;
+
+            // Original code passes this to the reward thread 
+            InternalRewardUnlocked(reward.unlockId);
+        }
+    }
+
+    InternalTrackableUpdated(trackable, oldVal, newVal);
+    if (m_pHandler)
+        m_pHandler->OnChangedTrackable(m_userId, trackable, oldVal, newVal);
+}

--- a/Chairloader/Patches/SteamAPI/ArkSteamRewardSystem.cpp
+++ b/Chairloader/Patches/SteamAPI/ArkSteamRewardSystem.cpp
@@ -33,15 +33,19 @@ void ArkSteamRewardSystem::InternalRewardUnlocked(unsigned unlockId)
     // unlockId = ArkReward::unlockId
     CArkRewardSystem::InternalRewardUnlocked(unlockId);
 
-    const char* name = SteamUserStats()->GetAchievementName(unlockId);
-    if (!name)
+    ISteamUserStats* pUserStats = SteamUserStats();
+    if (pUserStats)
     {
-        CryError("[ArkSteamRewardSystem] Unknown unlockId {}", unlockId);
-        return;
-    }
+        const char* name = pUserStats->GetAchievementName(unlockId);
+        if (!name)
+        {
+            CryError("[ArkSteamRewardSystem] Unknown unlockId {}", unlockId);
+            return;
+        }
 
-    const char* displayName = SteamUserStats()->GetAchievementDisplayAttribute(name, "name");
-    CryLog("[ArkSteamRewardSystem] Unlocking '{}' (id = {}, name = {})", displayName, unlockId, name);
-    SteamUserStats()->SetAchievement(name);
-    SteamUserStats()->StoreStats();
+        const char* displayName = pUserStats->GetAchievementDisplayAttribute(name, "name");
+        CryLog("[ArkSteamRewardSystem] Unlocking '{}' (id = {}, name = {})", displayName, unlockId, name);
+        pUserStats->SetAchievement(name);
+        pUserStats->StoreStats();
+    }
 }

--- a/Chairloader/Patches/SteamAPI/ArkSteamRewardSystem.cpp
+++ b/Chairloader/Patches/SteamAPI/ArkSteamRewardSystem.cpp
@@ -2,13 +2,6 @@
 #include <Chairloader/IChairXmlUtils.h>
 #include "SteamAPI/ArkSteamRewardSystem.h"
 
-ArkSteamRewardSystem::ArkSteamRewardSystem()
-{
-    // Replace existing reward system
-    delete gEnv->pArkRewardSystem;
-    gEnv->pArkRewardSystem = this;
-}
-
 bool ArkSteamRewardSystem::LoadRewardData(const string& _strRewardFile)
 {
     if (!CArkRewardSystem::LoadRewardData(_strRewardFile))

--- a/Chairloader/Patches/SteamAPI/ArkSteamRewardSystem.h
+++ b/Chairloader/Patches/SteamAPI/ArkSteamRewardSystem.h
@@ -5,8 +5,6 @@
 class ArkSteamRewardSystem : public ArkFixedRewardSystem
 {
 public:
-    ArkSteamRewardSystem();
-
     virtual bool LoadRewardData(const string& _strRewardFile) override;
     virtual void InternalRewardUnlocked(unsigned _rewardId) override;
 };

--- a/Chairloader/Patches/SteamAPI/ArkSteamRewardSystem.h
+++ b/Chairloader/Patches/SteamAPI/ArkSteamRewardSystem.h
@@ -2,7 +2,7 @@
 #include "ArkFixedRewardSystem.h"
 
 //! Implementation of IArkRewardSystem using Steam API.
-class ArkSteamRewardSystem : public ArkFixedRewardSystem
+class ArkSteamRewardSystem final : public ArkFixedRewardSystem
 {
 public:
     virtual bool LoadRewardData(const string& _strRewardFile) override;

--- a/Chairloader/Patches/SteamAPI/ArkSteamRewardSystem.h
+++ b/Chairloader/Patches/SteamAPI/ArkSteamRewardSystem.h
@@ -1,22 +1,12 @@
 #pragma once
-#include <Prey/CrySystem/Ark/ArkRewardSystem.h>
+#include "ArkFixedRewardSystem.h"
 
 //! Implementation of IArkRewardSystem using Steam API.
-//! Unlike the original version, doesn't user RewardsThread.
-class ArkSteamRewardSystem : public CArkRewardSystem
+class ArkSteamRewardSystem : public ArkFixedRewardSystem
 {
 public:
     ArkSteamRewardSystem();
 
     virtual bool LoadRewardData(const string& _strRewardFile) override;
-    virtual unsigned IncrementTrackableValue(unsigned _trackable) override;
-    virtual unsigned IncrementTrackableValue(uint64_t _associatedMetric) override;
-    virtual unsigned UpdateTrackableValueMax(uint64_t _associatedMetric, unsigned _value) override;
-    virtual void UnlockReward(unsigned _reward) override;
     virtual void InternalRewardUnlocked(unsigned _rewardId) override;
-
-private:
-    //! Original code calls somewhere into gEnv->pSystem->GetIPlatformOS()
-    inline bool IsSuppressed() { return false; }
-    void TrackableChanged(unsigned trackable, unsigned oldVal, unsigned newVal);
 };

--- a/Chairloader/Patches/SteamAPI/ArkSteamRewardSystem.h
+++ b/Chairloader/Patches/SteamAPI/ArkSteamRewardSystem.h
@@ -1,0 +1,22 @@
+#pragma once
+#include <Prey/CrySystem/Ark/ArkRewardSystem.h>
+
+//! Implementation of IArkRewardSystem using Steam API.
+//! Unlike the original version, doesn't user RewardsThread.
+class ArkSteamRewardSystem : public CArkRewardSystem
+{
+public:
+    ArkSteamRewardSystem();
+
+    virtual bool LoadRewardData(const string& _strRewardFile) override;
+    virtual unsigned IncrementTrackableValue(unsigned _trackable) override;
+    virtual unsigned IncrementTrackableValue(uint64_t _associatedMetric) override;
+    virtual unsigned UpdateTrackableValueMax(uint64_t _associatedMetric, unsigned _value) override;
+    virtual void UnlockReward(unsigned _reward) override;
+    virtual void InternalRewardUnlocked(unsigned _rewardId) override;
+
+private:
+    //! Original code calls somewhere into gEnv->pSystem->GetIPlatformOS()
+    inline bool IsSuppressed() { return false; }
+    void TrackableChanged(unsigned trackable, unsigned oldVal, unsigned newVal);
+};

--- a/Chairloader/Patches/SteamAPI/ChairSteamAPI.cpp
+++ b/Chairloader/Patches/SteamAPI/ChairSteamAPI.cpp
@@ -43,14 +43,6 @@ ChairSteamAPI::~ChairSteamAPI()
 
     assert(gCL->pSteamAPI == this);
     gCL->pSteamAPI = nullptr;
-
-    // Note: the game crashes in GameOverlayRenderer64.dll on shutdown.
-    // Callstack:
-    // - GameOverlayRenderer64.dll!???
-    // - GameOverlayRenderer64.dll!XInputSetState_Hook
-    // - PreyDll.dll!CleanupVibrationAtExit
-    // This also happens in normal Steam version of the game.
-    // I guess it's fine?
 }
 
 void ChairSteamAPI::ReplaceArkSystems()

--- a/Chairloader/Patches/SteamAPI/ChairSteamAPI.cpp
+++ b/Chairloader/Patches/SteamAPI/ChairSteamAPI.cpp
@@ -1,15 +1,6 @@
 #include <Prey/CryCore/Platform/CryWindows.h>
-#include <Prey/CrySystem/System.h>
 #include "SteamAPI/ArkSteamRewardSystem.h"
 #include "SteamAPI/ChairSteamAPI.h"
-
-auto g_CSystem_InitSoundSystem_Hook = CSystem::FInitSoundSystem.MakeHook();
-
-bool CSystem_InitSoundSystem_Hook(CSystem* const _this, const SSystemInitParams& _initParams)
-{
-    static_cast<ChairSteamAPI*>(gCL->pSteamAPI)->InitArkSystems();
-    return g_CSystem_InitSoundSystem_Hook.InvokeOrig(_this, _initParams);
-}
 
 std::unique_ptr<ChairSteamAPI> ChairSteamAPI::CreateInstance()
 {
@@ -38,8 +29,6 @@ ChairSteamAPI::ChairSteamAPI(void* hModuleVoid)
         CryFatalError("Steam is not running");
 
     InitSteam();
-
-    g_CSystem_InitSoundSystem_Hook.SetHookFunc(&CSystem_InitSoundSystem_Hook);
 }
 
 ChairSteamAPI::~ChairSteamAPI()
@@ -64,7 +53,7 @@ ChairSteamAPI::~ChairSteamAPI()
     // I guess it's fine?
 }
 
-void ChairSteamAPI::InitArkSystems()
+void ChairSteamAPI::ReplaceArkSystems()
 {
     m_pRewardSystem = std::make_unique<ArkSteamRewardSystem>();
 }

--- a/Chairloader/Patches/SteamAPI/ChairSteamAPI.cpp
+++ b/Chairloader/Patches/SteamAPI/ChairSteamAPI.cpp
@@ -9,7 +9,7 @@ std::unique_ptr<ChairSteamAPI> ChairSteamAPI::CreateInstance()
 
     if (!hModule)
     {
-        CryLog("{} not found. Not running Steam version.");
+        CryLog("{} not found. Not running Steam version.", DLL_NAME);
         return nullptr;
     }
 

--- a/Chairloader/Patches/SteamAPI/ChairSteamAPI.cpp
+++ b/Chairloader/Patches/SteamAPI/ChairSteamAPI.cpp
@@ -1,0 +1,126 @@
+#include <Prey/CryCore/Platform/CryWindows.h>
+#include "ChairSteamAPI.h"
+
+std::unique_ptr<ChairSteamAPI> ChairSteamAPI::CreateInstance()
+{
+    HMODULE hModule = LoadLibraryA(DLL_NAME);
+
+    if (!hModule)
+    {
+        CryLog("{} not found. Not running Steam version.");
+        return nullptr;
+    }
+
+    char path[MAX_PATH];
+    GetModuleFileNameA(hModule, path, sizeof(path));
+    CryLog("Found Steam API: {}", path);
+    return std::make_unique<ChairSteamAPI>(hModule);
+}
+
+ChairSteamAPI::ChairSteamAPI(void* hModuleVoid)
+{
+    assert(!gCL->pSteamAPI);
+    gCL->pSteamAPI = this;
+    m_hModule = hModuleVoid;
+    LoadFuncs();
+
+    if (!IsSteamRunning())
+        CryFatalError("Steam is not running");
+
+    InitSteam();
+}
+
+ChairSteamAPI::~ChairSteamAPI()
+{
+    m_pShutdown();
+
+    if (m_hModule)
+    {
+        FreeLibrary((HMODULE)m_hModule);
+        m_hModule = nullptr;
+    }
+
+    assert(gCL->pSteamAPI == this);
+    gCL->pSteamAPI = nullptr;
+
+    // Note: the game crashes in GameOverlayRenderer64.dll on shutdown.
+    // Callstack:
+    // - GameOverlayRenderer64.dll!???
+    // - GameOverlayRenderer64.dll!XInputSetState_Hook
+    // - PreyDll.dll!CleanupVibrationAtExit
+    // This also happens in normal Steam version of the game.
+    // I guess it's fine?
+}
+
+void ChairSteamAPI::Update()
+{
+    m_pRunCallbacks();
+}
+
+void ChairSteamAPI::LoadFuncs()
+{
+    std::vector<std::string> errorFuncList;
+
+    auto fnGetFunc = [&](auto& pFuncStorage, const char* name)
+    {
+        using FuncT = typename std::remove_reference_t<decltype(pFuncStorage)>;
+        pFuncStorage = (FuncT)GetProcAddress((HMODULE)m_hModule, name);
+
+        if (!pFuncStorage)
+            errorFuncList.push_back(name);
+    };
+
+    // IChairSteamAPI funcs
+    fnGetFunc(m_pGetHSteamUser, "SteamAPI_GetHSteamUser");
+    fnGetFunc(m_pRegisterCallback, "SteamAPI_RegisterCallback");
+    fnGetFunc(m_pUnregisterCallback, "SteamAPI_UnregisterCallback");
+    fnGetFunc(m_pRegisterCallResult, "SteamAPI_RegisterCallResult");
+    fnGetFunc(m_pUnregisterCallResult, "SteamAPI_UnregisterCallResult");
+    fnGetFunc(m_pIsSteamRunning, "SteamAPI_IsSteamRunning");
+    fnGetFunc(m_pGetHSteamUserCurrent, "Steam_GetHSteamUserCurrent");
+    fnGetFunc(m_pGetSteamInstallPath, "SteamAPI_GetSteamInstallPath");
+    fnGetFunc(m_pGetHSteamPipe, "SteamAPI_GetHSteamPipe");
+    fnGetFunc(m_pCreateInterface, "SteamInternal_CreateInterface");
+
+    // Internal funcs
+    fnGetFunc(m_pInit, "SteamAPI_Init");
+    fnGetFunc(m_pShutdown, "SteamAPI_Shutdown");
+    fnGetFunc(m_pContextInit, "SteamInternal_ContextInit");
+    fnGetFunc(m_pRunCallbacks, "SteamAPI_RunCallbacks");
+
+    if (!errorFuncList.empty())
+    {
+        // Fail fatally because
+        // a) this shouldn't happen
+        // b) achievements will suddenly stop tracking for players
+        std::string msg;
+
+        for (const std::string& i : errorFuncList)
+            msg += i + "\n";
+
+        CryFatalError("Failed to load functions from {}:\n{}", DLL_NAME, msg);
+    }
+}
+
+void ChairSteamAPI::InitSteam()
+{
+    if (!m_pInit())
+        CryFatalError("SteamAPI_Init failed");
+
+    // Initialize the context
+
+    // SteamInternal_ContextInit takes a base pointer for the equivalent of
+    // struct { void (*pFn)(void* pCtx); uintp counter; CSteamAPIContext ctx; }
+    // Do not change layout of 2 + sizeof... or add non-pointer aligned data!
+    // NOTE: declaring "static CSteamAPIConext" creates a large function
+    // which queries the initialization status of the object. We know that
+    // it is pointer-aligned and fully memset with zeros, so just alias a
+    // static buffer of the appropriate size and call it a CSteamAPIContext.
+    static void* s_CallbackCounterAndContext[2 + sizeof(CSteamAPIContext) / sizeof(void*)] = { (void*)&SteamInternal_OnContextInit, 0 };
+    m_pContext = (CSteamAPIContext*)m_pContextInit(s_CallbackCounterAndContext);
+
+    if (!m_pContext)
+        CryFatalError("SteamInternal_ContextInit returned nullptr");
+
+    CryLog("Steam AppID = {}", SteamUtils()->GetAppID());
+}

--- a/Chairloader/Patches/SteamAPI/ChairSteamAPI.cpp
+++ b/Chairloader/Patches/SteamAPI/ChairSteamAPI.cpp
@@ -1,4 +1,5 @@
 #include <Prey/CryCore/Platform/CryWindows.h>
+#include "SteamAPI/ArkSteamDlcSystem.h"
 #include "SteamAPI/ArkSteamRewardSystem.h"
 #include "SteamAPI/ChairSteamAPI.h"
 
@@ -49,7 +50,10 @@ void ChairSteamAPI::ReplaceArkSystems()
 {
     // Existing systems are owned by CSystem. It will destroy them in ShutDown.
     delete gEnv->pArkRewardSystem;
+    delete gEnv->pArkDlcSystem;
     gEnv->pArkRewardSystem = new ArkSteamRewardSystem();
+    gEnv->pArkDlcSystem = new ArkSteamDlcSystem();
+    gEnv->pArkDlcSystem->InitEnv(gEnv);
 }
 
 void ChairSteamAPI::Update()

--- a/Chairloader/Patches/SteamAPI/ChairSteamAPI.cpp
+++ b/Chairloader/Patches/SteamAPI/ChairSteamAPI.cpp
@@ -55,7 +55,9 @@ ChairSteamAPI::~ChairSteamAPI()
 
 void ChairSteamAPI::ReplaceArkSystems()
 {
-    m_pRewardSystem = std::make_unique<ArkSteamRewardSystem>();
+    // Existing systems are owned by CSystem. It will destroy them in ShutDown.
+    delete gEnv->pArkRewardSystem;
+    gEnv->pArkRewardSystem = new ArkSteamRewardSystem();
 }
 
 void ChairSteamAPI::Update()

--- a/Chairloader/Patches/SteamAPI/ChairSteamAPI.h
+++ b/Chairloader/Patches/SteamAPI/ChairSteamAPI.h
@@ -1,8 +1,6 @@
 #pragma once
 #include <Chairloader/SteamAPI/IChairSteamAPI.h>
 
-class ArkSteamRewardSystem;
-
 class ChairSteamAPI final : public IChairSteamAPI, NoCopy
 {
 public:

--- a/Chairloader/Patches/SteamAPI/ChairSteamAPI.h
+++ b/Chairloader/Patches/SteamAPI/ChairSteamAPI.h
@@ -15,7 +15,7 @@ public:
     ~ChairSteamAPI();
 
     //! Initializes various Ark???System that replace ones created in CSystem::Init.
-    void InitArkSystems();
+    void ReplaceArkSystems();
 
     //! Runs Steam callbacks.
     void Update();

--- a/Chairloader/Patches/SteamAPI/ChairSteamAPI.h
+++ b/Chairloader/Patches/SteamAPI/ChairSteamAPI.h
@@ -8,8 +8,9 @@ public:
     //! @returns instance or nullptr.
     static std::unique_ptr<ChairSteamAPI> CreateInstance();
 
-    //! @param hModule DLL handle.
-    ChairSteamAPI(void* hModule);
+    //! @param  hModule DLL handle.
+    //! @param  isGog   GOG version.
+    ChairSteamAPI(void* hModule, bool isGog);
     ~ChairSteamAPI();
 
     //! Initializes various Ark???System that replace ones created in CSystem::Init.
@@ -36,6 +37,9 @@ public:
 private:
     //! DLL handle.
     void* m_hModule = nullptr;
+
+    //! Using GOG version's Steam API wrapper.
+    bool m_bIsGog = false;
 
     //! The context pointer
     CSteamAPIContext* m_pContext = nullptr;

--- a/Chairloader/Patches/SteamAPI/ChairSteamAPI.h
+++ b/Chairloader/Patches/SteamAPI/ChairSteamAPI.h
@@ -70,5 +70,6 @@ private:
     void LoadFuncs();
 
     //! Initializes Steam API.
-    void InitSteam();
+    //! @returns whether it was successful.
+    bool InitSteam();
 };

--- a/Chairloader/Patches/SteamAPI/ChairSteamAPI.h
+++ b/Chairloader/Patches/SteamAPI/ChairSteamAPI.h
@@ -1,0 +1,67 @@
+#pragma once
+#include <Chairloader/SteamAPI/IChairSteamAPI.h>
+
+class ChairSteamAPI final : public IChairSteamAPI, NoCopy
+{
+public:
+    //! Creates an instance of ChairSteamAPI if Steam API is available.
+    //! @returns instance or nullptr.
+    static std::unique_ptr<ChairSteamAPI> CreateInstance();
+
+    //! @param hModule DLL handle.
+    ChairSteamAPI(void* hModule);
+    ~ChairSteamAPI();
+
+    //! Runs Steam callbacks.
+    void Update();
+
+    // IChairSteamAPI
+    virtual CSteamAPIContext& GetContext() override { return *m_pContext; }
+    virtual void* GetDllHandle() override { return m_hModule; }
+
+    virtual HSteamUser GetHSteamUser() override { return m_pGetHSteamUser(); }
+    virtual void RegisterCallback(CCallbackBase* pCallback, int iCallback) override { return m_pRegisterCallback(pCallback, iCallback); }
+    virtual void UnregisterCallback(CCallbackBase* pCallback) override { return m_pUnregisterCallback(pCallback); }
+    virtual void RegisterCallResult(CCallbackBase* pCallback, SteamAPICall_t hAPICall) override { return m_pRegisterCallResult(pCallback, hAPICall); }
+    virtual void UnregisterCallResult(CCallbackBase* pCallback, SteamAPICall_t hAPICall) override { return m_pUnregisterCallResult(pCallback, hAPICall); }
+    virtual bool IsSteamRunning() override { return m_pIsSteamRunning(); }
+    virtual HSteamUser GetHSteamUserCurrent() override { return m_pGetHSteamUserCurrent(); }
+    virtual const char* GetSteamInstallPath() override { return m_pGetSteamInstallPath(); }
+    virtual HSteamPipe GetHSteamPipe() override { return m_pGetHSteamPipe(); }
+    virtual void* Internal_CreateInterface(const char* ver) { return m_pCreateInterface(ver); }
+
+private:
+    //! DLL handle.
+    void* m_hModule = nullptr;
+
+    //! The context pointer
+    CSteamAPIContext* m_pContext = nullptr;
+
+    //! DLL function pointers (in IChairSteamAPI)
+    //! @{
+    decltype(&SteamAPI_GetHSteamUser) m_pGetHSteamUser = nullptr;
+    decltype(&SteamAPI_RegisterCallback) m_pRegisterCallback = nullptr;
+    decltype(&SteamAPI_UnregisterCallback) m_pUnregisterCallback = nullptr;
+    decltype(&SteamAPI_RegisterCallResult) m_pRegisterCallResult = nullptr;
+    decltype(&SteamAPI_UnregisterCallResult) m_pUnregisterCallResult = nullptr;
+    decltype(&SteamAPI_IsSteamRunning) m_pIsSteamRunning = nullptr;
+    decltype(&Steam_GetHSteamUserCurrent) m_pGetHSteamUserCurrent = nullptr;
+    decltype(&SteamAPI_GetSteamInstallPath) m_pGetSteamInstallPath = nullptr;
+    decltype(&SteamAPI_GetHSteamPipe) m_pGetHSteamPipe = nullptr;
+    decltype(&SteamInternal_CreateInterface) m_pCreateInterface = nullptr;
+    //! @}
+    
+    //! DLL function pointers (used internally)
+    //! @{
+    decltype(&SteamAPI_Init) m_pInit = nullptr;
+    decltype(&SteamAPI_Shutdown) m_pShutdown = nullptr;
+    decltype(&SteamInternal_ContextInit) m_pContextInit = nullptr;
+    decltype(&SteamAPI_RunCallbacks) m_pRunCallbacks = nullptr;
+    //! @}
+
+    //! Loads functions from the DLL.
+    void LoadFuncs();
+
+    //! Initializes Steam API.
+    void InitSteam();
+};

--- a/Chairloader/Patches/SteamAPI/ChairSteamAPI.h
+++ b/Chairloader/Patches/SteamAPI/ChairSteamAPI.h
@@ -1,6 +1,8 @@
 #pragma once
 #include <Chairloader/SteamAPI/IChairSteamAPI.h>
 
+class ArkSteamRewardSystem;
+
 class ChairSteamAPI final : public IChairSteamAPI, NoCopy
 {
 public:
@@ -11,6 +13,9 @@ public:
     //! @param hModule DLL handle.
     ChairSteamAPI(void* hModule);
     ~ChairSteamAPI();
+
+    //! Initializes various Ark???System that replace ones created in CSystem::Init.
+    void InitArkSystems();
 
     //! Runs Steam callbacks.
     void Update();
@@ -58,6 +63,8 @@ private:
     decltype(&SteamInternal_ContextInit) m_pContextInit = nullptr;
     decltype(&SteamAPI_RunCallbacks) m_pRunCallbacks = nullptr;
     //! @}
+    
+    std::unique_ptr<ArkSteamRewardSystem> m_pRewardSystem;
 
     //! Loads functions from the DLL.
     void LoadFuncs();

--- a/Chairloader/Patches/SteamAPI/ChairSteamAPI.h
+++ b/Chairloader/Patches/SteamAPI/ChairSteamAPI.h
@@ -63,8 +63,6 @@ private:
     decltype(&SteamInternal_ContextInit) m_pContextInit = nullptr;
     decltype(&SteamAPI_RunCallbacks) m_pRunCallbacks = nullptr;
     //! @}
-    
-    std::unique_ptr<ArkSteamRewardSystem> m_pRewardSystem;
 
     //! Loads functions from the DLL.
     void LoadFuncs();

--- a/Common/CMakeLists.txt
+++ b/Common/CMakeLists.txt
@@ -5,9 +5,53 @@ file(GLOB_RECURSE PREY_HEADER_FILES
 	Prey/*.*
 )
 
+set(STEAM_API_FILES
+	Chairloader/SteamAPI/IChairSteamAPI.h
+	Chairloader/SteamAPI/isteamapplist.h
+	Chairloader/SteamAPI/isteamapps.h
+	Chairloader/SteamAPI/isteamappticket.h
+	Chairloader/SteamAPI/isteamclient.h
+	Chairloader/SteamAPI/isteamcontroller.h
+	Chairloader/SteamAPI/isteamfriends.h
+	Chairloader/SteamAPI/isteamgamecoordinator.h
+	Chairloader/SteamAPI/isteamgameserver.h
+	Chairloader/SteamAPI/isteamgameserverstats.h
+	Chairloader/SteamAPI/isteamhtmlsurface.h
+	Chairloader/SteamAPI/isteamhttp.h
+	Chairloader/SteamAPI/isteaminventory.h
+	Chairloader/SteamAPI/isteammasterserverupdater.h
+	Chairloader/SteamAPI/isteammatchmaking.h
+	Chairloader/SteamAPI/isteammusic.h
+	Chairloader/SteamAPI/isteammusicremote.h
+	Chairloader/SteamAPI/isteamnetworking.h
+	Chairloader/SteamAPI/isteamps3overlayrenderer.h
+	Chairloader/SteamAPI/isteamremotestorage.h
+	Chairloader/SteamAPI/isteamscreenshots.h
+	Chairloader/SteamAPI/isteamugc.h
+	Chairloader/SteamAPI/isteamunifiedmessages.h
+	Chairloader/SteamAPI/isteamuser.h
+	Chairloader/SteamAPI/isteamuserstats.h
+	Chairloader/SteamAPI/isteamutils.h
+	Chairloader/SteamAPI/isteamvideo.h
+	Chairloader/SteamAPI/LICENSE
+	Chairloader/SteamAPI/matchmakingtypes.h
+	Chairloader/SteamAPI/README.txt
+	Chairloader/SteamAPI/steamclientpublic.h
+	Chairloader/SteamAPI/steamencryptedappticket.h
+	Chairloader/SteamAPI/steamhttpenums.h
+	Chairloader/SteamAPI/steamps3params.h
+	Chairloader/SteamAPI/steamtypes.h
+	Chairloader/SteamAPI/steamuniverse.h
+	Chairloader/SteamAPI/steam_api.h
+	Chairloader/SteamAPI/steam_api_chairloader.cpp
+	Chairloader/SteamAPI/steam_api_internal.h
+	Chairloader/SteamAPI/steam_gameserver.h
+)
+
 set(SOURCE_FILES
 	CMakeLists.txt
 	${PREY_HEADER_FILES}
+	${STEAM_API_FILES}
 
 	Chairloader/Hooks/FunctionHook.cpp
 	Chairloader/Hooks/FunctionHook.h

--- a/Common/Chairloader/ChairloaderEnv.h
+++ b/Common/Chairloader/ChairloaderEnv.h
@@ -8,6 +8,7 @@ class EntityUtils;
 struct IRenderAuxGeomEx;
 struct IChairRender;
 struct IChairXmlUtils;
+struct IChairSteamAPI;
 
 struct ChairloaderGlobalEnvironment {
 	IChairloader* cl;
@@ -17,6 +18,7 @@ struct ChairloaderGlobalEnvironment {
 	IRenderAuxGeomEx* pAuxGeomEx;
 	IChairRender* pRender;
 	IChairXmlUtils* pXmlUtils;
+	IChairSteamAPI* pSteamAPI; //!< NULL if not Steam version
 };
 
 extern ChairloaderGlobalEnvironment* gCL;

--- a/Common/Chairloader/SteamAPI/IChairSteamAPI.h
+++ b/Common/Chairloader/SteamAPI/IChairSteamAPI.h
@@ -7,6 +7,9 @@ struct IChairSteamAPI
     //! The name of Steam API DLL.
     static constexpr char DLL_NAME[] = "steam_api64.dll";
 
+    //! The name of the wrapper DLL in GOG version of the game.
+    static constexpr char GOG_DLL_NAME[] = "common64.dll";
+
     virtual ~IChairSteamAPI() {}
 
     //! CSteamAPIContext is marked as deprecated but actually

--- a/Common/Chairloader/SteamAPI/IChairSteamAPI.h
+++ b/Common/Chairloader/SteamAPI/IChairSteamAPI.h
@@ -1,0 +1,33 @@
+#pragma once
+#include <Chairloader/SteamAPI/steam_api.h>
+
+//! Steam API DLL wrappers. The library is loaded by Chairloader.
+struct IChairSteamAPI
+{
+    //! The name of Steam API DLL.
+    static constexpr char DLL_NAME[] = "steam_api64.dll";
+
+    virtual ~IChairSteamAPI() {}
+
+    //! CSteamAPIContext is marked as deprecated but actually
+    //! used internally by the API. Because Valve.
+    //! @returns the Steam API context.
+    virtual CSteamAPIContext& GetContext() = 0;
+
+    //! @returns the SteamAPI DLL handle. Actual type is HMODULE.
+    virtual void* GetDllHandle() = 0;
+
+    //! Functions exported from steam_api64.dll
+    //! @{
+    virtual HSteamUser GetHSteamUser() = 0;
+    virtual void RegisterCallback(CCallbackBase* pCallback, int iCallback) = 0;
+    virtual void UnregisterCallback(CCallbackBase* pCallback) = 0;
+    virtual void RegisterCallResult(CCallbackBase* pCallback, SteamAPICall_t hAPICall) = 0;
+    virtual void UnregisterCallResult(CCallbackBase* pCallback, SteamAPICall_t hAPICall) = 0;
+    virtual bool IsSteamRunning() = 0;
+    virtual HSteamUser GetHSteamUserCurrent() = 0;
+    virtual const char* GetSteamInstallPath() = 0;
+    virtual HSteamPipe GetHSteamPipe() = 0;
+    virtual void* Internal_CreateInterface(const char* ver) = 0;
+    //! @}
+};

--- a/Common/Chairloader/SteamAPI/LICENSE
+++ b/Common/Chairloader/SteamAPI/LICENSE
@@ -1,0 +1,149 @@
+================ STEAMWORKS SDK license ===================
+VALVE, Corp.
+SDK LICENSE
+
+This SDK License (the "Agreement") is made by and between you (the "Licensee")
+and Valve Corporation, a Washington corporation,(“Valve”) with offices located
+at 10400 NE 4th Street, Suite 1400, Bellevue, WA 98004, USA.
+
+THIS DOCUMENT DESCRIBES A CONTRACT BETWEEN YOU AND VALVE. PLEASE READ IT BEFORE
+DOWNLOADING OR USING THE STEAMWORKS SOFTWARE DEVELOPMENT KIT (THE “SDK”). BY
+DOWNLOADING AND/OR USING THE SDK YOU INDICATE YOUR ACCEPTANCE OF THIS
+AGREEMENT. IF YOU DO NOT AGREE, DO NOT DOWNLOAD AND/OR USE THE SDK.
+
+Whereas, Valve is the developer of an online platform titled "Steam" that
+provides online distribution services as well as a number of additional online
+services designed to be embedded in computer games and application software,
+including, but not limited to, user authentication, in-app purchasing and
+trading, leaderboards, matchmaking, stats and achievements (the “Steamworks
+Services”) and the SDK;
+
+Whereas, Licensee wishes to develop a game or application software designed to
+take advantage of the Steamworks Services (the "Licensee Software"); and
+
+Whereas, Licensee wishes to receive, and Valve wishes to disclose to Licensee,
+the SDK, and other information as deemed appropriate by Valve, all on the
+terms set forth herein;
+
+Now, therefore, in consideration of the mutual promises made herein, the
+parties agree as follows:
+
+1. License.
+
+1.1 License Grant. Valve hereby grants Licensee a nonexclusive, royalty-free,
+terminable, worldwide, nontransferable license to:
+
+(a) use and locally reproduce the SDK in source code form, solely to develop
+the Licensee Software; and
+
+(b) reproduce and distribute the part of the SDK provided inside the folder
+named redistributable_bin (the "SDK Redistributables") along with the Licensee
+Software in object code form.
+
+1.2 Updates. Valve may from time to time, in its sole discretion, provide
+updates, error corrections, and future versions of the SDK to Licensee. Upon
+delivery, such updates, error corrections and future versions shall be deemed
+part of the SDK, as applicable, under this Agreement.
+
+1.3 Reservation of Rights. Valve reserves all rights not explicitly granted
+herein.
+
+2. Ancillary Obligations.
+
+2.1 No obligation to provide services. Nothing herein shall be construed as
+establishing an obligation to Valve to provide Steamworks Services or accept
+Licensee Software for distribution via Steam.
+
+2.2 Indemnity. Licensee hereby agrees that it is solely responsible for any
+and all Licensee Software and Licensee's creation, distribution, and promotion
+thereof. Licensee shall defend, indemnify, and hold harmless Valve, its
+officers, directors, employees and agents against any and all claims, damages
+(including reasonable attorneys’ fees and costs), losses, or liabilities
+whatsoever arising out of Licensee's creation, distribution, or promotion of
+the Licensee Software.
+
+2.3 Trademarks. Licensee acknowledges and agrees that this Agreement does not
+grant Licensee any right to use any trademarks or trade names of Valve or its
+licensors. All such marks shall remain the property of the respective owner.
+Licensee will refrain from any action or communication that can be incorrectly
+interpreted as a cooperation or partnership between Valve and Licensee.
+
+2.4 No reverse engineering. Licensee will not take any steps to reverse
+engineer the functionality of the SDK or develop software to replace the SDK's
+functionality. If Licensee develops software to interact with the Steamworks
+Services, such software shall not communicate with the Steamworks Services
+directly but always through the application programming interface (API)
+provided by the SDK Redistributables.
+
+3. Term.
+
+3.1 Term. This Agreement shall become effective as of the date Licensee
+downloads or installs the SDK. It will continue to apply until terminated by
+either Valve or Licensee as set out below.
+
+3.2 Termination. Valve may terminate this Agreement immediately upon written
+(including email) notice to Licensee. Licensee may terminate this Agreement at
+any time by ceasing Licensees use of the SDK and ending Licensee's
+distribution of Licensee Software created using the SDK. Furthermore, the
+Agreement will terminate automatically upon Licensee's breach of any term of
+this Agreement.
+
+3.3 Survival. Sections 1.3, 2, 3.2, 3.3, and 4-6 shall survive any expiration
+or termination of this Agreement.
+
+4. Disclaimer of Warranties; Limitation of Liability
+
+4.1 NO WARRANTIES. THE SDK AND ANY OTHER MATERIAL DOWNLOADED BY LICENSEE IS
+PROVIDED “AS IS”. VALVE AND ITS SUPPLIERS DISCLAIM ALL WARRANTIES WITH RESPECT
+TO THE SDK, EITHER EXPRESS OR IMPLIED, INCLUDING, BUT NOT LIMITED TO, IMPLIED
+WARRANTIES OF MERCHANTABILITY, NON-INFRINGEMENT, TITLE AND FITNESS FOR A
+PARTICULAR PURPOSE.
+
+4.2 LIMITATION OF LIABILITY. IN NO EVENT SHALL VALVE OR ITS SUPPLIERS BE
+LIABLE FOR ANY SPECIAL, INCIDENTAL, INDIRECT, OR CONSEQUENTIAL DAMAGES
+WHATSOEVER (INCLUDING, WITHOUT LIMITATION, DAMAGES FOR LOSS OF BUSINESS
+PROFITS, BUSINESS INTERRUPTION, LOSS OF BUSINESS INFORMATION, OR ANY OTHER
+PECUNIARY LOSS) ARISING OUT OF THE USE OF OR INABILITY TO USE THE ENGINE
+AND/OR THE SDK, EVEN IF VALVE HAS BEEN ADVISED OF THE POSSIBILITY OF SUCH
+DAMAGES.
+
+5. No Exclusivity.
+
+Neither this Agreement nor the disclosure or receipt of Information shall
+constitute or imply any promise to or intention to make any purchase of
+products or services by either party or its affiliated companies or any
+commitment by either party or its affiliated companies with respect to the
+present or future marketing of any product or service or any commitment to
+enter into any other business relationship. Except for the license and use
+restrictions expressly set forth herein, each party will be free (1) to
+pursue, negotiate, and enter into similar relationships with third parties and
+(2) to develop, market, and make available similar products and services.
+Neither party will be obligated to enter into any other agreement with the
+other party by virtue of this Agreement.
+
+6. General.
+
+6.1 Modification. No amendment or modification of this Agreement shall be
+valid or binding on the parties unless made in writing and signed on behalf of
+both of the parties by their respective duly authorized officers or
+representatives.
+
+6.2 Assignment. Licensee may not assign this agreement without the prior
+written consent of Valve. Subject to the limitations set forth in this
+Agreement, this Agreement will inure to the benefit of and be binding upon the
+parties, their successors and assigns.
+
+6.3 Severability. If any provision of this Agreement shall be held by a court
+of competent jurisdiction to be illegal, invalid or unenforceable, the
+remaining provisions shall remain in full force and effect.
+
+6.4 Governing Law, Jurisdiction and Venue. This Agreement shall be governed by
+the laws of the State of Washington. For any claims of any kind arising out of
+this Agreement or use of the SDK, each of the parties hereto submits to
+exclusive jurisdiction and venue in the state and federal courts sitting in
+King County, Washington.
+
+6.5 Entire Agreement. This Agreement constitutes the entire understanding
+between the parties hereto and supersedes all previous communications,
+representations and understandings, oral or written, between the parties, with
+respect to the subject matter of this Agreement.

--- a/Common/Chairloader/SteamAPI/README.txt
+++ b/Common/Chairloader/SteamAPI/README.txt
@@ -1,0 +1,7 @@
+This directory contains header files for Steamworks SDK v139.
+This is the version used by Prey based on interface names.
+
+Patched to call into Chairloader instead of steam_api64.dll.
+
+Source:
+https://github.com/ValveSoftware/Proton/tree/e82bed8475f5fe7e95e7bdfbcf6ab35c1cf9da5c/lsteamclient/steamworks_sdk_139

--- a/Common/Chairloader/SteamAPI/isteamapplist.h
+++ b/Common/Chairloader/SteamAPI/isteamapplist.h
@@ -1,0 +1,63 @@
+//====== Copyright © 1996-2008, Valve Corporation, All rights reserved. =======
+//
+// Purpose: interface to app data in Steam
+//
+//=============================================================================
+
+#ifndef ISTEAMAPPLIST_H
+#define ISTEAMAPPLIST_H
+#ifdef _WIN32
+#pragma once
+#endif
+
+#include "isteamclient.h"
+#include "steamtypes.h"
+
+//-----------------------------------------------------------------------------
+// Purpose: This is a restricted interface that can only be used by previously approved apps,
+//	contact your Steam Account Manager if you believe you need access to this API.
+//	This interface lets you detect installed apps for the local Steam client, useful for debugging tools
+//	to offer lists of apps to debug via Steam.
+//-----------------------------------------------------------------------------
+class ISteamAppList
+{
+public:
+	virtual uint32 GetNumInstalledApps() = 0;
+	virtual uint32 GetInstalledApps( AppId_t *pvecAppID, uint32 unMaxAppIDs ) = 0;
+
+	virtual int  GetAppName( AppId_t nAppID, OUT_STRING() char *pchName, int cchNameMax ) = 0; // returns -1 if no name was found
+	virtual int  GetAppInstallDir( AppId_t nAppID, char *pchDirectory, int cchNameMax ) = 0; // returns -1 if no dir was found
+
+	virtual int GetAppBuildId( AppId_t nAppID ) = 0; // return the buildid of this app, may change at any time based on backend updates to the game
+};
+
+#define STEAMAPPLIST_INTERFACE_VERSION "STEAMAPPLIST_INTERFACE_VERSION001"
+
+// callbacks
+#if defined( VALVE_CALLBACK_PACK_SMALL )
+#pragma pack( push, 4 )
+#elif defined( VALVE_CALLBACK_PACK_LARGE )
+#pragma pack( push, 8 )
+#else
+#error isteamclient.h must be included
+#endif 
+
+
+//---------------------------------------------------------------------------------
+// Purpose: Sent when a new app is installed
+//---------------------------------------------------------------------------------
+DEFINE_CALLBACK( SteamAppInstalled_t, k_iSteamAppListCallbacks + 1 );
+	CALLBACK_MEMBER( 0,	AppId_t,	m_nAppID )			// ID of the app that installs
+END_DEFINE_CALLBACK_1()
+
+
+//---------------------------------------------------------------------------------
+// Purpose: Sent when an app is uninstalled
+//---------------------------------------------------------------------------------
+DEFINE_CALLBACK( SteamAppUninstalled_t, k_iSteamAppListCallbacks + 2 );
+	CALLBACK_MEMBER( 0,	AppId_t,	m_nAppID )			// ID of the app that installs
+END_DEFINE_CALLBACK_1()
+
+
+#pragma pack( pop )
+#endif // ISTEAMAPPLIST_H

--- a/Common/Chairloader/SteamAPI/isteamapps.h
+++ b/Common/Chairloader/SteamAPI/isteamapps.h
@@ -1,0 +1,176 @@
+//====== Copyright © 1996-2008, Valve Corporation, All rights reserved. =======
+//
+// Purpose: interface to app data in Steam
+//
+//=============================================================================
+
+#ifndef ISTEAMAPPS_H
+#define ISTEAMAPPS_H
+#ifdef _WIN32
+#pragma once
+#endif
+
+const int k_cubAppProofOfPurchaseKeyMax = 240;			// max supported length of a legacy cd key 
+
+
+//-----------------------------------------------------------------------------
+// Purpose: interface to app data
+//-----------------------------------------------------------------------------
+class ISteamApps
+{
+public:
+	virtual bool BIsSubscribed() = 0;
+	virtual bool BIsLowViolence() = 0;
+	virtual bool BIsCybercafe() = 0;
+	virtual bool BIsVACBanned() = 0;
+	virtual const char *GetCurrentGameLanguage() = 0;
+	virtual const char *GetAvailableGameLanguages() = 0;
+
+	// only use this member if you need to check ownership of another game related to yours, a demo for example
+	virtual bool BIsSubscribedApp( AppId_t appID ) = 0;
+
+	// Takes AppID of DLC and checks if the user owns the DLC & if the DLC is installed
+	virtual bool BIsDlcInstalled( AppId_t appID ) = 0;
+
+	// returns the Unix time of the purchase of the app
+	virtual uint32 GetEarliestPurchaseUnixTime( AppId_t nAppID ) = 0;
+
+	// Checks if the user is subscribed to the current app through a free weekend
+	// This function will return false for users who have a retail or other type of license
+	// Before using, please ask your Valve technical contact how to package and secure your free weekened
+	virtual bool BIsSubscribedFromFreeWeekend() = 0;
+
+	// Returns the number of DLC pieces for the running app
+	virtual int GetDLCCount() = 0;
+
+	// Returns metadata for DLC by index, of range [0, GetDLCCount()]
+	virtual bool BGetDLCDataByIndex( int iDLC, AppId_t *pAppID, bool *pbAvailable, char *pchName, int cchNameBufferSize ) = 0;
+
+	// Install/Uninstall control for optional DLC
+	virtual void InstallDLC( AppId_t nAppID ) = 0;
+	virtual void UninstallDLC( AppId_t nAppID ) = 0;
+	
+	// Request legacy cd-key for yourself or owned DLC. If you are interested in this
+	// data then make sure you provide us with a list of valid keys to be distributed
+	// to users when they purchase the game, before the game ships.
+	// You'll receive an AppProofOfPurchaseKeyResponse_t callback when
+	// the key is available (which may be immediately).
+	virtual void RequestAppProofOfPurchaseKey( AppId_t nAppID ) = 0;
+
+	virtual bool GetCurrentBetaName( char *pchName, int cchNameBufferSize ) = 0; // returns current beta branch name, 'public' is the default branch
+	virtual bool MarkContentCorrupt( bool bMissingFilesOnly ) = 0; // signal Steam that game files seems corrupt or missing
+	virtual uint32 GetInstalledDepots( AppId_t appID, DepotId_t *pvecDepots, uint32 cMaxDepots ) = 0; // return installed depots in mount order
+
+	// returns current app install folder for AppID, returns folder name length
+	virtual uint32 GetAppInstallDir( AppId_t appID, char *pchFolder, uint32 cchFolderBufferSize ) = 0;
+	virtual bool BIsAppInstalled( AppId_t appID ) = 0; // returns true if that app is installed (not necessarily owned)
+	
+	virtual CSteamID GetAppOwner() = 0; // returns the SteamID of the original owner. If different from current user, it's borrowed
+
+	// Returns the associated launch param if the game is run via steam://run/<appid>//?param1=value1;param2=value2;param3=value3 etc.
+	// Parameter names starting with the character '@' are reserved for internal use and will always return and empty string.
+	// Parameter names starting with an underscore '_' are reserved for steam features -- they can be queried by the game,
+	// but it is advised that you not param names beginning with an underscore for your own features.
+	virtual const char *GetLaunchQueryParam( const char *pchKey ) = 0;
+
+	// get download progress for optional DLC
+	virtual bool GetDlcDownloadProgress( AppId_t nAppID, uint64 *punBytesDownloaded, uint64 *punBytesTotal ) = 0; 
+
+	// return the buildid of this app, may change at any time based on backend updates to the game
+	virtual int GetAppBuildId() = 0;
+
+	// Request all proof of purchase keys for the calling appid and asociated DLC.
+	// A series of AppProofOfPurchaseKeyResponse_t callbacks will be sent with
+	// appropriate appid values, ending with a final callback where the m_nAppId
+	// member is k_uAppIdInvalid (zero).
+	virtual void RequestAllProofOfPurchaseKeys() = 0;
+
+	CALL_RESULT( FileDetailsResult_t )
+	virtual SteamAPICall_t GetFileDetails( const char* pszFileName ) = 0;
+};
+
+#define STEAMAPPS_INTERFACE_VERSION "STEAMAPPS_INTERFACE_VERSION008"
+
+// callbacks
+#if defined( VALVE_CALLBACK_PACK_SMALL )
+#pragma pack( push, 4 )
+#elif defined( VALVE_CALLBACK_PACK_LARGE )
+#pragma pack( push, 8 )
+#else
+#error isteamclient.h must be included
+#endif 
+//-----------------------------------------------------------------------------
+// Purpose: posted after the user gains ownership of DLC & that DLC is installed
+//-----------------------------------------------------------------------------
+struct DlcInstalled_t
+{
+	enum { k_iCallback = k_iSteamAppsCallbacks + 5 };
+	AppId_t m_nAppID;		// AppID of the DLC
+};
+
+
+//-----------------------------------------------------------------------------
+// Purpose: possible results when registering an activation code
+//-----------------------------------------------------------------------------
+enum ERegisterActivationCodeResult
+{
+	k_ERegisterActivationCodeResultOK = 0,
+	k_ERegisterActivationCodeResultFail = 1,
+	k_ERegisterActivationCodeResultAlreadyRegistered = 2,
+	k_ERegisterActivationCodeResultTimeout = 3,
+	k_ERegisterActivationCodeAlreadyOwned = 4,
+};
+
+
+//-----------------------------------------------------------------------------
+// Purpose: response to RegisterActivationCode()
+//-----------------------------------------------------------------------------
+struct RegisterActivationCodeResponse_t
+{
+	enum { k_iCallback = k_iSteamAppsCallbacks + 8 };
+	ERegisterActivationCodeResult m_eResult;
+	uint32 m_unPackageRegistered;						// package that was registered. Only set on success
+};
+
+
+//---------------------------------------------------------------------------------
+// Purpose: posted after the user gains executes a steam url with query parameters
+// such as steam://run/<appid>//?param1=value1;param2=value2;param3=value3; etc
+// while the game is already running.  The new params can be queried
+// with GetLaunchQueryParam.
+//---------------------------------------------------------------------------------
+struct NewLaunchQueryParameters_t
+{
+	enum { k_iCallback = k_iSteamAppsCallbacks + 14 };
+};
+
+
+//-----------------------------------------------------------------------------
+// Purpose: response to RequestAppProofOfPurchaseKey/RequestAllProofOfPurchaseKeys
+// for supporting third-party CD keys, or other proof-of-purchase systems.
+//-----------------------------------------------------------------------------
+struct AppProofOfPurchaseKeyResponse_t
+{
+	enum { k_iCallback = k_iSteamAppsCallbacks + 21 };
+	EResult m_eResult;
+	uint32	m_nAppID;
+	uint32	m_cchKeyLength;
+	char	m_rgchKey[k_cubAppProofOfPurchaseKeyMax];
+};
+
+
+//-----------------------------------------------------------------------------
+// Purpose: response to GetFileDetails
+//-----------------------------------------------------------------------------
+struct FileDetailsResult_t
+{
+	enum { k_iCallback = k_iSteamAppsCallbacks + 23 };
+	EResult		m_eResult;
+	uint64		m_ulFileSize;	// original file size in bytes
+	uint8		m_FileSHA[20];	// original file SHA1 hash
+	uint32		m_unFlags;		// 
+};
+
+
+#pragma pack( pop )
+#endif // ISTEAMAPPS_H

--- a/Common/Chairloader/SteamAPI/isteamappticket.h
+++ b/Common/Chairloader/SteamAPI/isteamappticket.h
@@ -1,0 +1,32 @@
+//====== Copyright 1996-2008, Valve Corporation, All rights reserved. =======
+//
+// Purpose: a private, but well versioned, interface to get at critical bits
+// of a steam3 appticket - consumed by the simple drm wrapper to let it 
+// ask about ownership with greater confidence.
+//
+//=============================================================================
+
+#ifndef ISTEAMAPPTICKET_H
+#define ISTEAMAPPTICKET_H
+#ifdef WIN32
+#pragma once
+#endif
+
+#include "steamtypes.h"
+
+//-----------------------------------------------------------------------------
+// Purpose: hand out a reasonable "future proof" view of an app ownership ticket
+// the raw (signed) buffer, and indices into that buffer where the appid and 
+// steamid are located.  the sizes of the appid and steamid are implicit in 
+// (each version of) the interface - currently uin32 appid and uint64 steamid
+//-----------------------------------------------------------------------------
+class ISteamAppTicket
+{
+public:
+    virtual uint32 GetAppOwnershipTicketData( uint32 nAppID, void *pvBuffer, uint32 cbBufferLength, uint32 *piAppId, uint32 *piSteamId, uint32 *piSignature, uint32 *pcbSignature ) = 0;
+};
+
+#define STEAMAPPTICKET_INTERFACE_VERSION "STEAMAPPTICKET_INTERFACE_VERSION001"
+
+
+#endif // ISTEAMAPPTICKET_H

--- a/Common/Chairloader/SteamAPI/isteamclient.h
+++ b/Common/Chairloader/SteamAPI/isteamclient.h
@@ -1,0 +1,520 @@
+﻿//====== Copyright � 1996-2008, Valve Corporation, All rights reserved. =======
+//
+// Purpose: Main interface for loading and accessing Steamworks API's from the 
+//			Steam client.
+//			For most uses, this code is wrapped inside of SteamAPI_Init()
+//=============================================================================
+
+#ifndef ISTEAMCLIENT_H
+#define ISTEAMCLIENT_H
+#ifdef _WIN32
+#pragma once
+#endif
+
+#include "steamtypes.h"
+#include "steamclientpublic.h"
+
+// Define compile time assert macros to let us validate the structure sizes.
+#define VALVE_COMPILE_TIME_ASSERT( pred ) typedef char compile_time_assert_type[(pred) ? 1 : -1];
+
+#ifndef REFERENCE
+#define REFERENCE(arg) ((void)arg)
+#endif
+
+#if ( defined(STEAM_API_EXPORTS) || defined(STEAM_API_NODLL) ) && !defined(API_GEN)
+#define STEAM_PRIVATE_API( ... ) __VA_ARGS__
+#elif defined(STEAM_API_EXPORTS) && defined(API_GEN)
+#define STEAM_PRIVATE_API( ... )
+#else
+#define STEAM_PRIVATE_API( ... ) protected: __VA_ARGS__ public:
+#endif
+
+#if defined(__linux__) || defined(__APPLE__) 
+// The 32-bit version of gcc has the alignment requirement for uint64 and double set to
+// 4 meaning that even with #pragma pack(8) these types will only be four-byte aligned.
+// The 64-bit version of gcc has the alignment requirement for these types set to
+// 8 meaning that unless we use #pragma pack(4) our structures will get bigger.
+// The 64-bit structure packing has to match the 32-bit structure packing for each platform.
+#define VALVE_CALLBACK_PACK_SMALL
+#else
+#define VALVE_CALLBACK_PACK_LARGE
+#endif
+
+#if defined( VALVE_CALLBACK_PACK_SMALL )
+#pragma pack( push, 4 )
+#elif defined( VALVE_CALLBACK_PACK_LARGE )
+#pragma pack( push, 8 )
+#else
+#error ???
+#endif 
+
+typedef struct ValvePackingSentinel_t
+{
+    uint32 m_u32;
+    uint64 m_u64;
+    uint16 m_u16;
+    double m_d;
+} ValvePackingSentinel_t;
+
+#pragma pack( pop )
+
+
+#if defined(VALVE_CALLBACK_PACK_SMALL)
+VALVE_COMPILE_TIME_ASSERT( sizeof(ValvePackingSentinel_t) == 24 )
+#elif defined(VALVE_CALLBACK_PACK_LARGE)
+VALVE_COMPILE_TIME_ASSERT( sizeof(ValvePackingSentinel_t) == 32 )
+#else
+#error ???
+#endif
+
+
+// handle to a communication pipe to the Steam client
+typedef int32 HSteamPipe;
+// handle to single instance of a steam user
+typedef int32 HSteamUser;
+// function prototype
+#if defined( POSIX )
+#define __cdecl
+#endif
+extern "C" typedef void (__cdecl *SteamAPIWarningMessageHook_t)(int, const char *);
+extern "C" typedef uint32 ( *SteamAPI_CheckCallbackRegistered_t )( int iCallbackNum );
+#if defined( __SNC__ )
+	#pragma diag_suppress=1700	   // warning 1700: class "%s" has virtual functions but non-virtual destructor
+#endif
+
+// interface predec
+class ISteamUser;
+class ISteamGameServer;
+class ISteamFriends;
+class ISteamUtils;
+class ISteamMatchmaking;
+class ISteamContentServer;
+class ISteamMatchmakingServers;
+class ISteamUserStats;
+class ISteamApps;
+class ISteamNetworking;
+class ISteamRemoteStorage;
+class ISteamScreenshots;
+class ISteamMusic;
+class ISteamMusicRemote;
+class ISteamGameServerStats;
+class ISteamPS3OverlayRender;
+class ISteamHTTP;
+class ISteamUnifiedMessages;
+class ISteamController;
+class ISteamUGC;
+class ISteamAppList;
+class ISteamHTMLSurface;
+class ISteamInventory;
+class ISteamVideo;
+
+//-----------------------------------------------------------------------------
+// Purpose: Interface to creating a new steam instance, or to
+//			connect to an existing steam instance, whether it's in a
+//			different process or is local.
+//
+//			For most scenarios this is all handled automatically via SteamAPI_Init().
+//			You'll only need these APIs if you have a more complex versioning scheme,
+//			or if you want to implement a multiplexed gameserver where a single process
+//			is handling multiple games at once with independent gameserver SteamIDs.
+//-----------------------------------------------------------------------------
+class ISteamClient
+{
+public:
+	// Creates a communication pipe to the Steam client.
+	// NOT THREADSAFE - ensure that no other threads are accessing Steamworks API when calling
+	virtual HSteamPipe CreateSteamPipe() = 0;
+
+	// Releases a previously created communications pipe
+	// NOT THREADSAFE - ensure that no other threads are accessing Steamworks API when calling
+	virtual bool BReleaseSteamPipe( HSteamPipe hSteamPipe ) = 0;
+
+	// connects to an existing global user, failing if none exists
+	// used by the game to coordinate with the steamUI
+	// NOT THREADSAFE - ensure that no other threads are accessing Steamworks API when calling
+	virtual HSteamUser ConnectToGlobalUser( HSteamPipe hSteamPipe ) = 0;
+
+	// used by game servers, create a steam user that won't be shared with anyone else
+	// NOT THREADSAFE - ensure that no other threads are accessing Steamworks API when calling
+	virtual HSteamUser CreateLocalUser( HSteamPipe *phSteamPipe, EAccountType eAccountType ) = 0;
+
+	// removes an allocated user
+	// NOT THREADSAFE - ensure that no other threads are accessing Steamworks API when calling
+	virtual void ReleaseUser( HSteamPipe hSteamPipe, HSteamUser hUser ) = 0;
+
+	// retrieves the ISteamUser interface associated with the handle
+	virtual ISteamUser *GetISteamUser( HSteamUser hSteamUser, HSteamPipe hSteamPipe, const char *pchVersion ) = 0;
+
+	// retrieves the ISteamGameServer interface associated with the handle
+	virtual ISteamGameServer *GetISteamGameServer( HSteamUser hSteamUser, HSteamPipe hSteamPipe, const char *pchVersion ) = 0;
+
+	// set the local IP and Port to bind to
+	// this must be set before CreateLocalUser()
+	virtual void SetLocalIPBinding( uint32 unIP, uint16 usPort ) = 0; 
+
+	// returns the ISteamFriends interface
+	virtual ISteamFriends *GetISteamFriends( HSteamUser hSteamUser, HSteamPipe hSteamPipe, const char *pchVersion ) = 0;
+
+	// returns the ISteamUtils interface
+	virtual ISteamUtils *GetISteamUtils( HSteamPipe hSteamPipe, const char *pchVersion ) = 0;
+
+	// returns the ISteamMatchmaking interface
+	virtual ISteamMatchmaking *GetISteamMatchmaking( HSteamUser hSteamUser, HSteamPipe hSteamPipe, const char *pchVersion ) = 0;
+
+	// returns the ISteamMatchmakingServers interface
+	virtual ISteamMatchmakingServers *GetISteamMatchmakingServers( HSteamUser hSteamUser, HSteamPipe hSteamPipe, const char *pchVersion ) = 0;
+
+	// returns the a generic interface
+	virtual void *GetISteamGenericInterface( HSteamUser hSteamUser, HSteamPipe hSteamPipe, const char *pchVersion ) = 0;
+
+	// returns the ISteamUserStats interface
+	virtual ISteamUserStats *GetISteamUserStats( HSteamUser hSteamUser, HSteamPipe hSteamPipe, const char *pchVersion ) = 0;
+
+	// returns the ISteamGameServerStats interface
+	virtual ISteamGameServerStats *GetISteamGameServerStats( HSteamUser hSteamuser, HSteamPipe hSteamPipe, const char *pchVersion ) = 0;
+
+	// returns apps interface
+	virtual ISteamApps *GetISteamApps( HSteamUser hSteamUser, HSteamPipe hSteamPipe, const char *pchVersion ) = 0;
+
+	// networking
+	virtual ISteamNetworking *GetISteamNetworking( HSteamUser hSteamUser, HSteamPipe hSteamPipe, const char *pchVersion ) = 0;
+
+	// remote storage
+	virtual ISteamRemoteStorage *GetISteamRemoteStorage( HSteamUser hSteamuser, HSteamPipe hSteamPipe, const char *pchVersion ) = 0;
+
+	// user screenshots
+	virtual ISteamScreenshots *GetISteamScreenshots( HSteamUser hSteamuser, HSteamPipe hSteamPipe, const char *pchVersion ) = 0;
+
+	// Deprecated. Applications should use SteamAPI_RunCallbacks() or SteamGameServer_RunCallbacks() instead.
+	STEAM_PRIVATE_API( virtual void RunFrame() = 0; )
+
+	// returns the number of IPC calls made since the last time this function was called
+	// Used for perf debugging so you can understand how many IPC calls your game makes per frame
+	// Every IPC call is at minimum a thread context switch if not a process one so you want to rate
+	// control how often you do them.
+	virtual uint32 GetIPCCallCount() = 0;
+
+	// API warning handling
+	// 'int' is the severity; 0 for msg, 1 for warning
+	// 'const char *' is the text of the message
+	// callbacks will occur directly after the API function is called that generated the warning or message.
+	virtual void SetWarningMessageHook( SteamAPIWarningMessageHook_t pFunction ) = 0;
+
+	// Trigger global shutdown for the DLL
+	virtual bool BShutdownIfAllPipesClosed() = 0;
+
+	// Expose HTTP interface
+	virtual ISteamHTTP *GetISteamHTTP( HSteamUser hSteamuser, HSteamPipe hSteamPipe, const char *pchVersion ) = 0;
+
+	// Exposes the ISteamUnifiedMessages interface
+	virtual ISteamUnifiedMessages *GetISteamUnifiedMessages( HSteamUser hSteamuser, HSteamPipe hSteamPipe, const char *pchVersion ) = 0;
+
+	// Exposes the ISteamController interface
+	virtual ISteamController *GetISteamController( HSteamUser hSteamUser, HSteamPipe hSteamPipe, const char *pchVersion ) = 0;
+
+	// Exposes the ISteamUGC interface
+	virtual ISteamUGC *GetISteamUGC( HSteamUser hSteamUser, HSteamPipe hSteamPipe, const char *pchVersion ) = 0;
+
+	// returns app list interface, only available on specially registered apps
+	virtual ISteamAppList *GetISteamAppList( HSteamUser hSteamUser, HSteamPipe hSteamPipe, const char *pchVersion ) = 0;
+	
+	// Music Player
+	virtual ISteamMusic *GetISteamMusic( HSteamUser hSteamuser, HSteamPipe hSteamPipe, const char *pchVersion ) = 0;
+
+	// Music Player Remote
+	virtual ISteamMusicRemote *GetISteamMusicRemote(HSteamUser hSteamuser, HSteamPipe hSteamPipe, const char *pchVersion) = 0;
+
+	// html page display
+	virtual ISteamHTMLSurface *GetISteamHTMLSurface(HSteamUser hSteamuser, HSteamPipe hSteamPipe, const char *pchVersion) = 0;
+
+	// Helper functions for internal Steam usage
+	STEAM_PRIVATE_API( virtual void DEPRECATED_Set_SteamAPI_CPostAPIResultInProcess( void (*)() ) = 0; )
+	STEAM_PRIVATE_API( virtual void DEPRECATED_Remove_SteamAPI_CPostAPIResultInProcess( void (*)() ) = 0; )
+	STEAM_PRIVATE_API( virtual void Set_SteamAPI_CCheckCallbackRegisteredInProcess( SteamAPI_CheckCallbackRegistered_t func ) = 0; )
+
+	// inventory
+	virtual ISteamInventory *GetISteamInventory( HSteamUser hSteamuser, HSteamPipe hSteamPipe, const char *pchVersion ) = 0;
+
+	// Video
+	virtual ISteamVideo *GetISteamVideo( HSteamUser hSteamuser, HSteamPipe hSteamPipe, const char *pchVersion ) = 0;
+};
+
+
+#define STEAMCLIENT_INTERFACE_VERSION		"SteamClient017"
+
+//-----------------------------------------------------------------------------
+// Purpose: Base values for callback identifiers, each callback must
+//			have a unique ID.
+//-----------------------------------------------------------------------------
+enum { k_iSteamUserCallbacks = 100 };
+enum { k_iSteamGameServerCallbacks = 200 };
+enum { k_iSteamFriendsCallbacks = 300 };
+enum { k_iSteamBillingCallbacks = 400 };
+enum { k_iSteamMatchmakingCallbacks = 500 };
+enum { k_iSteamContentServerCallbacks = 600 };
+enum { k_iSteamUtilsCallbacks = 700 };
+enum { k_iClientFriendsCallbacks = 800 };
+enum { k_iClientUserCallbacks = 900 };
+enum { k_iSteamAppsCallbacks = 1000 };
+enum { k_iSteamUserStatsCallbacks = 1100 };
+enum { k_iSteamNetworkingCallbacks = 1200 };
+enum { k_iClientRemoteStorageCallbacks = 1300 };
+enum { k_iClientDepotBuilderCallbacks = 1400 };
+enum { k_iSteamGameServerItemsCallbacks = 1500 };
+enum { k_iClientUtilsCallbacks = 1600 };
+enum { k_iSteamGameCoordinatorCallbacks = 1700 };
+enum { k_iSteamGameServerStatsCallbacks = 1800 };
+enum { k_iSteam2AsyncCallbacks = 1900 };
+enum { k_iSteamGameStatsCallbacks = 2000 };
+enum { k_iClientHTTPCallbacks = 2100 };
+enum { k_iClientScreenshotsCallbacks = 2200 };
+enum { k_iSteamScreenshotsCallbacks = 2300 };
+enum { k_iClientAudioCallbacks = 2400 };
+enum { k_iClientUnifiedMessagesCallbacks = 2500 };
+enum { k_iSteamStreamLauncherCallbacks = 2600 };
+enum { k_iClientControllerCallbacks = 2700 };
+enum { k_iSteamControllerCallbacks = 2800 };
+enum { k_iClientParentalSettingsCallbacks = 2900 };
+enum { k_iClientDeviceAuthCallbacks = 3000 };
+enum { k_iClientNetworkDeviceManagerCallbacks = 3100 };
+enum { k_iClientMusicCallbacks = 3200 };
+enum { k_iClientRemoteClientManagerCallbacks = 3300 };
+enum { k_iClientUGCCallbacks = 3400 };
+enum { k_iSteamStreamClientCallbacks = 3500 };
+enum { k_IClientProductBuilderCallbacks = 3600 };
+enum { k_iClientShortcutsCallbacks = 3700 };
+enum { k_iClientRemoteControlManagerCallbacks = 3800 };
+enum { k_iSteamAppListCallbacks = 3900 };
+enum { k_iSteamMusicCallbacks = 4000 };
+enum { k_iSteamMusicRemoteCallbacks = 4100 };
+enum { k_iClientVRCallbacks = 4200 };
+enum { k_iClientGameNotificationCallbacks = 4300 }; 
+enum { k_iSteamGameNotificationCallbacks = 4400 }; 
+enum { k_iSteamHTMLSurfaceCallbacks = 4500 };
+enum { k_iClientVideoCallbacks = 4600 };
+enum { k_iClientInventoryCallbacks = 4700 };
+enum { k_iClientBluetoothManagerCallbacks = 4800 };
+
+//-----------------------------------------------------------------------------
+// The CALLBACK macros are for client side callback logging enabled with
+// log_callback <first callnbackID> <last callbackID>
+// Do not change any of these. 
+//-----------------------------------------------------------------------------
+
+#ifdef STEAM_CALLBACK_INSPECTION_ENABLED
+
+#define DEFINE_CALLBACK( callbackname, callbackid ) \
+struct callbackname { \
+	typedef callbackname SteamCallback_t; \
+	enum { k_iCallback = callbackid }; \
+	static callbackname *GetNullPointer() { return 0; } \
+	static const char *GetCallbackName() { return #callbackname; } \
+	static uint32  GetCallbackID() { return callbackname::k_iCallback; }
+
+#define CALLBACK_MEMBER( varidx, vartype, varname ) \
+	public: vartype varname ; \
+	static void GetMemberVar_##varidx( unsigned int &varOffset, unsigned int &varSize, uint32 &varCount, const char **pszName, const char **pszType ) { \
+			varOffset = (unsigned int)(size_t)&GetNullPointer()->varname; \
+			varSize = sizeof( vartype ); \
+			varCount = 1; \
+			*pszName = #varname; *pszType = #vartype; }
+
+#define CALLBACK_ARRAY( varidx, vartype, varname, varcount ) \
+	public: vartype varname [ varcount ]; \
+	static void GetMemberVar_##varidx( unsigned int &varOffset, unsigned int &varSize, uint32 &varCount, const char **pszName, const char **pszType ) { \
+	varOffset = (unsigned int)(size_t)&GetNullPointer()->varname[0]; \
+	varSize = sizeof( vartype ); \
+	varCount = varcount; \
+	*pszName = #varname; *pszType = #vartype; }
+
+
+#define END_CALLBACK_INTERNAL_BEGIN( numvars )  \
+	static uint32  GetNumMemberVariables() { return numvars; } \
+	static bool    GetMemberVariable( uint32 index, uint32 &varOffset, uint32 &varSize,  uint32 &varCount, const char **pszName, const char **pszType ) { \
+	switch ( index ) { default : return false;
+
+
+#define END_CALLBACK_INTERNAL_SWITCH( varidx ) case varidx : GetMemberVar_##varidx( varOffset, varSize, varCount, pszName, pszType ); return true;
+
+#define END_CALLBACK_INTERNAL_END() }; } };
+
+#define END_DEFINE_CALLBACK_0() \
+	static uint32  GetNumMemberVariables() { return 0; } \
+	static bool    GetMemberVariable( uint32 index, uint32 &varOffset, uint32 &varSize,  uint32 &varCount, const char **pszName, const char **pszType ) { REFERENCE( pszType ); REFERENCE( pszName ); REFERENCE( varCount ); REFERENCE( varSize ); REFERENCE( varOffset ); REFERENCE( index ); return false; } \
+	};
+	
+#else
+
+#define DEFINE_CALLBACK( callbackname, callbackid )	struct callbackname { typedef callbackname SteamCallback_t; enum { k_iCallback = callbackid };
+#define CALLBACK_MEMBER( varidx, vartype, varname )	public: vartype varname ; 
+#define CALLBACK_ARRAY( varidx, vartype, varname, varcount ) public: vartype varname [ varcount ];
+#define END_CALLBACK_INTERNAL_BEGIN( numvars )  
+#define END_CALLBACK_INTERNAL_SWITCH( varidx )
+#define END_CALLBACK_INTERNAL_END()					};
+#define END_DEFINE_CALLBACK_0()						};
+
+#endif
+
+#define END_DEFINE_CALLBACK_1() \
+	END_CALLBACK_INTERNAL_BEGIN( 1 ) \
+	END_CALLBACK_INTERNAL_SWITCH( 0 ) \
+	END_CALLBACK_INTERNAL_END()
+
+#define END_DEFINE_CALLBACK_2() \
+	END_CALLBACK_INTERNAL_BEGIN( 2 ) \
+	END_CALLBACK_INTERNAL_SWITCH( 0 ) \
+	END_CALLBACK_INTERNAL_SWITCH( 1 ) \
+	END_CALLBACK_INTERNAL_END()
+
+#define END_DEFINE_CALLBACK_3() \
+	END_CALLBACK_INTERNAL_BEGIN( 3 ) \
+	END_CALLBACK_INTERNAL_SWITCH( 0 ) \
+	END_CALLBACK_INTERNAL_SWITCH( 1 ) \
+	END_CALLBACK_INTERNAL_SWITCH( 2 ) \
+	END_CALLBACK_INTERNAL_END()
+
+#define END_DEFINE_CALLBACK_4() \
+	END_CALLBACK_INTERNAL_BEGIN( 4 ) \
+	END_CALLBACK_INTERNAL_SWITCH( 0 ) \
+	END_CALLBACK_INTERNAL_SWITCH( 1 ) \
+	END_CALLBACK_INTERNAL_SWITCH( 2 ) \
+	END_CALLBACK_INTERNAL_SWITCH( 3 ) \
+	END_CALLBACK_INTERNAL_END()
+
+#define END_DEFINE_CALLBACK_5() \
+	END_CALLBACK_INTERNAL_BEGIN( 4 ) \
+	END_CALLBACK_INTERNAL_SWITCH( 0 ) \
+	END_CALLBACK_INTERNAL_SWITCH( 1 ) \
+	END_CALLBACK_INTERNAL_SWITCH( 2 ) \
+	END_CALLBACK_INTERNAL_SWITCH( 3 ) \
+	END_CALLBACK_INTERNAL_SWITCH( 4 ) \
+	END_CALLBACK_INTERNAL_END()
+
+
+#define END_DEFINE_CALLBACK_6() \
+	END_CALLBACK_INTERNAL_BEGIN( 6 ) \
+	END_CALLBACK_INTERNAL_SWITCH( 0 ) \
+	END_CALLBACK_INTERNAL_SWITCH( 1 ) \
+	END_CALLBACK_INTERNAL_SWITCH( 2 ) \
+	END_CALLBACK_INTERNAL_SWITCH( 3 ) \
+	END_CALLBACK_INTERNAL_SWITCH( 4 ) \
+	END_CALLBACK_INTERNAL_SWITCH( 5 ) \
+	END_CALLBACK_INTERNAL_END()
+
+#define END_DEFINE_CALLBACK_7() \
+	END_CALLBACK_INTERNAL_BEGIN( 7 ) \
+	END_CALLBACK_INTERNAL_SWITCH( 0 ) \
+	END_CALLBACK_INTERNAL_SWITCH( 1 ) \
+	END_CALLBACK_INTERNAL_SWITCH( 2 ) \
+	END_CALLBACK_INTERNAL_SWITCH( 3 ) \
+	END_CALLBACK_INTERNAL_SWITCH( 4 ) \
+	END_CALLBACK_INTERNAL_SWITCH( 5 ) \
+	END_CALLBACK_INTERNAL_SWITCH( 6 ) \
+	END_CALLBACK_INTERNAL_END()
+
+#define END_DEFINE_CALLBACK_8() \
+	END_CALLBACK_INTERNAL_BEGIN( 8 ) \
+	END_CALLBACK_INTERNAL_SWITCH( 0 ) \
+	END_CALLBACK_INTERNAL_SWITCH( 1 ) \
+	END_CALLBACK_INTERNAL_SWITCH( 2 ) \
+	END_CALLBACK_INTERNAL_SWITCH( 3 ) \
+	END_CALLBACK_INTERNAL_SWITCH( 4 ) \
+	END_CALLBACK_INTERNAL_SWITCH( 5 ) \
+	END_CALLBACK_INTERNAL_SWITCH( 6 ) \
+	END_CALLBACK_INTERNAL_SWITCH( 7 ) \
+	END_CALLBACK_INTERNAL_END()
+
+#define END_DEFINE_CALLBACK_9() \
+	END_CALLBACK_INTERNAL_BEGIN( 9 ) \
+	END_CALLBACK_INTERNAL_SWITCH( 0 ) \
+	END_CALLBACK_INTERNAL_SWITCH( 1 ) \
+	END_CALLBACK_INTERNAL_SWITCH( 2 ) \
+	END_CALLBACK_INTERNAL_SWITCH( 3 ) \
+	END_CALLBACK_INTERNAL_SWITCH( 4 ) \
+	END_CALLBACK_INTERNAL_SWITCH( 5 ) \
+	END_CALLBACK_INTERNAL_SWITCH( 6 ) \
+	END_CALLBACK_INTERNAL_SWITCH( 7 ) \
+	END_CALLBACK_INTERNAL_SWITCH( 8 ) \
+	END_CALLBACK_INTERNAL_END()
+
+#define END_DEFINE_CALLBACK_10() \
+	END_CALLBACK_INTERNAL_BEGIN( 10 ) \
+	END_CALLBACK_INTERNAL_SWITCH( 0 ) \
+	END_CALLBACK_INTERNAL_SWITCH( 1 ) \
+	END_CALLBACK_INTERNAL_SWITCH( 2 ) \
+	END_CALLBACK_INTERNAL_SWITCH( 3 ) \
+	END_CALLBACK_INTERNAL_SWITCH( 4 ) \
+	END_CALLBACK_INTERNAL_SWITCH( 5 ) \
+	END_CALLBACK_INTERNAL_SWITCH( 6 ) \
+	END_CALLBACK_INTERNAL_SWITCH( 7 ) \
+	END_CALLBACK_INTERNAL_SWITCH( 8 ) \
+	END_CALLBACK_INTERNAL_SWITCH( 9 ) \
+	END_CALLBACK_INTERNAL_END()
+
+#define END_DEFINE_CALLBACK_11() \
+	END_CALLBACK_INTERNAL_BEGIN( 11 ) \
+	END_CALLBACK_INTERNAL_SWITCH( 0 ) \
+	END_CALLBACK_INTERNAL_SWITCH( 1 ) \
+	END_CALLBACK_INTERNAL_SWITCH( 2 ) \
+	END_CALLBACK_INTERNAL_SWITCH( 3 ) \
+	END_CALLBACK_INTERNAL_SWITCH( 4 ) \
+	END_CALLBACK_INTERNAL_SWITCH( 5 ) \
+	END_CALLBACK_INTERNAL_SWITCH( 6 ) \
+	END_CALLBACK_INTERNAL_SWITCH( 7 ) \
+	END_CALLBACK_INTERNAL_SWITCH( 8 ) \
+	END_CALLBACK_INTERNAL_SWITCH( 9 ) \
+	END_CALLBACK_INTERNAL_SWITCH( 10 ) \
+	END_CALLBACK_INTERNAL_END()
+
+#define END_DEFINE_CALLBACK_12() \
+	END_CALLBACK_INTERNAL_BEGIN( 12 ) \
+	END_CALLBACK_INTERNAL_SWITCH( 0 ) \
+	END_CALLBACK_INTERNAL_SWITCH( 1 ) \
+	END_CALLBACK_INTERNAL_SWITCH( 2 ) \
+	END_CALLBACK_INTERNAL_SWITCH( 3 ) \
+	END_CALLBACK_INTERNAL_SWITCH( 4 ) \
+	END_CALLBACK_INTERNAL_SWITCH( 5 ) \
+	END_CALLBACK_INTERNAL_SWITCH( 6 ) \
+	END_CALLBACK_INTERNAL_SWITCH( 7 ) \
+	END_CALLBACK_INTERNAL_SWITCH( 8 ) \
+	END_CALLBACK_INTERNAL_SWITCH( 9 ) \
+	END_CALLBACK_INTERNAL_SWITCH( 10 ) \
+	END_CALLBACK_INTERNAL_SWITCH( 11 ) \
+	END_CALLBACK_INTERNAL_END()
+
+#define END_DEFINE_CALLBACK_13() \
+	END_CALLBACK_INTERNAL_BEGIN( 13 ) \
+	END_CALLBACK_INTERNAL_SWITCH( 0 ) \
+	END_CALLBACK_INTERNAL_SWITCH( 1 ) \
+	END_CALLBACK_INTERNAL_SWITCH( 2 ) \
+	END_CALLBACK_INTERNAL_SWITCH( 3 ) \
+	END_CALLBACK_INTERNAL_SWITCH( 4 ) \
+	END_CALLBACK_INTERNAL_SWITCH( 5 ) \
+	END_CALLBACK_INTERNAL_SWITCH( 6 ) \
+	END_CALLBACK_INTERNAL_SWITCH( 7 ) \
+	END_CALLBACK_INTERNAL_SWITCH( 8 ) \
+	END_CALLBACK_INTERNAL_SWITCH( 9 ) \
+	END_CALLBACK_INTERNAL_SWITCH( 10 ) \
+	END_CALLBACK_INTERNAL_SWITCH( 11 ) \
+	END_CALLBACK_INTERNAL_SWITCH( 12 ) \
+	END_CALLBACK_INTERNAL_END()
+
+#define END_DEFINE_CALLBACK_14() \
+	END_CALLBACK_INTERNAL_BEGIN( 14 ) \
+	END_CALLBACK_INTERNAL_SWITCH( 0 ) \
+	END_CALLBACK_INTERNAL_SWITCH( 1 ) \
+	END_CALLBACK_INTERNAL_SWITCH( 2 ) \
+	END_CALLBACK_INTERNAL_SWITCH( 3 ) \
+	END_CALLBACK_INTERNAL_SWITCH( 4 ) \
+	END_CALLBACK_INTERNAL_SWITCH( 5 ) \
+	END_CALLBACK_INTERNAL_SWITCH( 6 ) \
+	END_CALLBACK_INTERNAL_SWITCH( 7 ) \
+	END_CALLBACK_INTERNAL_SWITCH( 8 ) \
+	END_CALLBACK_INTERNAL_SWITCH( 9 ) \
+	END_CALLBACK_INTERNAL_SWITCH( 10 ) \
+	END_CALLBACK_INTERNAL_SWITCH( 11 ) \
+	END_CALLBACK_INTERNAL_SWITCH( 12 ) \
+	END_CALLBACK_INTERNAL_SWITCH( 13 ) \
+	END_CALLBACK_INTERNAL_END()
+
+#endif // ISTEAMCLIENT_H

--- a/Common/Chairloader/SteamAPI/isteamcontroller.h
+++ b/Common/Chairloader/SteamAPI/isteamcontroller.h
@@ -1,0 +1,429 @@
+//====== Copyright 1996-2013, Valve Corporation, All rights reserved. =======
+//
+// Purpose: interface to valve controller
+//
+//=============================================================================
+
+#ifndef ISTEAMCONTROLLER_H
+#define ISTEAMCONTROLLER_H
+#ifdef _WIN32
+#pragma once
+#endif
+
+#include "isteamclient.h"
+
+#define STEAM_CONTROLLER_MAX_COUNT 16
+
+#define STEAM_CONTROLLER_MAX_ANALOG_ACTIONS 16
+
+#define STEAM_CONTROLLER_MAX_DIGITAL_ACTIONS 128
+
+#define STEAM_CONTROLLER_MAX_ORIGINS 8
+
+// When sending an option to a specific controller handle, you can send to all controllers via this command
+#define STEAM_CONTROLLER_HANDLE_ALL_CONTROLLERS UINT64_MAX
+
+#define STEAM_CONTROLLER_MIN_ANALOG_ACTION_DATA -1.0f
+#define STEAM_CONTROLLER_MAX_ANALOG_ACTION_DATA 1.0f
+
+enum ESteamControllerPad
+{
+	k_ESteamControllerPad_Left,
+	k_ESteamControllerPad_Right
+};
+
+enum EControllerSource
+{
+	k_EControllerSource_None,
+	k_EControllerSource_LeftTrackpad,
+	k_EControllerSource_RightTrackpad,
+	k_EControllerSource_Joystick,
+	k_EControllerSource_ABXY,
+	k_EControllerSource_Switch,
+	k_EControllerSource_LeftTrigger,
+	k_EControllerSource_RightTrigger,
+	k_EControllerSource_Gyro,
+	k_EControllerSource_CenterTrackpad,		// PS4
+	k_EControllerSource_RightJoystick,		// Traditional Controllers
+	k_EControllerSource_DPad,				// Traditional Controllers
+	k_EControllerSource_Count
+};
+
+enum EControllerSourceMode
+{
+	k_EControllerSourceMode_None,
+	k_EControllerSourceMode_Dpad,
+	k_EControllerSourceMode_Buttons,
+	k_EControllerSourceMode_FourButtons,
+	k_EControllerSourceMode_AbsoluteMouse,
+	k_EControllerSourceMode_RelativeMouse,
+	k_EControllerSourceMode_JoystickMove,
+	k_EControllerSourceMode_JoystickMouse,
+	k_EControllerSourceMode_JoystickCamera,
+	k_EControllerSourceMode_ScrollWheel,
+	k_EControllerSourceMode_Trigger,
+	k_EControllerSourceMode_TouchMenu,
+	k_EControllerSourceMode_MouseJoystick,
+	k_EControllerSourceMode_MouseRegion,
+	k_EControllerSourceMode_RadialMenu,
+	k_EControllerSourceMode_Switches
+};
+
+enum EControllerActionOrigin
+{
+	// Steam Controller
+	k_EControllerActionOrigin_None,
+	k_EControllerActionOrigin_A,
+	k_EControllerActionOrigin_B,
+	k_EControllerActionOrigin_X,
+	k_EControllerActionOrigin_Y,
+	k_EControllerActionOrigin_LeftBumper,
+	k_EControllerActionOrigin_RightBumper,
+	k_EControllerActionOrigin_LeftGrip,
+	k_EControllerActionOrigin_RightGrip,
+	k_EControllerActionOrigin_Start,
+	k_EControllerActionOrigin_Back,
+	k_EControllerActionOrigin_LeftPad_Touch,
+	k_EControllerActionOrigin_LeftPad_Swipe,
+	k_EControllerActionOrigin_LeftPad_Click,
+	k_EControllerActionOrigin_LeftPad_DPadNorth,
+	k_EControllerActionOrigin_LeftPad_DPadSouth,
+	k_EControllerActionOrigin_LeftPad_DPadWest,
+	k_EControllerActionOrigin_LeftPad_DPadEast,
+	k_EControllerActionOrigin_RightPad_Touch,
+	k_EControllerActionOrigin_RightPad_Swipe,
+	k_EControllerActionOrigin_RightPad_Click,
+	k_EControllerActionOrigin_RightPad_DPadNorth,
+	k_EControllerActionOrigin_RightPad_DPadSouth,
+	k_EControllerActionOrigin_RightPad_DPadWest,
+	k_EControllerActionOrigin_RightPad_DPadEast,
+	k_EControllerActionOrigin_LeftTrigger_Pull,
+	k_EControllerActionOrigin_LeftTrigger_Click,
+	k_EControllerActionOrigin_RightTrigger_Pull,
+	k_EControllerActionOrigin_RightTrigger_Click,
+	k_EControllerActionOrigin_LeftStick_Move,
+	k_EControllerActionOrigin_LeftStick_Click,
+	k_EControllerActionOrigin_LeftStick_DPadNorth,
+	k_EControllerActionOrigin_LeftStick_DPadSouth,
+	k_EControllerActionOrigin_LeftStick_DPadWest,
+	k_EControllerActionOrigin_LeftStick_DPadEast,
+	k_EControllerActionOrigin_Gyro_Move,
+	k_EControllerActionOrigin_Gyro_Pitch,
+	k_EControllerActionOrigin_Gyro_Yaw,
+	k_EControllerActionOrigin_Gyro_Roll,
+	
+	// PS4 Dual Shock
+	k_EControllerActionOrigin_PS4_X,
+	k_EControllerActionOrigin_PS4_Circle,
+	k_EControllerActionOrigin_PS4_Triangle,
+	k_EControllerActionOrigin_PS4_Square,
+	k_EControllerActionOrigin_PS4_LeftBumper,
+	k_EControllerActionOrigin_PS4_RightBumper,
+	k_EControllerActionOrigin_PS4_Options,  //Start
+	k_EControllerActionOrigin_PS4_Share,	//Back
+	k_EControllerActionOrigin_PS4_LeftPad_Touch,
+	k_EControllerActionOrigin_PS4_LeftPad_Swipe,
+	k_EControllerActionOrigin_PS4_LeftPad_Click,
+	k_EControllerActionOrigin_PS4_LeftPad_DPadNorth,
+	k_EControllerActionOrigin_PS4_LeftPad_DPadSouth,
+	k_EControllerActionOrigin_PS4_LeftPad_DPadWest,
+	k_EControllerActionOrigin_PS4_LeftPad_DPadEast,
+	k_EControllerActionOrigin_PS4_RightPad_Touch,
+	k_EControllerActionOrigin_PS4_RightPad_Swipe,
+	k_EControllerActionOrigin_PS4_RightPad_Click,
+	k_EControllerActionOrigin_PS4_RightPad_DPadNorth,
+	k_EControllerActionOrigin_PS4_RightPad_DPadSouth,
+	k_EControllerActionOrigin_PS4_RightPad_DPadWest,
+	k_EControllerActionOrigin_PS4_RightPad_DPadEast,
+	k_EControllerActionOrigin_PS4_CenterPad_Touch,
+	k_EControllerActionOrigin_PS4_CenterPad_Swipe,
+	k_EControllerActionOrigin_PS4_CenterPad_Click,
+	k_EControllerActionOrigin_PS4_CenterPad_DPadNorth,
+	k_EControllerActionOrigin_PS4_CenterPad_DPadSouth,
+	k_EControllerActionOrigin_PS4_CenterPad_DPadWest,
+	k_EControllerActionOrigin_PS4_CenterPad_DPadEast,
+	k_EControllerActionOrigin_PS4_LeftTrigger_Pull,
+	k_EControllerActionOrigin_PS4_LeftTrigger_Click,
+	k_EControllerActionOrigin_PS4_RightTrigger_Pull,
+	k_EControllerActionOrigin_PS4_RightTrigger_Click,
+	k_EControllerActionOrigin_PS4_LeftStick_Move,
+	k_EControllerActionOrigin_PS4_LeftStick_Click,
+	k_EControllerActionOrigin_PS4_LeftStick_DPadNorth,
+	k_EControllerActionOrigin_PS4_LeftStick_DPadSouth,
+	k_EControllerActionOrigin_PS4_LeftStick_DPadWest,
+	k_EControllerActionOrigin_PS4_LeftStick_DPadEast,
+	k_EControllerActionOrigin_PS4_RightStick_Move,
+	k_EControllerActionOrigin_PS4_RightStick_Click,
+	k_EControllerActionOrigin_PS4_RightStick_DPadNorth,
+	k_EControllerActionOrigin_PS4_RightStick_DPadSouth,
+	k_EControllerActionOrigin_PS4_RightStick_DPadWest,
+	k_EControllerActionOrigin_PS4_RightStick_DPadEast,
+	k_EControllerActionOrigin_PS4_DPad_North,
+	k_EControllerActionOrigin_PS4_DPad_South,
+	k_EControllerActionOrigin_PS4_DPad_West,
+	k_EControllerActionOrigin_PS4_DPad_East,
+	k_EControllerActionOrigin_PS4_Gyro_Move,
+	k_EControllerActionOrigin_PS4_Gyro_Pitch,
+	k_EControllerActionOrigin_PS4_Gyro_Yaw,
+	k_EControllerActionOrigin_PS4_Gyro_Roll,
+
+	// XBox One
+	k_EControllerActionOrigin_XBoxOne_A,
+	k_EControllerActionOrigin_XBoxOne_B,
+	k_EControllerActionOrigin_XBoxOne_X,
+	k_EControllerActionOrigin_XBoxOne_Y,
+	k_EControllerActionOrigin_XBoxOne_LeftBumper,
+	k_EControllerActionOrigin_XBoxOne_RightBumper,
+	k_EControllerActionOrigin_XBoxOne_Menu,  //Start
+	k_EControllerActionOrigin_XBoxOne_View,  //Back
+	k_EControllerActionOrigin_XBoxOne_LeftTrigger_Pull,
+	k_EControllerActionOrigin_XBoxOne_LeftTrigger_Click,
+	k_EControllerActionOrigin_XBoxOne_RightTrigger_Pull,
+	k_EControllerActionOrigin_XBoxOne_RightTrigger_Click,
+	k_EControllerActionOrigin_XBoxOne_LeftStick_Move,
+	k_EControllerActionOrigin_XBoxOne_LeftStick_Click,
+	k_EControllerActionOrigin_XBoxOne_LeftStick_DPadNorth,
+	k_EControllerActionOrigin_XBoxOne_LeftStick_DPadSouth,
+	k_EControllerActionOrigin_XBoxOne_LeftStick_DPadWest,
+	k_EControllerActionOrigin_XBoxOne_LeftStick_DPadEast,
+	k_EControllerActionOrigin_XBoxOne_RightStick_Move,
+	k_EControllerActionOrigin_XBoxOne_RightStick_Click,
+	k_EControllerActionOrigin_XBoxOne_RightStick_DPadNorth,
+	k_EControllerActionOrigin_XBoxOne_RightStick_DPadSouth,
+	k_EControllerActionOrigin_XBoxOne_RightStick_DPadWest,
+	k_EControllerActionOrigin_XBoxOne_RightStick_DPadEast,
+	k_EControllerActionOrigin_XBoxOne_DPad_North,
+	k_EControllerActionOrigin_XBoxOne_DPad_South,
+	k_EControllerActionOrigin_XBoxOne_DPad_West,
+	k_EControllerActionOrigin_XBoxOne_DPad_East,
+
+	// XBox 360
+	k_EControllerActionOrigin_XBox360_A,
+	k_EControllerActionOrigin_XBox360_B,
+	k_EControllerActionOrigin_XBox360_X,
+	k_EControllerActionOrigin_XBox360_Y,
+	k_EControllerActionOrigin_XBox360_LeftBumper,
+	k_EControllerActionOrigin_XBox360_RightBumper,
+	k_EControllerActionOrigin_XBox360_Start,  //Start
+	k_EControllerActionOrigin_XBox360_Back,  //Back
+	k_EControllerActionOrigin_XBox360_LeftTrigger_Pull,
+	k_EControllerActionOrigin_XBox360_LeftTrigger_Click,
+	k_EControllerActionOrigin_XBox360_RightTrigger_Pull,
+	k_EControllerActionOrigin_XBox360_RightTrigger_Click,
+	k_EControllerActionOrigin_XBox360_LeftStick_Move,
+	k_EControllerActionOrigin_XBox360_LeftStick_Click,
+	k_EControllerActionOrigin_XBox360_LeftStick_DPadNorth,
+	k_EControllerActionOrigin_XBox360_LeftStick_DPadSouth,
+	k_EControllerActionOrigin_XBox360_LeftStick_DPadWest,
+	k_EControllerActionOrigin_XBox360_LeftStick_DPadEast,
+	k_EControllerActionOrigin_XBox360_RightStick_Move,
+	k_EControllerActionOrigin_XBox360_RightStick_Click,
+	k_EControllerActionOrigin_XBox360_RightStick_DPadNorth,
+	k_EControllerActionOrigin_XBox360_RightStick_DPadSouth,
+	k_EControllerActionOrigin_XBox360_RightStick_DPadWest,
+	k_EControllerActionOrigin_XBox360_RightStick_DPadEast,
+	k_EControllerActionOrigin_XBox360_DPad_North,
+	k_EControllerActionOrigin_XBox360_DPad_South,
+	k_EControllerActionOrigin_XBox360_DPad_West,
+	k_EControllerActionOrigin_XBox360_DPad_East,	
+
+	// SteamController V2
+	k_EControllerActionOrigin_SteamV2_A,
+	k_EControllerActionOrigin_SteamV2_B,
+	k_EControllerActionOrigin_SteamV2_X,
+	k_EControllerActionOrigin_SteamV2_Y,
+	k_EControllerActionOrigin_SteamV2_LeftBumper,
+	k_EControllerActionOrigin_SteamV2_RightBumper,
+	k_EControllerActionOrigin_SteamV2_LeftGrip,
+	k_EControllerActionOrigin_SteamV2_RightGrip,
+	k_EControllerActionOrigin_SteamV2_Start,
+	k_EControllerActionOrigin_SteamV2_Back,
+	k_EControllerActionOrigin_SteamV2_LeftPad_Touch,
+	k_EControllerActionOrigin_SteamV2_LeftPad_Swipe,
+	k_EControllerActionOrigin_SteamV2_LeftPad_Click,
+	k_EControllerActionOrigin_SteamV2_LeftPad_DPadNorth,
+	k_EControllerActionOrigin_SteamV2_LeftPad_DPadSouth,
+	k_EControllerActionOrigin_SteamV2_LeftPad_DPadWest,
+	k_EControllerActionOrigin_SteamV2_LeftPad_DPadEast,
+	k_EControllerActionOrigin_SteamV2_RightPad_Touch,
+	k_EControllerActionOrigin_SteamV2_RightPad_Swipe,
+	k_EControllerActionOrigin_SteamV2_RightPad_Click,
+	k_EControllerActionOrigin_SteamV2_RightPad_DPadNorth,
+	k_EControllerActionOrigin_SteamV2_RightPad_DPadSouth,
+	k_EControllerActionOrigin_SteamV2_RightPad_DPadWest,
+	k_EControllerActionOrigin_SteamV2_RightPad_DPadEast,
+	k_EControllerActionOrigin_SteamV2_LeftTrigger_Pull,
+	k_EControllerActionOrigin_SteamV2_LeftTrigger_Click,
+	k_EControllerActionOrigin_SteamV2_RightTrigger_Pull,
+	k_EControllerActionOrigin_SteamV2_RightTrigger_Click,
+	k_EControllerActionOrigin_SteamV2_LeftStick_Move,
+	k_EControllerActionOrigin_SteamV2_LeftStick_Click,
+	k_EControllerActionOrigin_SteamV2_LeftStick_DPadNorth,
+	k_EControllerActionOrigin_SteamV2_LeftStick_DPadSouth,
+	k_EControllerActionOrigin_SteamV2_LeftStick_DPadWest,
+	k_EControllerActionOrigin_SteamV2_LeftStick_DPadEast,
+	k_EControllerActionOrigin_SteamV2_Gyro_Move,
+	k_EControllerActionOrigin_SteamV2_Gyro_Pitch,
+	k_EControllerActionOrigin_SteamV2_Gyro_Yaw,
+	k_EControllerActionOrigin_SteamV2_Gyro_Roll,
+
+	k_EControllerActionOrigin_Count
+};
+
+enum ESteamControllerLEDFlag
+{
+	k_ESteamControllerLEDFlag_SetColor,
+	k_ESteamControllerLEDFlag_RestoreUserDefault
+};
+
+// ControllerHandle_t is used to refer to a specific controller.
+// This handle will consistently identify a controller, even if it is disconnected and re-connected
+typedef uint64 ControllerHandle_t;
+
+
+// These handles are used to refer to a specific in-game action or action set
+// All action handles should be queried during initialization for performance reasons
+typedef uint64 ControllerActionSetHandle_t;
+typedef uint64 ControllerDigitalActionHandle_t;
+typedef uint64 ControllerAnalogActionHandle_t;
+
+#pragma pack( push, 1 )
+
+struct ControllerAnalogActionData_t
+{
+	// Type of data coming from this action, this will match what got specified in the action set
+	EControllerSourceMode eMode;
+	
+	// The current state of this action; will be delta updates for mouse actions
+	float x, y;
+	
+	// Whether or not this action is currently available to be bound in the active action set
+	bool bActive;
+};
+
+struct ControllerDigitalActionData_t
+{
+	// The current state of this action; will be true if currently pressed
+	bool bState;
+	
+	// Whether or not this action is currently available to be bound in the active action set
+	bool bActive;
+};
+
+struct ControllerMotionData_t
+{
+	// Sensor-fused absolute rotation; will drift in heading
+	float rotQuatX;
+	float rotQuatY;
+	float rotQuatZ;
+	float rotQuatW;
+	
+	// Positional acceleration
+	float posAccelX;
+	float posAccelY;
+	float posAccelZ;
+
+	// Angular velocity
+	float rotVelX;
+	float rotVelY;
+	float rotVelZ;
+};
+
+#pragma pack( pop )
+
+
+//-----------------------------------------------------------------------------
+// Purpose: Native Steam controller support API
+//-----------------------------------------------------------------------------
+class ISteamController
+{
+public:
+	
+	// Init and Shutdown must be called when starting/ending use of this interface
+	virtual bool Init() = 0;
+	virtual bool Shutdown() = 0;
+	
+	// Synchronize API state with the latest Steam Controller inputs available. This
+	// is performed automatically by SteamAPI_RunCallbacks, but for the absolute lowest
+	// possible latency, you call this directly before reading controller state.
+	virtual void RunFrame() = 0;
+
+	// Enumerate currently connected controllers
+	// handlesOut should point to a STEAM_CONTROLLER_MAX_COUNT sized array of ControllerHandle_t handles
+	// Returns the number of handles written to handlesOut
+	virtual int GetConnectedControllers( ControllerHandle_t *handlesOut ) = 0;
+	
+	// Invokes the Steam overlay and brings up the binding screen
+	// Returns false is overlay is disabled / unavailable, or the user is not in Big Picture mode
+	virtual bool ShowBindingPanel( ControllerHandle_t controllerHandle ) = 0;
+	
+	// ACTION SETS
+	// Lookup the handle for an Action Set. Best to do this once on startup, and store the handles for all future API calls.
+	virtual ControllerActionSetHandle_t GetActionSetHandle( const char *pszActionSetName ) = 0;
+	
+	// Reconfigure the controller to use the specified action set (ie 'Menu', 'Walk' or 'Drive')
+	// This is cheap, and can be safely called repeatedly. It's often easier to repeatedly call it in
+	// your state loops, instead of trying to place it in all of your state transitions.
+	virtual void ActivateActionSet( ControllerHandle_t controllerHandle, ControllerActionSetHandle_t actionSetHandle ) = 0;
+	virtual ControllerActionSetHandle_t GetCurrentActionSet( ControllerHandle_t controllerHandle ) = 0;
+	
+	// ACTIONS
+	// Lookup the handle for a digital action. Best to do this once on startup, and store the handles for all future API calls.
+	virtual ControllerDigitalActionHandle_t GetDigitalActionHandle( const char *pszActionName ) = 0;
+	
+	// Returns the current state of the supplied digital game action
+	virtual ControllerDigitalActionData_t GetDigitalActionData( ControllerHandle_t controllerHandle, ControllerDigitalActionHandle_t digitalActionHandle ) = 0;
+	
+	// Get the origin(s) for a digital action within an action set. Returns the number of origins supplied in originsOut. Use this to display the appropriate on-screen prompt for the action.
+	// originsOut should point to a STEAM_CONTROLLER_MAX_ORIGINS sized array of EControllerActionOrigin handles
+	virtual int GetDigitalActionOrigins( ControllerHandle_t controllerHandle, ControllerActionSetHandle_t actionSetHandle, ControllerDigitalActionHandle_t digitalActionHandle, EControllerActionOrigin *originsOut ) = 0;
+	
+	// Lookup the handle for an analog action. Best to do this once on startup, and store the handles for all future API calls.
+	virtual ControllerAnalogActionHandle_t GetAnalogActionHandle( const char *pszActionName ) = 0;
+	
+	// Returns the current state of these supplied analog game action
+	virtual ControllerAnalogActionData_t GetAnalogActionData( ControllerHandle_t controllerHandle, ControllerAnalogActionHandle_t analogActionHandle ) = 0;
+
+	// Get the origin(s) for an analog action within an action set. Returns the number of origins supplied in originsOut. Use this to display the appropriate on-screen prompt for the action.
+	// originsOut should point to a STEAM_CONTROLLER_MAX_ORIGINS sized array of EControllerActionOrigin handles
+	virtual int GetAnalogActionOrigins( ControllerHandle_t controllerHandle, ControllerActionSetHandle_t actionSetHandle, ControllerAnalogActionHandle_t analogActionHandle, EControllerActionOrigin *originsOut ) = 0;
+		
+	virtual void StopAnalogActionMomentum( ControllerHandle_t controllerHandle, ControllerAnalogActionHandle_t eAction ) = 0;
+	
+	// Trigger a haptic pulse on a controller
+	virtual void TriggerHapticPulse( ControllerHandle_t controllerHandle, ESteamControllerPad eTargetPad, unsigned short usDurationMicroSec ) = 0;
+
+	// Trigger a pulse with a duty cycle of usDurationMicroSec / usOffMicroSec, unRepeat times.
+	// nFlags is currently unused and reserved for future use.
+	virtual void TriggerRepeatedHapticPulse( ControllerHandle_t controllerHandle, ESteamControllerPad eTargetPad, unsigned short usDurationMicroSec, unsigned short usOffMicroSec, unsigned short unRepeat, unsigned int nFlags ) = 0;
+	
+	// Tigger a vibration event on supported controllers.  
+	virtual void TriggerVibration( ControllerHandle_t controllerHandle, unsigned short usLeftSpeed, unsigned short usRightSpeed ) = 0;
+
+	// Set the controller LED color on supported controllers.  
+	virtual void SetLEDColor( ControllerHandle_t controllerHandle, uint8 nColorR, uint8 nColorG, uint8 nColorB, unsigned int nFlags ) = 0;
+
+	// Returns the associated gamepad index for the specified controller, if emulating a gamepad
+	virtual int GetGamepadIndexForController( ControllerHandle_t ulControllerHandle ) = 0;
+	
+	// Returns the associated controller handle for the specified emulated gamepad
+	virtual ControllerHandle_t GetControllerForGamepadIndex( int nIndex ) = 0;
+	
+	// Returns raw motion data from the specified controller
+	virtual ControllerMotionData_t GetMotionData( ControllerHandle_t controllerHandle ) = 0;
+	
+	// Attempt to display origins of given action in the controller HUD, for the currently active action set
+	// Returns false is overlay is disabled / unavailable, or the user is not in Big Picture mode
+	virtual bool ShowDigitalActionOrigins( ControllerHandle_t controllerHandle, ControllerDigitalActionHandle_t digitalActionHandle, float flScale, float flXPosition, float flYPosition ) = 0;
+	virtual bool ShowAnalogActionOrigins( ControllerHandle_t controllerHandle, ControllerAnalogActionHandle_t analogActionHandle, float flScale, float flXPosition, float flYPosition ) = 0;
+
+	// Returns a localized string (from Steam's language setting) for the specified origin
+	virtual const char *GetStringForActionOrigin( EControllerActionOrigin eOrigin ) = 0;
+
+	// Get a local path to art for on-screen glyph for a particular origin 
+	virtual const char *GetGlyphForActionOrigin( EControllerActionOrigin eOrigin ) = 0;
+};
+
+#define STEAMCONTROLLER_INTERFACE_VERSION "SteamController005"
+
+#endif // ISTEAMCONTROLLER_H

--- a/Common/Chairloader/SteamAPI/isteamfriends.h
+++ b/Common/Chairloader/SteamAPI/isteamfriends.h
@@ -1,0 +1,636 @@
+//====== Copyright (C) 1996-2008, Valve Corporation, All rights reserved. =====
+//
+// Purpose: interface to both friends list data and general information about users
+//
+//=============================================================================
+
+#ifndef ISTEAMFRIENDS_H
+#define ISTEAMFRIENDS_H
+#ifdef _WIN32
+#pragma once
+#endif
+
+#include "isteamclient.h"
+#include "steamclientpublic.h"
+
+
+//-----------------------------------------------------------------------------
+// Purpose: set of relationships to other users
+//-----------------------------------------------------------------------------
+enum EFriendRelationship
+{
+	k_EFriendRelationshipNone = 0,
+	k_EFriendRelationshipBlocked = 1,			// this doesn't get stored; the user has just done an Ignore on an friendship invite
+	k_EFriendRelationshipRequestRecipient = 2,
+	k_EFriendRelationshipFriend = 3,
+	k_EFriendRelationshipRequestInitiator = 4,
+	k_EFriendRelationshipIgnored = 5,			// this is stored; the user has explicit blocked this other user from comments/chat/etc
+	k_EFriendRelationshipIgnoredFriend = 6,
+	k_EFriendRelationshipSuggested_DEPRECATED = 7,		// was used by the original implementation of the facebook linking feature, but now unused.
+
+	// keep this updated
+	k_EFriendRelationshipMax = 8,
+};
+
+// maximum length of friend group name (not including terminating nul!)
+const int k_cchMaxFriendsGroupName = 64;
+
+// maximum number of groups a single user is allowed
+const int k_cFriendsGroupLimit = 100;
+
+// friends group identifier type
+typedef int16 FriendsGroupID_t;
+
+// invalid friends group identifier constant
+const FriendsGroupID_t k_FriendsGroupID_Invalid = -1;
+
+const int k_cEnumerateFollowersMax = 50;
+
+
+//-----------------------------------------------------------------------------
+// Purpose: list of states a friend can be in
+//-----------------------------------------------------------------------------
+enum EPersonaState
+{
+	k_EPersonaStateOffline = 0,			// friend is not currently logged on
+	k_EPersonaStateOnline = 1,			// friend is logged on
+	k_EPersonaStateBusy = 2,			// user is on, but busy
+	k_EPersonaStateAway = 3,			// auto-away feature
+	k_EPersonaStateSnooze = 4,			// auto-away for a long time
+	k_EPersonaStateLookingToTrade = 5,	// Online, trading
+	k_EPersonaStateLookingToPlay = 6,	// Online, wanting to play
+	k_EPersonaStateMax,
+};
+
+
+//-----------------------------------------------------------------------------
+// Purpose: flags for enumerating friends list, or quickly checking a the relationship between users
+//-----------------------------------------------------------------------------
+enum EFriendFlags
+{
+	k_EFriendFlagNone			= 0x00,
+	k_EFriendFlagBlocked		= 0x01,
+	k_EFriendFlagFriendshipRequested	= 0x02,
+	k_EFriendFlagImmediate		= 0x04,			// "regular" friend
+	k_EFriendFlagClanMember		= 0x08,
+	k_EFriendFlagOnGameServer	= 0x10,	
+	// k_EFriendFlagHasPlayedWith	= 0x20,	// not currently used
+	// k_EFriendFlagFriendOfFriend	= 0x40, // not currently used
+	k_EFriendFlagRequestingFriendship = 0x80,
+	k_EFriendFlagRequestingInfo = 0x100,
+	k_EFriendFlagIgnored		= 0x200,
+	k_EFriendFlagIgnoredFriend	= 0x400,
+	// k_EFriendFlagSuggested		= 0x800,	// not used
+	k_EFriendFlagChatMember		= 0x1000,
+	k_EFriendFlagAll			= 0xFFFF,
+};
+
+
+// friend game played information
+#if defined( VALVE_CALLBACK_PACK_SMALL )
+#pragma pack( push, 4 )
+#elif defined( VALVE_CALLBACK_PACK_LARGE )
+#pragma pack( push, 8 )
+#else
+#error isteamclient.h must be included
+#endif 
+struct FriendGameInfo_t
+{
+	CGameID m_gameID;
+	uint32 m_unGameIP;
+	uint16 m_usGamePort;
+	uint16 m_usQueryPort;
+	CSteamID m_steamIDLobby;
+};
+#pragma pack( pop )
+
+// maximum number of characters in a user's name. Two flavors; one for UTF-8 and one for UTF-16.
+// The UTF-8 version has to be very generous to accomodate characters that get large when encoded
+// in UTF-8.
+enum
+{
+	k_cchPersonaNameMax = 128,
+	k_cwchPersonaNameMax = 32,
+};
+
+//-----------------------------------------------------------------------------
+// Purpose: user restriction flags
+//-----------------------------------------------------------------------------
+enum EUserRestriction
+{
+	k_nUserRestrictionNone		= 0,	// no known chat/content restriction
+	k_nUserRestrictionUnknown	= 1,	// we don't know yet (user offline)
+	k_nUserRestrictionAnyChat	= 2,	// user is not allowed to (or can't) send/recv any chat
+	k_nUserRestrictionVoiceChat	= 4,	// user is not allowed to (or can't) send/recv voice chat
+	k_nUserRestrictionGroupChat	= 8,	// user is not allowed to (or can't) send/recv group chat
+	k_nUserRestrictionRating	= 16,	// user is too young according to rating in current region
+	k_nUserRestrictionGameInvites	= 32,	// user cannot send or recv game invites (e.g. mobile)
+	k_nUserRestrictionTrading	= 64,	// user cannot participate in trading (console, mobile)
+};
+
+//-----------------------------------------------------------------------------
+// Purpose: information about user sessions
+//-----------------------------------------------------------------------------
+struct FriendSessionStateInfo_t
+{
+	uint32 m_uiOnlineSessionInstances;
+	uint8 m_uiPublishedToFriendsSessionInstance;
+};
+
+
+
+// size limit on chat room or member metadata
+const uint32 k_cubChatMetadataMax = 8192;
+
+// size limits on Rich Presence data
+enum { k_cchMaxRichPresenceKeys = 20 };
+enum { k_cchMaxRichPresenceKeyLength = 64 };
+enum { k_cchMaxRichPresenceValueLength = 256 };
+
+// These values are passed as parameters to the store
+enum EOverlayToStoreFlag
+{
+	k_EOverlayToStoreFlag_None = 0,
+	k_EOverlayToStoreFlag_AddToCart = 1,
+	k_EOverlayToStoreFlag_AddToCartAndShow = 2,
+};
+
+//-----------------------------------------------------------------------------
+// Purpose: interface to accessing information about individual users,
+//			that can be a friend, in a group, on a game server or in a lobby with the local user
+//-----------------------------------------------------------------------------
+class ISteamFriends
+{
+public:
+	// returns the local players name - guaranteed to not be NULL.
+	// this is the same name as on the users community profile page
+	// this is stored in UTF-8 format
+	// like all the other interface functions that return a char *, it's important that this pointer is not saved
+	// off; it will eventually be free'd or re-allocated
+	virtual const char *GetPersonaName() = 0;
+
+	// Sets the player name, stores it on the server and publishes the changes to all friends who are online.
+	// Changes take place locally immediately, and a PersonaStateChange_t is posted, presuming success.
+	//
+	// The final results are available through the return value SteamAPICall_t, using SetPersonaNameResponse_t.
+	//
+	// If the name change fails to happen on the server, then an additional global PersonaStateChange_t will be posted
+	// to change the name back, in addition to the SetPersonaNameResponse_t callback.
+	CALL_RESULT( SetPersonaNameResponse_t )
+	virtual SteamAPICall_t SetPersonaName( const char *pchPersonaName ) = 0;
+
+	// gets the status of the current user
+	virtual EPersonaState GetPersonaState() = 0;
+
+	// friend iteration
+	// takes a set of k_EFriendFlags, and returns the number of users the client knows about who meet that criteria
+	// then GetFriendByIndex() can then be used to return the id's of each of those users
+	virtual int GetFriendCount( int iFriendFlags ) = 0;
+
+	// returns the steamID of a user
+	// iFriend is a index of range [0, GetFriendCount())
+	// iFriendsFlags must be the same value as used in GetFriendCount()
+	// the returned CSteamID can then be used by all the functions below to access details about the user
+	virtual CSteamID GetFriendByIndex( int iFriend, int iFriendFlags ) = 0;
+
+	// returns a relationship to a user
+	virtual EFriendRelationship GetFriendRelationship( CSteamID steamIDFriend ) = 0;
+
+	// returns the current status of the specified user
+	// this will only be known by the local user if steamIDFriend is in their friends list; on the same game server; in a chat room or lobby; or in a small group with the local user
+	virtual EPersonaState GetFriendPersonaState( CSteamID steamIDFriend ) = 0;
+
+	// returns the name another user - guaranteed to not be NULL.
+	// same rules as GetFriendPersonaState() apply as to whether or not the user knowns the name of the other user
+	// note that on first joining a lobby, chat room or game server the local user will not known the name of the other users automatically; that information will arrive asyncronously
+	// 
+	virtual const char *GetFriendPersonaName( CSteamID steamIDFriend ) = 0;
+
+	// returns true if the friend is actually in a game, and fills in pFriendGameInfo with an extra details 
+	virtual bool GetFriendGamePlayed( CSteamID steamIDFriend, OUT_STRUCT() FriendGameInfo_t *pFriendGameInfo ) = 0;
+	// accesses old friends names - returns an empty string when their are no more items in the history
+	virtual const char *GetFriendPersonaNameHistory( CSteamID steamIDFriend, int iPersonaName ) = 0;
+	// friends steam level
+	virtual int GetFriendSteamLevel( CSteamID steamIDFriend ) = 0;
+
+	// Returns nickname the current user has set for the specified player. Returns NULL if the no nickname has been set for that player.
+	virtual const char *GetPlayerNickname( CSteamID steamIDPlayer ) = 0;
+
+	// friend grouping (tag) apis
+	// returns the number of friends groups
+	virtual int GetFriendsGroupCount() = 0;
+	// returns the friends group ID for the given index (invalid indices return k_FriendsGroupID_Invalid)
+	virtual FriendsGroupID_t GetFriendsGroupIDByIndex( int iFG ) = 0;
+	// returns the name for the given friends group (NULL in the case of invalid friends group IDs)
+	virtual const char *GetFriendsGroupName( FriendsGroupID_t friendsGroupID ) = 0;
+	// returns the number of members in a given friends group
+	virtual int GetFriendsGroupMembersCount( FriendsGroupID_t friendsGroupID ) = 0;
+	// gets up to nMembersCount members of the given friends group, if fewer exist than requested those positions' SteamIDs will be invalid
+	virtual void GetFriendsGroupMembersList( FriendsGroupID_t friendsGroupID, OUT_ARRAY_CALL(nMembersCount, GetFriendsGroupMembersCount, friendsGroupID ) CSteamID *pOutSteamIDMembers, int nMembersCount ) = 0;
+
+	// returns true if the specified user meets any of the criteria specified in iFriendFlags
+	// iFriendFlags can be the union (binary or, |) of one or more k_EFriendFlags values
+	virtual bool HasFriend( CSteamID steamIDFriend, int iFriendFlags ) = 0;
+
+	// clan (group) iteration and access functions
+	virtual int GetClanCount() = 0;
+	virtual CSteamID GetClanByIndex( int iClan ) = 0;
+	virtual const char *GetClanName( CSteamID steamIDClan ) = 0;
+	virtual const char *GetClanTag( CSteamID steamIDClan ) = 0;
+	// returns the most recent information we have about what's happening in a clan
+	virtual bool GetClanActivityCounts( CSteamID steamIDClan, int *pnOnline, int *pnInGame, int *pnChatting ) = 0;
+	// for clans a user is a member of, they will have reasonably up-to-date information, but for others you'll have to download the info to have the latest
+	virtual SteamAPICall_t DownloadClanActivityCounts( ARRAY_COUNT(cClansToRequest) CSteamID *psteamIDClans, int cClansToRequest ) = 0;
+
+	// iterators for getting users in a chat room, lobby, game server or clan
+	// note that large clans that cannot be iterated by the local user
+	// note that the current user must be in a lobby to retrieve CSteamIDs of other users in that lobby
+	// steamIDSource can be the steamID of a group, game server, lobby or chat room
+	virtual int GetFriendCountFromSource( CSteamID steamIDSource ) = 0;
+	virtual CSteamID GetFriendFromSourceByIndex( CSteamID steamIDSource, int iFriend ) = 0;
+
+	// returns true if the local user can see that steamIDUser is a member or in steamIDSource
+	virtual bool IsUserInSource( CSteamID steamIDUser, CSteamID steamIDSource ) = 0;
+
+	// User is in a game pressing the talk button (will suppress the microphone for all voice comms from the Steam friends UI)
+	virtual void SetInGameVoiceSpeaking( CSteamID steamIDUser, bool bSpeaking ) = 0;
+
+	// activates the game overlay, with an optional dialog to open 
+	// valid options are "Friends", "Community", "Players", "Settings", "OfficialGameGroup", "Stats", "Achievements"
+	virtual void ActivateGameOverlay( const char *pchDialog ) = 0;
+
+	// activates game overlay to a specific place
+	// valid options are
+	//		"steamid" - opens the overlay web browser to the specified user or groups profile
+	//		"chat" - opens a chat window to the specified user, or joins the group chat 
+	//		"jointrade" - opens a window to a Steam Trading session that was started with the ISteamEconomy/StartTrade Web API
+	//		"stats" - opens the overlay web browser to the specified user's stats
+	//		"achievements" - opens the overlay web browser to the specified user's achievements
+	//		"friendadd" - opens the overlay in minimal mode prompting the user to add the target user as a friend
+	//		"friendremove" - opens the overlay in minimal mode prompting the user to remove the target friend
+	//		"friendrequestaccept" - opens the overlay in minimal mode prompting the user to accept an incoming friend invite
+	//		"friendrequestignore" - opens the overlay in minimal mode prompting the user to ignore an incoming friend invite
+	virtual void ActivateGameOverlayToUser( const char *pchDialog, CSteamID steamID ) = 0;
+
+	// activates game overlay web browser directly to the specified URL
+	// full address with protocol type is required, e.g. http://www.steamgames.com/
+	virtual void ActivateGameOverlayToWebPage( const char *pchURL ) = 0;
+
+	// activates game overlay to store page for app
+	virtual void ActivateGameOverlayToStore( AppId_t nAppID, EOverlayToStoreFlag eFlag ) = 0;
+
+	// Mark a target user as 'played with'. This is a client-side only feature that requires that the calling user is 
+	// in game 
+	virtual void SetPlayedWith( CSteamID steamIDUserPlayedWith ) = 0;
+
+	// activates game overlay to open the invite dialog. Invitations will be sent for the provided lobby.
+	virtual void ActivateGameOverlayInviteDialog( CSteamID steamIDLobby ) = 0;
+
+	// gets the small (32x32) avatar of the current user, which is a handle to be used in IClientUtils::GetImageRGBA(), or 0 if none set
+	virtual int GetSmallFriendAvatar( CSteamID steamIDFriend ) = 0;
+
+	// gets the medium (64x64) avatar of the current user, which is a handle to be used in IClientUtils::GetImageRGBA(), or 0 if none set
+	virtual int GetMediumFriendAvatar( CSteamID steamIDFriend ) = 0;
+
+	// gets the large (184x184) avatar of the current user, which is a handle to be used in IClientUtils::GetImageRGBA(), or 0 if none set
+	// returns -1 if this image has yet to be loaded, in this case wait for a AvatarImageLoaded_t callback and then call this again
+	virtual int GetLargeFriendAvatar( CSteamID steamIDFriend ) = 0;
+
+	// requests information about a user - persona name & avatar
+	// if bRequireNameOnly is set, then the avatar of a user isn't downloaded 
+	// - it's a lot slower to download avatars and churns the local cache, so if you don't need avatars, don't request them
+	// if returns true, it means that data is being requested, and a PersonaStateChanged_t callback will be posted when it's retrieved
+	// if returns false, it means that we already have all the details about that user, and functions can be called immediately
+	virtual bool RequestUserInformation( CSteamID steamIDUser, bool bRequireNameOnly ) = 0;
+
+	// requests information about a clan officer list
+	// when complete, data is returned in ClanOfficerListResponse_t call result
+	// this makes available the calls below
+	// you can only ask about clans that a user is a member of
+	// note that this won't download avatars automatically; if you get an officer,
+	// and no avatar image is available, call RequestUserInformation( steamID, false ) to download the avatar
+	CALL_RESULT( ClanOfficerListResponse_t )
+	virtual SteamAPICall_t RequestClanOfficerList( CSteamID steamIDClan ) = 0;
+
+	// iteration of clan officers - can only be done when a RequestClanOfficerList() call has completed
+	
+	// returns the steamID of the clan owner
+	virtual CSteamID GetClanOwner( CSteamID steamIDClan ) = 0;
+	// returns the number of officers in a clan (including the owner)
+	virtual int GetClanOfficerCount( CSteamID steamIDClan ) = 0;
+	// returns the steamID of a clan officer, by index, of range [0,GetClanOfficerCount)
+	virtual CSteamID GetClanOfficerByIndex( CSteamID steamIDClan, int iOfficer ) = 0;
+	// if current user is chat restricted, he can't send or receive any text/voice chat messages.
+	// the user can't see custom avatars. But the user can be online and send/recv game invites.
+	// a chat restricted user can't add friends or join any groups.
+	virtual uint32 GetUserRestrictions() = 0;
+
+	// Rich Presence data is automatically shared between friends who are in the same game
+	// Each user has a set of Key/Value pairs
+	// Note the following limits: k_cchMaxRichPresenceKeys, k_cchMaxRichPresenceKeyLength, k_cchMaxRichPresenceValueLength
+	// There are two magic keys:
+	//		"status"  - a UTF-8 string that will show up in the 'view game info' dialog in the Steam friends list
+	//		"connect" - a UTF-8 string that contains the command-line for how a friend can connect to a game
+	// GetFriendRichPresence() returns an empty string "" if no value is set
+	// SetRichPresence() to a NULL or an empty string deletes the key
+	// You can iterate the current set of keys for a friend with GetFriendRichPresenceKeyCount()
+	// and GetFriendRichPresenceKeyByIndex() (typically only used for debugging)
+	virtual bool SetRichPresence( const char *pchKey, const char *pchValue ) = 0;
+	virtual void ClearRichPresence() = 0;
+	virtual const char *GetFriendRichPresence( CSteamID steamIDFriend, const char *pchKey ) = 0;
+	virtual int GetFriendRichPresenceKeyCount( CSteamID steamIDFriend ) = 0;
+	virtual const char *GetFriendRichPresenceKeyByIndex( CSteamID steamIDFriend, int iKey ) = 0;
+	// Requests rich presence for a specific user.
+	virtual void RequestFriendRichPresence( CSteamID steamIDFriend ) = 0;
+
+	// rich invite support
+	// if the target accepts the invite, the pchConnectString gets added to the command-line for launching the game
+	// if the game is already running, a GameRichPresenceJoinRequested_t callback is posted containing the connect string
+	// invites can only be sent to friends
+	virtual bool InviteUserToGame( CSteamID steamIDFriend, const char *pchConnectString ) = 0;
+
+	// recently-played-with friends iteration
+	// this iterates the entire list of users recently played with, across games
+	// GetFriendCoplayTime() returns as a unix time
+	virtual int GetCoplayFriendCount() = 0;
+	virtual CSteamID GetCoplayFriend( int iCoplayFriend ) = 0;
+	virtual int GetFriendCoplayTime( CSteamID steamIDFriend ) = 0;
+	virtual AppId_t GetFriendCoplayGame( CSteamID steamIDFriend ) = 0;
+
+	// chat interface for games
+	// this allows in-game access to group (clan) chats from in the game
+	// the behavior is somewhat sophisticated, because the user may or may not be already in the group chat from outside the game or in the overlay
+	// use ActivateGameOverlayToUser( "chat", steamIDClan ) to open the in-game overlay version of the chat
+	CALL_RESULT( JoinClanChatRoomCompletionResult_t )
+	virtual SteamAPICall_t JoinClanChatRoom( CSteamID steamIDClan ) = 0;
+	virtual bool LeaveClanChatRoom( CSteamID steamIDClan ) = 0;
+	virtual int GetClanChatMemberCount( CSteamID steamIDClan ) = 0;
+	virtual CSteamID GetChatMemberByIndex( CSteamID steamIDClan, int iUser ) = 0;
+	virtual bool SendClanChatMessage( CSteamID steamIDClanChat, const char *pchText ) = 0;
+	virtual int GetClanChatMessage( CSteamID steamIDClanChat, int iMessage, void *prgchText, int cchTextMax, EChatEntryType *peChatEntryType, OUT_STRUCT() CSteamID *psteamidChatter ) = 0;
+	virtual bool IsClanChatAdmin( CSteamID steamIDClanChat, CSteamID steamIDUser ) = 0;
+
+	// interact with the Steam (game overlay / desktop)
+	virtual bool IsClanChatWindowOpenInSteam( CSteamID steamIDClanChat ) = 0;
+	virtual bool OpenClanChatWindowInSteam( CSteamID steamIDClanChat ) = 0;
+	virtual bool CloseClanChatWindowInSteam( CSteamID steamIDClanChat ) = 0;
+
+	// peer-to-peer chat interception
+	// this is so you can show P2P chats inline in the game
+	virtual bool SetListenForFriendsMessages( bool bInterceptEnabled ) = 0;
+	virtual bool ReplyToFriendMessage( CSteamID steamIDFriend, const char *pchMsgToSend ) = 0;
+	virtual int GetFriendMessage( CSteamID steamIDFriend, int iMessageID, void *pvData, int cubData, EChatEntryType *peChatEntryType ) = 0;
+
+	// following apis
+	CALL_RESULT( FriendsGetFollowerCount_t )
+	virtual SteamAPICall_t GetFollowerCount( CSteamID steamID ) = 0;
+	CALL_RESULT( FriendsIsFollowing_t )
+	virtual SteamAPICall_t IsFollowing( CSteamID steamID ) = 0;
+	CALL_RESULT( FriendsEnumerateFollowingList_t )
+	virtual SteamAPICall_t EnumerateFollowingList( uint32 unStartIndex ) = 0;
+};
+
+#define STEAMFRIENDS_INTERFACE_VERSION "SteamFriends015"
+
+// callbacks
+#if defined( VALVE_CALLBACK_PACK_SMALL )
+#pragma pack( push, 4 )
+#elif defined( VALVE_CALLBACK_PACK_LARGE )
+#pragma pack( push, 8 )
+#else
+#error isteamclient.h must be included
+#endif 
+
+//-----------------------------------------------------------------------------
+// Purpose: called when a friends' status changes
+//-----------------------------------------------------------------------------
+struct PersonaStateChange_t
+{
+	enum { k_iCallback = k_iSteamFriendsCallbacks + 4 };
+	
+	uint64 m_ulSteamID;		// steamID of the friend who changed
+	int m_nChangeFlags;		// what's changed
+};
+
+
+// used in PersonaStateChange_t::m_nChangeFlags to describe what's changed about a user
+// these flags describe what the client has learned has changed recently, so on startup you'll see a name, avatar & relationship change for every friend
+enum EPersonaChange
+{
+	k_EPersonaChangeName		= 0x0001,
+	k_EPersonaChangeStatus		= 0x0002,
+	k_EPersonaChangeComeOnline	= 0x0004,
+	k_EPersonaChangeGoneOffline	= 0x0008,
+	k_EPersonaChangeGamePlayed	= 0x0010,
+	k_EPersonaChangeGameServer	= 0x0020,
+	k_EPersonaChangeAvatar		= 0x0040,
+	k_EPersonaChangeJoinedSource= 0x0080,
+	k_EPersonaChangeLeftSource	= 0x0100,
+	k_EPersonaChangeRelationshipChanged = 0x0200,
+	k_EPersonaChangeNameFirstSet = 0x0400,
+	k_EPersonaChangeFacebookInfo = 0x0800,
+	k_EPersonaChangeNickname =	0x1000,
+	k_EPersonaChangeSteamLevel = 0x2000,
+};
+
+
+//-----------------------------------------------------------------------------
+// Purpose: posted when game overlay activates or deactivates
+//			the game can use this to be pause or resume single player games
+//-----------------------------------------------------------------------------
+struct GameOverlayActivated_t
+{
+	enum { k_iCallback = k_iSteamFriendsCallbacks + 31 };
+	uint8 m_bActive;	// true if it's just been activated, false otherwise
+};
+
+
+//-----------------------------------------------------------------------------
+// Purpose: called when the user tries to join a different game server from their friends list
+//			game client should attempt to connect to specified server when this is received
+//-----------------------------------------------------------------------------
+struct GameServerChangeRequested_t
+{
+	enum { k_iCallback = k_iSteamFriendsCallbacks + 32 };
+	char m_rgchServer[64];		// server address ("127.0.0.1:27015", "tf2.valvesoftware.com")
+	char m_rgchPassword[64];	// server password, if any
+};
+
+
+//-----------------------------------------------------------------------------
+// Purpose: called when the user tries to join a lobby from their friends list
+//			game client should attempt to connect to specified lobby when this is received
+//-----------------------------------------------------------------------------
+struct GameLobbyJoinRequested_t
+{
+	enum { k_iCallback = k_iSteamFriendsCallbacks + 33 };
+	CSteamID m_steamIDLobby;
+
+	// The friend they did the join via (will be invalid if not directly via a friend)
+	//
+	// On PS3, the friend will be invalid if this was triggered by a PSN invite via the XMB, but
+	// the account type will be console user so you can tell at least that this was from a PSN friend
+	// rather than a Steam friend.
+	CSteamID m_steamIDFriend;		
+};
+
+
+//-----------------------------------------------------------------------------
+// Purpose: called when an avatar is loaded in from a previous GetLargeFriendAvatar() call
+//			if the image wasn't already available
+//-----------------------------------------------------------------------------
+struct AvatarImageLoaded_t
+{
+	enum { k_iCallback = k_iSteamFriendsCallbacks + 34 };
+	CSteamID m_steamID; // steamid the avatar has been loaded for
+	int m_iImage; // the image index of the now loaded image
+	int m_iWide; // width of the loaded image
+	int m_iTall; // height of the loaded image
+};
+
+
+//-----------------------------------------------------------------------------
+// Purpose: marks the return of a request officer list call
+//-----------------------------------------------------------------------------
+struct ClanOfficerListResponse_t
+{
+	enum { k_iCallback = k_iSteamFriendsCallbacks + 35 };
+	CSteamID m_steamIDClan;
+	int m_cOfficers;
+	uint8 m_bSuccess;
+};
+
+
+//-----------------------------------------------------------------------------
+// Purpose: callback indicating updated data about friends rich presence information
+//-----------------------------------------------------------------------------
+struct FriendRichPresenceUpdate_t
+{
+	enum { k_iCallback = k_iSteamFriendsCallbacks + 36 };
+	CSteamID m_steamIDFriend;	// friend who's rich presence has changed
+	AppId_t m_nAppID;			// the appID of the game (should always be the current game)
+};
+
+
+//-----------------------------------------------------------------------------
+// Purpose: called when the user tries to join a game from their friends list
+//			rich presence will have been set with the "connect" key which is set here
+//-----------------------------------------------------------------------------
+struct GameRichPresenceJoinRequested_t
+{
+	enum { k_iCallback = k_iSteamFriendsCallbacks + 37 };
+	CSteamID m_steamIDFriend;		// the friend they did the join via (will be invalid if not directly via a friend)
+	char m_rgchConnect[k_cchMaxRichPresenceValueLength];
+};
+
+
+//-----------------------------------------------------------------------------
+// Purpose: a chat message has been received for a clan chat the game has joined
+//-----------------------------------------------------------------------------
+struct GameConnectedClanChatMsg_t
+{
+	enum { k_iCallback = k_iSteamFriendsCallbacks + 38 };
+	CSteamID m_steamIDClanChat;
+	CSteamID m_steamIDUser;
+	int m_iMessageID;
+};
+
+
+//-----------------------------------------------------------------------------
+// Purpose: a user has joined a clan chat
+//-----------------------------------------------------------------------------
+struct GameConnectedChatJoin_t
+{
+	enum { k_iCallback = k_iSteamFriendsCallbacks + 39 };
+	CSteamID m_steamIDClanChat;
+	CSteamID m_steamIDUser;
+};
+
+
+//-----------------------------------------------------------------------------
+// Purpose: a user has left the chat we're in
+//-----------------------------------------------------------------------------
+struct GameConnectedChatLeave_t
+{
+	enum { k_iCallback = k_iSteamFriendsCallbacks + 40 };
+	CSteamID m_steamIDClanChat;
+	CSteamID m_steamIDUser;
+	bool m_bKicked;		// true if admin kicked
+	bool m_bDropped;	// true if Steam connection dropped
+};
+
+
+//-----------------------------------------------------------------------------
+// Purpose: a DownloadClanActivityCounts() call has finished
+//-----------------------------------------------------------------------------
+struct DownloadClanActivityCountsResult_t
+{
+	enum { k_iCallback = k_iSteamFriendsCallbacks + 41 };
+	bool m_bSuccess;
+};
+
+
+//-----------------------------------------------------------------------------
+// Purpose: a JoinClanChatRoom() call has finished
+//-----------------------------------------------------------------------------
+struct JoinClanChatRoomCompletionResult_t
+{
+	enum { k_iCallback = k_iSteamFriendsCallbacks + 42 };
+	CSteamID m_steamIDClanChat;
+	EChatRoomEnterResponse m_eChatRoomEnterResponse;
+};
+
+//-----------------------------------------------------------------------------
+// Purpose: a chat message has been received from a user
+//-----------------------------------------------------------------------------
+struct GameConnectedFriendChatMsg_t
+{
+	enum { k_iCallback = k_iSteamFriendsCallbacks + 43 };
+	CSteamID m_steamIDUser;
+	int m_iMessageID;
+};
+
+
+struct FriendsGetFollowerCount_t
+{
+	enum { k_iCallback = k_iSteamFriendsCallbacks + 44 };
+	EResult m_eResult;
+	CSteamID m_steamID;
+	int m_nCount;
+};
+
+
+struct FriendsIsFollowing_t
+{
+	enum { k_iCallback = k_iSteamFriendsCallbacks + 45 };
+	EResult m_eResult;
+	CSteamID m_steamID;
+	bool m_bIsFollowing;
+};
+
+
+struct FriendsEnumerateFollowingList_t
+{
+	enum { k_iCallback = k_iSteamFriendsCallbacks + 46 };
+	EResult m_eResult;
+	CSteamID m_rgSteamID[ k_cEnumerateFollowersMax ];
+	int32 m_nResultsReturned;
+	int32 m_nTotalResultCount;
+};
+
+//-----------------------------------------------------------------------------
+// Purpose: reports the result of an attempt to change the user's persona name
+//-----------------------------------------------------------------------------
+struct SetPersonaNameResponse_t
+{
+	enum { k_iCallback = k_iSteamFriendsCallbacks + 47 };
+
+	bool m_bSuccess; // true if name change succeeded completely.
+	bool m_bLocalSuccess; // true if name change was retained locally.  (We might not have been able to communicate with Steam)
+	EResult m_result; // detailed result code
+};
+
+
+#pragma pack( pop )
+
+#endif // ISTEAMFRIENDS_H

--- a/Common/Chairloader/SteamAPI/isteamgamecoordinator.h
+++ b/Common/Chairloader/SteamAPI/isteamgamecoordinator.h
@@ -1,0 +1,76 @@
+//====== Copyright ©, Valve Corporation, All rights reserved. =======
+//
+// Purpose: interface to the game coordinator for this application
+//
+//=============================================================================
+
+#ifndef ISTEAMGAMECOORDINATOR
+#define ISTEAMGAMECOORDINATOR
+#ifdef _WIN32
+#pragma once
+#endif
+
+#include "isteamclient.h"
+#include "steamtypes.h"
+#include "steamclientpublic.h"
+
+
+// list of possible return values from the ISteamGameCoordinator API
+enum EGCResults
+{
+	k_EGCResultOK = 0,
+	k_EGCResultNoMessage = 1,			// There is no message in the queue
+	k_EGCResultBufferTooSmall = 2,		// The buffer is too small for the requested message
+	k_EGCResultNotLoggedOn = 3,			// The client is not logged onto Steam
+	k_EGCResultInvalidMessage = 4,		// Something was wrong with the message being sent with SendMessage
+};
+
+
+//-----------------------------------------------------------------------------
+// Purpose: Functions for sending and receiving messages from the Game Coordinator
+//			for this application
+//-----------------------------------------------------------------------------
+class ISteamGameCoordinator
+{
+public:
+
+	// sends a message to the Game Coordinator
+	virtual EGCResults SendMessage( uint32 unMsgType, const void *pubData, uint32 cubData ) = 0;
+
+	// returns true if there is a message waiting from the game coordinator
+	virtual bool IsMessageAvailable( uint32 *pcubMsgSize ) = 0; 
+
+	// fills the provided buffer with the first message in the queue and returns k_EGCResultOK or 
+	// returns k_EGCResultNoMessage if there is no message waiting. pcubMsgSize is filled with the message size.
+	// If the provided buffer is not large enough to fit the entire message, k_EGCResultBufferTooSmall is returned
+	// and the message remains at the head of the queue.
+	virtual EGCResults RetrieveMessage( uint32 *punMsgType, void *pubDest, uint32 cubDest, uint32 *pcubMsgSize ) = 0; 
+
+};
+#define STEAMGAMECOORDINATOR_INTERFACE_VERSION "SteamGameCoordinator001"
+
+// callbacks
+#if defined( VALVE_CALLBACK_PACK_SMALL )
+#pragma pack( push, 4 )
+#elif defined( VALVE_CALLBACK_PACK_LARGE )
+#pragma pack( push, 8 )
+#else
+#error isteamclient.h must be included
+#endif 
+
+// callback notification - A new message is available for reading from the message queue
+struct GCMessageAvailable_t
+{
+	enum { k_iCallback = k_iSteamGameCoordinatorCallbacks + 1 };
+	uint32 m_nMessageSize;
+};
+
+// callback notification - A message failed to make it to the GC. It may be down temporarily
+struct GCMessageFailed_t
+{
+	enum { k_iCallback = k_iSteamGameCoordinatorCallbacks + 2 };
+};
+
+#pragma pack( pop )
+
+#endif // ISTEAMGAMECOORDINATOR

--- a/Common/Chairloader/SteamAPI/isteamgameserver.h
+++ b/Common/Chairloader/SteamAPI/isteamgameserver.h
@@ -1,0 +1,387 @@
+//====== Copyright (c) 1996-2008, Valve Corporation, All rights reserved. =======
+//
+// Purpose: interface to steam for game servers
+//
+//=============================================================================
+
+#ifndef ISTEAMGAMESERVER_H
+#define ISTEAMGAMESERVER_H
+#ifdef _WIN32
+#pragma once
+#endif
+
+#include "isteamclient.h"
+
+#define MASTERSERVERUPDATERPORT_USEGAMESOCKETSHARE	((uint16)-1)
+
+//-----------------------------------------------------------------------------
+// Purpose: Functions for authenticating users via Steam to play on a game server
+//-----------------------------------------------------------------------------
+class ISteamGameServer
+{
+public:
+
+//
+// Basic server data.  These properties, if set, must be set before before calling LogOn.  They
+// may not be changed after logged in.
+//
+
+	/// This is called by SteamGameServer_Init, and you will usually not need to call it directly
+	virtual bool InitGameServer( uint32 unIP, uint16 usGamePort, uint16 usQueryPort, uint32 unFlags, AppId_t nGameAppId, const char *pchVersionString ) = 0;
+
+	/// Game product identifier.  This is currently used by the master server for version checking purposes.
+	/// It's a required field, but will eventually will go away, and the AppID will be used for this purpose.
+	virtual void SetProduct( const char *pszProduct ) = 0;
+
+	/// Description of the game.  This is a required field and is displayed in the steam server browser....for now.
+	/// This is a required field, but it will go away eventually, as the data should be determined from the AppID.
+	virtual void SetGameDescription( const char *pszGameDescription ) = 0;
+
+	/// If your game is a "mod," pass the string that identifies it.  The default is an empty string, meaning
+	/// this application is the original game, not a mod.
+	///
+	/// @see k_cbMaxGameServerGameDir
+	virtual void SetModDir( const char *pszModDir ) = 0;
+
+	/// Is this is a dedicated server?  The default value is false.
+	virtual void SetDedicatedServer( bool bDedicated ) = 0;
+
+//
+// Login
+//
+
+	/// Begin process to login to a persistent game server account
+	///
+	/// You need to register for callbacks to determine the result of this operation.
+	/// @see SteamServersConnected_t
+	/// @see SteamServerConnectFailure_t
+	/// @see SteamServersDisconnected_t
+	virtual void LogOn( const char *pszToken ) = 0;
+
+	/// Login to a generic, anonymous account.
+	///
+	/// Note: in previous versions of the SDK, this was automatically called within SteamGameServer_Init,
+	/// but this is no longer the case.
+	virtual void LogOnAnonymous() = 0;
+
+	/// Begin process of logging game server out of steam
+	virtual void LogOff() = 0;
+	
+	// status functions
+	virtual bool BLoggedOn() = 0;
+	virtual bool BSecure() = 0; 
+	virtual CSteamID GetSteamID() = 0;
+
+	/// Returns true if the master server has requested a restart.
+	/// Only returns true once per request.
+	virtual bool WasRestartRequested() = 0;
+
+//
+// Server state.  These properties may be changed at any time.
+//
+
+	/// Max player count that will be reported to server browser and client queries
+	virtual void SetMaxPlayerCount( int cPlayersMax ) = 0;
+
+	/// Number of bots.  Default value is zero
+	virtual void SetBotPlayerCount( int cBotplayers ) = 0;
+
+	/// Set the name of server as it will appear in the server browser
+	///
+	/// @see k_cbMaxGameServerName
+	virtual void SetServerName( const char *pszServerName ) = 0;
+
+	/// Set name of map to report in the server browser
+	///
+	/// @see k_cbMaxGameServerName
+	virtual void SetMapName( const char *pszMapName ) = 0;
+
+	/// Let people know if your server will require a password
+	virtual void SetPasswordProtected( bool bPasswordProtected ) = 0;
+
+	/// Spectator server.  The default value is zero, meaning the service
+	/// is not used.
+	virtual void SetSpectatorPort( uint16 unSpectatorPort ) = 0;
+
+	/// Name of the spectator server.  (Only used if spectator port is nonzero.)
+	///
+	/// @see k_cbMaxGameServerMapName
+	virtual void SetSpectatorServerName( const char *pszSpectatorServerName ) = 0;
+
+	/// Call this to clear the whole list of key/values that are sent in rules queries.
+	virtual void ClearAllKeyValues() = 0;
+	
+	/// Call this to add/update a key/value pair.
+	virtual void SetKeyValue( const char *pKey, const char *pValue ) = 0;
+
+	/// Sets a string defining the "gametags" for this server, this is optional, but if it is set
+	/// it allows users to filter in the matchmaking/server-browser interfaces based on the value
+	///
+	/// @see k_cbMaxGameServerTags
+	virtual void SetGameTags( const char *pchGameTags ) = 0;
+
+	/// Sets a string defining the "gamedata" for this server, this is optional, but if it is set
+	/// it allows users to filter in the matchmaking/server-browser interfaces based on the value
+	/// don't set this unless it actually changes, its only uploaded to the master once (when
+	/// acknowledged)
+	///
+	/// @see k_cbMaxGameServerGameData
+	virtual void SetGameData( const char *pchGameData ) = 0;
+
+	/// Region identifier.  This is an optional field, the default value is empty, meaning the "world" region
+	virtual void SetRegion( const char *pszRegion ) = 0;
+
+//
+// Player list management / authentication
+//
+
+	// Handles receiving a new connection from a Steam user.  This call will ask the Steam
+	// servers to validate the users identity, app ownership, and VAC status.  If the Steam servers 
+	// are off-line, then it will validate the cached ticket itself which will validate app ownership 
+	// and identity.  The AuthBlob here should be acquired on the game client using SteamUser()->InitiateGameConnection()
+	// and must then be sent up to the game server for authentication.
+	//
+	// Return Value: returns true if the users ticket passes basic checks. pSteamIDUser will contain the Steam ID of this user. pSteamIDUser must NOT be NULL
+	// If the call succeeds then you should expect a GSClientApprove_t or GSClientDeny_t callback which will tell you whether authentication
+	// for the user has succeeded or failed (the steamid in the callback will match the one returned by this call)
+	virtual bool SendUserConnectAndAuthenticate( uint32 unIPClient, const void *pvAuthBlob, uint32 cubAuthBlobSize, CSteamID *pSteamIDUser ) = 0;
+
+	// Creates a fake user (ie, a bot) which will be listed as playing on the server, but skips validation.  
+	// 
+	// Return Value: Returns a SteamID for the user to be tracked with, you should call HandleUserDisconnect()
+	// when this user leaves the server just like you would for a real user.
+	virtual CSteamID CreateUnauthenticatedUserConnection() = 0;
+
+	// Should be called whenever a user leaves our game server, this lets Steam internally
+	// track which users are currently on which servers for the purposes of preventing a single
+	// account being logged into multiple servers, showing who is currently on a server, etc.
+	virtual void SendUserDisconnect( CSteamID steamIDUser ) = 0;
+
+	// Update the data to be displayed in the server browser and matchmaking interfaces for a user
+	// currently connected to the server.  For regular users you must call this after you receive a
+	// GSUserValidationSuccess callback.
+	// 
+	// Return Value: true if successful, false if failure (ie, steamIDUser wasn't for an active player)
+	virtual bool BUpdateUserData( CSteamID steamIDUser, const char *pchPlayerName, uint32 uScore ) = 0;
+
+	// New auth system APIs - do not mix with the old auth system APIs.
+	// ----------------------------------------------------------------
+
+	// Retrieve ticket to be sent to the entity who wishes to authenticate you ( using BeginAuthSession API ). 
+	// pcbTicket retrieves the length of the actual ticket.
+	virtual HAuthTicket GetAuthSessionTicket( void *pTicket, int cbMaxTicket, uint32 *pcbTicket ) = 0;
+
+	// Authenticate ticket ( from GetAuthSessionTicket ) from entity steamID to be sure it is valid and isnt reused
+	// Registers for callbacks if the entity goes offline or cancels the ticket ( see ValidateAuthTicketResponse_t callback and EAuthSessionResponse )
+	virtual EBeginAuthSessionResult BeginAuthSession( const void *pAuthTicket, int cbAuthTicket, CSteamID steamID ) = 0;
+
+	// Stop tracking started by BeginAuthSession - called when no longer playing game with this entity
+	virtual void EndAuthSession( CSteamID steamID ) = 0;
+
+	// Cancel auth ticket from GetAuthSessionTicket, called when no longer playing game with the entity you gave the ticket to
+	virtual void CancelAuthTicket( HAuthTicket hAuthTicket ) = 0;
+
+	// After receiving a user's authentication data, and passing it to SendUserConnectAndAuthenticate, use this function
+	// to determine if the user owns downloadable content specified by the provided AppID.
+	virtual EUserHasLicenseForAppResult UserHasLicenseForApp( CSteamID steamID, AppId_t appID ) = 0;
+
+	// Ask if a user in in the specified group, results returns async by GSUserGroupStatus_t
+	// returns false if we're not connected to the steam servers and thus cannot ask
+	virtual bool RequestUserGroupStatus( CSteamID steamIDUser, CSteamID steamIDGroup ) = 0;
+
+
+	// these two functions s are deprecated, and will not return results
+	// they will be removed in a future version of the SDK
+	virtual void GetGameplayStats( ) = 0;
+	CALL_RESULT( GSReputation_t )
+	virtual SteamAPICall_t GetServerReputation() = 0;
+
+	// Returns the public IP of the server according to Steam, useful when the server is 
+	// behind NAT and you want to advertise its IP in a lobby for other clients to directly
+	// connect to
+	virtual uint32 GetPublicIP() = 0;
+
+// These are in GameSocketShare mode, where instead of ISteamGameServer creating its own
+// socket to talk to the master server on, it lets the game use its socket to forward messages
+// back and forth. This prevents us from requiring server ops to open up yet another port
+// in their firewalls.
+//
+// the IP address and port should be in host order, i.e 127.0.0.1 == 0x7f000001
+	
+	// These are used when you've elected to multiplex the game server's UDP socket
+	// rather than having the master server updater use its own sockets.
+	// 
+	// Source games use this to simplify the job of the server admins, so they 
+	// don't have to open up more ports on their firewalls.
+	
+	// Call this when a packet that starts with 0xFFFFFFFF comes in. That means
+	// it's for us.
+	virtual bool HandleIncomingPacket( const void *pData, int cbData, uint32 srcIP, uint16 srcPort ) = 0;
+
+	// AFTER calling HandleIncomingPacket for any packets that came in that frame, call this.
+	// This gets a packet that the master server updater needs to send out on UDP.
+	// It returns the length of the packet it wants to send, or 0 if there are no more packets to send.
+	// Call this each frame until it returns 0.
+	virtual int GetNextOutgoingPacket( void *pOut, int cbMaxOut, uint32 *pNetAdr, uint16 *pPort ) = 0;
+
+//
+// Control heartbeats / advertisement with master server
+//
+
+	// Call this as often as you like to tell the master server updater whether or not
+	// you want it to be active (default: off).
+	virtual void EnableHeartbeats( bool bActive ) = 0;
+
+	// You usually don't need to modify this.
+	// Pass -1 to use the default value for iHeartbeatInterval.
+	// Some mods change this.
+	virtual void SetHeartbeatInterval( int iHeartbeatInterval ) = 0;
+
+	// Force a heartbeat to steam at the next opportunity
+	virtual void ForceHeartbeat() = 0;
+
+	// associate this game server with this clan for the purposes of computing player compat
+	CALL_RESULT( AssociateWithClanResult_t )
+	virtual SteamAPICall_t AssociateWithClan( CSteamID steamIDClan ) = 0;
+	
+	// ask if any of the current players dont want to play with this new player - or vice versa
+	CALL_RESULT( ComputeNewPlayerCompatibilityResult_t )
+	virtual SteamAPICall_t ComputeNewPlayerCompatibility( CSteamID steamIDNewPlayer ) = 0;
+
+};
+
+#define STEAMGAMESERVER_INTERFACE_VERSION "SteamGameServer012"
+
+// game server flags
+const uint32 k_unServerFlagNone			= 0x00;
+const uint32 k_unServerFlagActive		= 0x01;		// server has users playing
+const uint32 k_unServerFlagSecure		= 0x02;		// server wants to be secure
+const uint32 k_unServerFlagDedicated	= 0x04;		// server is dedicated
+const uint32 k_unServerFlagLinux		= 0x08;		// linux build
+const uint32 k_unServerFlagPassworded	= 0x10;		// password protected
+const uint32 k_unServerFlagPrivate		= 0x20;		// server shouldn't list on master server and
+													// won't enforce authentication of users that connect to the server.
+													// Useful when you run a server where the clients may not
+													// be connected to the internet but you want them to play (i.e LANs)
+
+
+// callbacks
+#if defined( VALVE_CALLBACK_PACK_SMALL )
+#pragma pack( push, 4 )
+#elif defined( VALVE_CALLBACK_PACK_LARGE )
+#pragma pack( push, 8 )
+#else
+#error isteamclient.h must be included
+#endif 
+
+
+// client has been approved to connect to this game server
+struct GSClientApprove_t
+{
+	enum { k_iCallback = k_iSteamGameServerCallbacks + 1 };
+	CSteamID m_SteamID;			// SteamID of approved player
+	CSteamID m_OwnerSteamID;	// SteamID of original owner for game license
+};
+
+
+// client has been denied to connection to this game server
+struct GSClientDeny_t
+{
+	enum { k_iCallback = k_iSteamGameServerCallbacks + 2 };
+	CSteamID m_SteamID;
+	EDenyReason m_eDenyReason;
+	char m_rgchOptionalText[128];
+};
+
+
+// request the game server should kick the user
+struct GSClientKick_t
+{
+	enum { k_iCallback = k_iSteamGameServerCallbacks + 3 };
+	CSteamID m_SteamID;
+	EDenyReason m_eDenyReason;
+};
+
+// NOTE: callback values 4 and 5 are skipped because they are used for old deprecated callbacks, 
+// do not reuse them here.
+
+
+// client achievement info
+struct GSClientAchievementStatus_t
+{
+	enum { k_iCallback = k_iSteamGameServerCallbacks + 6 };
+	uint64 m_SteamID;
+	char m_pchAchievement[128];
+	bool m_bUnlocked;
+};
+
+// received when the game server requests to be displayed as secure (VAC protected)
+// m_bSecure is true if the game server should display itself as secure to users, false otherwise
+struct GSPolicyResponse_t
+{
+	enum { k_iCallback = k_iSteamUserCallbacks + 15 };
+	uint8 m_bSecure;
+};
+
+// GS gameplay stats info
+struct GSGameplayStats_t
+{
+	enum { k_iCallback = k_iSteamGameServerCallbacks + 7 };
+	EResult m_eResult;					// Result of the call
+	int32	m_nRank;					// Overall rank of the server (0-based)
+	uint32	m_unTotalConnects;			// Total number of clients who have ever connected to the server
+	uint32	m_unTotalMinutesPlayed;		// Total number of minutes ever played on the server
+};
+
+// send as a reply to RequestUserGroupStatus()
+struct GSClientGroupStatus_t
+{
+	enum { k_iCallback = k_iSteamGameServerCallbacks + 8 };
+	CSteamID m_SteamIDUser;
+	CSteamID m_SteamIDGroup;
+	bool m_bMember;
+	bool m_bOfficer;
+};
+
+// Sent as a reply to GetServerReputation()
+struct GSReputation_t
+{
+	enum { k_iCallback = k_iSteamGameServerCallbacks + 9 };
+	EResult	m_eResult;				// Result of the call;
+	uint32	m_unReputationScore;	// The reputation score for the game server
+	bool	m_bBanned;				// True if the server is banned from the Steam
+									// master servers
+
+	// The following members are only filled out if m_bBanned is true. They will all 
+	// be set to zero otherwise. Master server bans are by IP so it is possible to be
+	// banned even when the score is good high if there is a bad server on another port.
+	// This information can be used to determine which server is bad.
+
+	uint32	m_unBannedIP;		// The IP of the banned server
+	uint16	m_usBannedPort;		// The port of the banned server
+	uint64	m_ulBannedGameID;	// The game ID the banned server is serving
+	uint32	m_unBanExpires;		// Time the ban expires, expressed in the Unix epoch (seconds since 1/1/1970)
+};
+
+// Sent as a reply to AssociateWithClan()
+struct AssociateWithClanResult_t
+{
+	enum { k_iCallback = k_iSteamGameServerCallbacks + 10 };
+	EResult	m_eResult;				// Result of the call;
+};
+
+// Sent as a reply to ComputeNewPlayerCompatibility()
+struct ComputeNewPlayerCompatibilityResult_t
+{
+	enum { k_iCallback = k_iSteamGameServerCallbacks + 11 };
+	EResult	m_eResult;				// Result of the call;
+	int m_cPlayersThatDontLikeCandidate;
+	int m_cPlayersThatCandidateDoesntLike;
+	int m_cClanPlayersThatDontLikeCandidate;
+	CSteamID m_SteamIDCandidate;
+};
+
+
+#pragma pack( pop )
+
+#endif // ISTEAMGAMESERVER_H

--- a/Common/Chairloader/SteamAPI/isteamgameserverstats.h
+++ b/Common/Chairloader/SteamAPI/isteamgameserverstats.h
@@ -1,0 +1,101 @@
+//====== Copyright © Valve Corporation, All rights reserved. =======
+//
+// Purpose: interface for game servers to steam stats and achievements
+//
+//=============================================================================
+
+#ifndef ISTEAMGAMESERVERSTATS_H
+#define ISTEAMGAMESERVERSTATS_H
+#ifdef _WIN32
+#pragma once
+#endif
+
+#include "isteamclient.h"
+
+//-----------------------------------------------------------------------------
+// Purpose: Functions for authenticating users via Steam to play on a game server
+//-----------------------------------------------------------------------------
+class ISteamGameServerStats
+{
+public:
+	// downloads stats for the user
+	// returns a GSStatsReceived_t callback when completed
+	// if the user has no stats, GSStatsReceived_t.m_eResult will be set to k_EResultFail
+	// these stats will only be auto-updated for clients playing on the server. For other
+	// users you'll need to call RequestUserStats() again to refresh any data
+	CALL_RESULT( GSStatsReceived_t )
+	virtual SteamAPICall_t RequestUserStats( CSteamID steamIDUser ) = 0;
+
+	// requests stat information for a user, usable after a successful call to RequestUserStats()
+	virtual bool GetUserStat( CSteamID steamIDUser, const char *pchName, int32 *pData ) = 0;
+	virtual bool GetUserStat( CSteamID steamIDUser, const char *pchName, float *pData ) = 0;
+	virtual bool GetUserAchievement( CSteamID steamIDUser, const char *pchName, bool *pbAchieved ) = 0;
+
+	// Set / update stats and achievements. 
+	// Note: These updates will work only on stats game servers are allowed to edit and only for 
+	// game servers that have been declared as officially controlled by the game creators. 
+	// Set the IP range of your official servers on the Steamworks page
+	virtual bool SetUserStat( CSteamID steamIDUser, const char *pchName, int32 nData ) = 0;
+	virtual bool SetUserStat( CSteamID steamIDUser, const char *pchName, float fData ) = 0;
+	virtual bool UpdateUserAvgRateStat( CSteamID steamIDUser, const char *pchName, float flCountThisSession, double dSessionLength ) = 0;
+
+	virtual bool SetUserAchievement( CSteamID steamIDUser, const char *pchName ) = 0;
+	virtual bool ClearUserAchievement( CSteamID steamIDUser, const char *pchName ) = 0;
+
+	// Store the current data on the server, will get a GSStatsStored_t callback when set.
+	//
+	// If the callback has a result of k_EResultInvalidParam, one or more stats 
+	// uploaded has been rejected, either because they broke constraints
+	// or were out of date. In this case the server sends back updated values.
+	// The stats should be re-iterated to keep in sync.
+	CALL_RESULT( GSStatsStored_t )
+	virtual SteamAPICall_t StoreUserStats( CSteamID steamIDUser ) = 0;
+};
+
+#define STEAMGAMESERVERSTATS_INTERFACE_VERSION "SteamGameServerStats001"
+
+// callbacks
+#if defined( VALVE_CALLBACK_PACK_SMALL )
+#pragma pack( push, 4 )
+#elif defined( VALVE_CALLBACK_PACK_LARGE )
+#pragma pack( push, 8 )
+#else
+#error isteamclient.h must be included
+#endif 
+
+//-----------------------------------------------------------------------------
+// Purpose: called when the latests stats and achievements have been received
+//			from the server
+//-----------------------------------------------------------------------------
+struct GSStatsReceived_t
+{
+	enum { k_iCallback = k_iSteamGameServerStatsCallbacks };
+	EResult		m_eResult;		// Success / error fetching the stats
+	CSteamID	m_steamIDUser;	// The user for whom the stats are retrieved for
+};
+
+
+//-----------------------------------------------------------------------------
+// Purpose: result of a request to store the user stats for a game
+//-----------------------------------------------------------------------------
+struct GSStatsStored_t
+{
+	enum { k_iCallback = k_iSteamGameServerStatsCallbacks + 1 };
+	EResult		m_eResult;		// success / error
+	CSteamID	m_steamIDUser;	// The user for whom the stats were stored
+};
+
+//-----------------------------------------------------------------------------
+// Purpose: Callback indicating that a user's stats have been unloaded.
+//  Call RequestUserStats again to access stats for this user
+//-----------------------------------------------------------------------------
+struct GSStatsUnloaded_t
+{
+	enum { k_iCallback = k_iSteamUserStatsCallbacks + 8 };
+	CSteamID	m_steamIDUser;	// User whose stats have been unloaded
+};
+
+#pragma pack( pop )
+
+
+#endif // ISTEAMGAMESERVERSTATS_H

--- a/Common/Chairloader/SteamAPI/isteamhtmlsurface.h
+++ b/Common/Chairloader/SteamAPI/isteamhtmlsurface.h
@@ -1,0 +1,453 @@
+//====== Copyright 1996-2013, Valve Corporation, All rights reserved. =======
+//
+// Purpose: interface to display html pages in a texture
+//
+//=============================================================================
+
+#ifndef ISTEAMHTMLSURFACE_H
+#define ISTEAMHTMLSURFACE_H
+#ifdef _WIN32
+#pragma once
+#endif
+
+#include "isteamclient.h"
+
+typedef uint32 HHTMLBrowser;
+const uint32 INVALID_HTMLBROWSER = 0;
+
+//-----------------------------------------------------------------------------
+// Purpose: Functions for displaying HTML pages and interacting with them
+//-----------------------------------------------------------------------------
+class ISteamHTMLSurface
+{
+public:
+	virtual ~ISteamHTMLSurface() {}
+
+	// Must call init and shutdown when starting/ending use of the interface
+	virtual bool Init() = 0;
+	virtual bool Shutdown() = 0;
+
+	// Create a browser object for display of a html page, when creation is complete the call handle
+	// will return a HTML_BrowserReady_t callback for the HHTMLBrowser of your new browser.
+	//   The user agent string is a substring to be added to the general user agent string so you can
+	// identify your client on web servers.
+	//   The userCSS string lets you apply a CSS style sheet to every displayed page, leave null if
+	// you do not require this functionality.
+	//
+	// YOU MUST HAVE IMPLEMENTED HANDLERS FOR HTML_BrowserReady_t, HTML_StartRequest_t,
+	// HTML_JSAlert_t, HTML_JSConfirm_t, and HTML_FileOpenDialog_t! See the CALLBACKS
+	// section of this interface (AllowStartRequest, etc) for more details. If you do
+	// not implement these callback handlers, the browser may appear to hang instead of
+	// navigating to new pages or triggering javascript popups.
+	//
+	CALL_RESULT( HTML_BrowserReady_t )
+	virtual SteamAPICall_t CreateBrowser( const char *pchUserAgent, const char *pchUserCSS ) = 0;
+
+	// Call this when you are done with a html surface, this lets us free the resources being used by it
+	virtual void RemoveBrowser( HHTMLBrowser unBrowserHandle ) = 0;
+
+	// Navigate to this URL, results in a HTML_StartRequest_t as the request commences 
+	virtual void LoadURL( HHTMLBrowser unBrowserHandle, const char *pchURL, const char *pchPostData ) = 0;
+
+	// Tells the surface the size in pixels to display the surface
+	virtual void SetSize( HHTMLBrowser unBrowserHandle, uint32 unWidth, uint32 unHeight ) = 0;
+
+	// Stop the load of the current html page
+	virtual void StopLoad( HHTMLBrowser unBrowserHandle ) = 0;
+	// Reload (most likely from local cache) the current page
+	virtual void Reload( HHTMLBrowser unBrowserHandle ) = 0;
+	// navigate back in the page history
+	virtual void GoBack( HHTMLBrowser unBrowserHandle ) = 0;
+	// navigate forward in the page history
+	virtual void GoForward( HHTMLBrowser unBrowserHandle ) = 0;
+
+	// add this header to any url requests from this browser
+	virtual void AddHeader( HHTMLBrowser unBrowserHandle, const char *pchKey, const char *pchValue ) = 0;
+	// run this javascript script in the currently loaded page
+	virtual void ExecuteJavascript( HHTMLBrowser unBrowserHandle, const char *pchScript ) = 0;
+
+	enum EHTMLMouseButton
+	{
+		eHTMLMouseButton_Left = 0,
+		eHTMLMouseButton_Right = 1,
+		eHTMLMouseButton_Middle = 2,
+	};
+
+	// Mouse click and mouse movement commands
+	virtual void MouseUp( HHTMLBrowser unBrowserHandle, EHTMLMouseButton eMouseButton ) = 0;
+	virtual void MouseDown( HHTMLBrowser unBrowserHandle, EHTMLMouseButton eMouseButton ) = 0;
+	virtual void MouseDoubleClick( HHTMLBrowser unBrowserHandle, EHTMLMouseButton eMouseButton ) = 0;
+	// x and y are relative to the HTML bounds
+	virtual void MouseMove( HHTMLBrowser unBrowserHandle, int x, int y ) = 0;
+	// nDelta is pixels of scroll
+	virtual void MouseWheel( HHTMLBrowser unBrowserHandle, int32 nDelta ) = 0;
+
+	enum EMouseCursor
+	{
+		dc_user = 0,
+		dc_none,
+		dc_arrow,
+		dc_ibeam,
+		dc_hourglass,
+		dc_waitarrow,
+		dc_crosshair,
+		dc_up,
+		dc_sizenw,
+		dc_sizese,
+		dc_sizene,
+		dc_sizesw,
+		dc_sizew,
+		dc_sizee,
+		dc_sizen,
+		dc_sizes,
+		dc_sizewe,
+		dc_sizens,
+		dc_sizeall,
+		dc_no,
+		dc_hand,
+		dc_blank, // don't show any custom cursor, just use your default
+		dc_middle_pan,
+		dc_north_pan,
+		dc_north_east_pan,
+		dc_east_pan,
+		dc_south_east_pan,
+		dc_south_pan,
+		dc_south_west_pan,
+		dc_west_pan,
+		dc_north_west_pan,
+		dc_alias,
+		dc_cell,
+		dc_colresize,
+		dc_copycur,
+		dc_verticaltext,
+		dc_rowresize,
+		dc_zoomin,
+		dc_zoomout,
+		dc_help,
+		dc_custom,
+
+		dc_last, // custom cursors start from this value and up
+	};
+
+	enum EHTMLKeyModifiers
+	{
+		k_eHTMLKeyModifier_None = 0,
+		k_eHTMLKeyModifier_AltDown = 1 << 0,
+		k_eHTMLKeyModifier_CtrlDown = 1 << 1,
+		k_eHTMLKeyModifier_ShiftDown = 1 << 2,
+	};
+
+	// keyboard interactions, native keycode is the virtual key code value from your OS
+	virtual void KeyDown( HHTMLBrowser unBrowserHandle, uint32 nNativeKeyCode, EHTMLKeyModifiers eHTMLKeyModifiers ) = 0;
+	virtual void KeyUp( HHTMLBrowser unBrowserHandle, uint32 nNativeKeyCode, EHTMLKeyModifiers eHTMLKeyModifiers ) = 0;
+	// cUnicodeChar is the unicode character point for this keypress (and potentially multiple chars per press)
+	virtual void KeyChar( HHTMLBrowser unBrowserHandle, uint32 cUnicodeChar, EHTMLKeyModifiers eHTMLKeyModifiers ) = 0;
+
+	// programmatically scroll this many pixels on the page
+	virtual void SetHorizontalScroll( HHTMLBrowser unBrowserHandle, uint32 nAbsolutePixelScroll ) = 0;
+	virtual void SetVerticalScroll( HHTMLBrowser unBrowserHandle, uint32 nAbsolutePixelScroll ) = 0;
+
+	// tell the html control if it has key focus currently, controls showing the I-beam cursor in text controls amongst other things
+	virtual void SetKeyFocus( HHTMLBrowser unBrowserHandle, bool bHasKeyFocus ) = 0;
+
+	// open the current pages html code in the local editor of choice, used for debugging
+	virtual void ViewSource( HHTMLBrowser unBrowserHandle ) = 0;
+	// copy the currently selected text on the html page to the local clipboard
+	virtual void CopyToClipboard( HHTMLBrowser unBrowserHandle ) = 0;
+	// paste from the local clipboard to the current html page
+	virtual void PasteFromClipboard( HHTMLBrowser unBrowserHandle ) = 0;
+
+	// find this string in the browser, if bCurrentlyInFind is true then instead cycle to the next matching element
+	virtual void Find( HHTMLBrowser unBrowserHandle, const char *pchSearchStr, bool bCurrentlyInFind, bool bReverse ) = 0;
+	// cancel a currently running find
+	virtual void StopFind( HHTMLBrowser unBrowserHandle ) = 0;
+
+	// return details about the link at position x,y on the current page
+	virtual void GetLinkAtPosition(  HHTMLBrowser unBrowserHandle, int x, int y ) = 0;
+
+	// set a webcookie for the hostname in question
+	virtual void SetCookie( const char *pchHostname, const char *pchKey, const char *pchValue, const char *pchPath = "/", RTime32 nExpires = 0, bool bSecure = false, bool bHTTPOnly = false ) = 0;
+
+	// Zoom the current page by flZoom ( from 0.0 to 2.0, so to zoom to 120% use 1.2 ), zooming around point X,Y in the page (use 0,0 if you don't care)
+	virtual void SetPageScaleFactor( HHTMLBrowser unBrowserHandle, float flZoom, int nPointX, int nPointY ) = 0;
+
+	// Enable/disable low-resource background mode, where javascript and repaint timers are throttled, resources are
+	// more aggressively purged from memory, and audio/video elements are paused. When background mode is enabled,
+	// all HTML5 video and audio objects will execute ".pause()" and gain the property "._steam_background_paused = 1".
+	// When background mode is disabled, any video or audio objects with that property will resume with ".play()".
+	virtual void SetBackgroundMode( HHTMLBrowser unBrowserHandle, bool bBackgroundMode ) = 0;
+
+	// CALLBACKS
+	//
+	//  These set of functions are used as responses to callback requests
+	//
+
+	// You MUST call this in response to a HTML_StartRequest_t callback
+	//  Set bAllowed to true to allow this navigation, false to cancel it and stay 
+	// on the current page. You can use this feature to limit the valid pages
+	// allowed in your HTML surface.
+	virtual void AllowStartRequest( HHTMLBrowser unBrowserHandle, bool bAllowed ) = 0;
+
+	// You MUST call this in response to a HTML_JSAlert_t or HTML_JSConfirm_t callback
+	//  Set bResult to true for the OK option of a confirm, use false otherwise
+	virtual void JSDialogResponse( HHTMLBrowser unBrowserHandle, bool bResult ) = 0;
+
+	// You MUST call this in response to a HTML_FileOpenDialog_t callback
+	IGNOREATTR()
+	virtual void FileLoadDialogResponse( HHTMLBrowser unBrowserHandle, const char **pchSelectedFiles ) = 0;
+};
+
+#define STEAMHTMLSURFACE_INTERFACE_VERSION "STEAMHTMLSURFACE_INTERFACE_VERSION_003"
+
+// callbacks
+#if defined( VALVE_CALLBACK_PACK_SMALL )
+#pragma pack( push, 4 )
+#elif defined( VALVE_CALLBACK_PACK_LARGE )
+#pragma pack( push, 8 )
+#else
+#error isteamclient.h must be included
+#endif 
+
+
+//-----------------------------------------------------------------------------
+// Purpose: The browser is ready for use
+//-----------------------------------------------------------------------------
+DEFINE_CALLBACK( HTML_BrowserReady_t, k_iSteamHTMLSurfaceCallbacks + 1 )
+CALLBACK_MEMBER( 0, HHTMLBrowser, unBrowserHandle ) // this browser is now fully created and ready to navigate to pages
+END_DEFINE_CALLBACK_1()
+
+
+//-----------------------------------------------------------------------------
+// Purpose: the browser has a pending paint
+//-----------------------------------------------------------------------------
+DEFINE_CALLBACK(HTML_NeedsPaint_t, k_iSteamHTMLSurfaceCallbacks + 2)
+CALLBACK_MEMBER(0, HHTMLBrowser, unBrowserHandle) // the browser that needs the paint
+CALLBACK_MEMBER(1, const char *, pBGRA ) // a pointer to the B8G8R8A8 data for this surface, valid until SteamAPI_RunCallbacks is next called
+CALLBACK_MEMBER(2, uint32, unWide) // the total width of the pBGRA texture
+CALLBACK_MEMBER(3, uint32, unTall) // the total height of the pBGRA texture
+CALLBACK_MEMBER(4, uint32, unUpdateX) // the offset in X for the damage rect for this update
+CALLBACK_MEMBER(5, uint32, unUpdateY) // the offset in Y for the damage rect for this update
+CALLBACK_MEMBER(6, uint32, unUpdateWide) // the width of the damage rect for this update
+CALLBACK_MEMBER(7, uint32, unUpdateTall) // the height of the damage rect for this update
+CALLBACK_MEMBER(8, uint32, unScrollX) // the page scroll the browser was at when this texture was rendered
+CALLBACK_MEMBER(9, uint32, unScrollY) // the page scroll the browser was at when this texture was rendered
+CALLBACK_MEMBER(10, float, flPageScale) // the page scale factor on this page when rendered
+CALLBACK_MEMBER(11, uint32, unPageSerial) // incremented on each new page load, you can use this to reject draws while navigating to new pages
+END_DEFINE_CALLBACK_12()
+
+
+//-----------------------------------------------------------------------------
+// Purpose: The browser wanted to navigate to a new page
+//   NOTE - you MUST call AllowStartRequest in response to this callback
+//-----------------------------------------------------------------------------
+DEFINE_CALLBACK(HTML_StartRequest_t, k_iSteamHTMLSurfaceCallbacks + 3)
+CALLBACK_MEMBER(0, HHTMLBrowser, unBrowserHandle) // the handle of the surface navigating
+CALLBACK_MEMBER(1, const char *, pchURL) // the url they wish to navigate to 
+CALLBACK_MEMBER(2, const char *, pchTarget) // the html link target type  (i.e _blank, _self, _parent, _top )
+CALLBACK_MEMBER(3, const char *, pchPostData ) // any posted data for the request
+CALLBACK_MEMBER(4, bool, bIsRedirect) // true if this was a http/html redirect from the last load request
+END_DEFINE_CALLBACK_5()
+
+
+//-----------------------------------------------------------------------------
+// Purpose: The browser has been requested to close due to user interaction (usually from a javascript window.close() call)
+//-----------------------------------------------------------------------------
+DEFINE_CALLBACK(HTML_CloseBrowser_t, k_iSteamHTMLSurfaceCallbacks + 4)
+CALLBACK_MEMBER(0, HHTMLBrowser, unBrowserHandle) // the handle of the surface 
+END_DEFINE_CALLBACK_1()
+
+
+//-----------------------------------------------------------------------------
+// Purpose: the browser is navigating to a new url
+//-----------------------------------------------------------------------------
+DEFINE_CALLBACK( HTML_URLChanged_t, k_iSteamHTMLSurfaceCallbacks + 5 )
+CALLBACK_MEMBER( 0, HHTMLBrowser, unBrowserHandle ) // the handle of the surface navigating
+CALLBACK_MEMBER( 1, const char *, pchURL ) // the url they wish to navigate to 
+CALLBACK_MEMBER( 2, const char *, pchPostData ) // any posted data for the request
+CALLBACK_MEMBER( 3, bool, bIsRedirect ) // true if this was a http/html redirect from the last load request
+CALLBACK_MEMBER( 4, const char *, pchPageTitle ) // the title of the page
+CALLBACK_MEMBER( 5, bool, bNewNavigation ) // true if this was from a fresh tab and not a click on an existing page
+END_DEFINE_CALLBACK_6()
+
+
+//-----------------------------------------------------------------------------
+// Purpose: A page is finished loading
+//-----------------------------------------------------------------------------
+DEFINE_CALLBACK( HTML_FinishedRequest_t, k_iSteamHTMLSurfaceCallbacks + 6 )
+CALLBACK_MEMBER( 0, HHTMLBrowser, unBrowserHandle ) // the handle of the surface 
+CALLBACK_MEMBER( 1, const char *, pchURL ) // 
+CALLBACK_MEMBER( 2, const char *, pchPageTitle ) // 
+END_DEFINE_CALLBACK_3()
+
+
+//-----------------------------------------------------------------------------
+// Purpose: a request to load this url in a new tab
+//-----------------------------------------------------------------------------
+DEFINE_CALLBACK( HTML_OpenLinkInNewTab_t, k_iSteamHTMLSurfaceCallbacks + 7 )
+CALLBACK_MEMBER( 0, HHTMLBrowser, unBrowserHandle ) // the handle of the surface 
+CALLBACK_MEMBER( 1, const char *, pchURL ) // 
+END_DEFINE_CALLBACK_2()
+
+
+//-----------------------------------------------------------------------------
+// Purpose: the page has a new title now
+//-----------------------------------------------------------------------------
+DEFINE_CALLBACK( HTML_ChangedTitle_t, k_iSteamHTMLSurfaceCallbacks + 8 )
+CALLBACK_MEMBER( 0, HHTMLBrowser, unBrowserHandle ) // the handle of the surface 
+CALLBACK_MEMBER( 1, const char *, pchTitle ) // 
+END_DEFINE_CALLBACK_2()
+
+
+//-----------------------------------------------------------------------------
+// Purpose: results from a search
+//-----------------------------------------------------------------------------
+DEFINE_CALLBACK( HTML_SearchResults_t, k_iSteamHTMLSurfaceCallbacks + 9 )
+CALLBACK_MEMBER( 0, HHTMLBrowser, unBrowserHandle ) // the handle of the surface 
+CALLBACK_MEMBER( 1, uint32, unResults ) // 
+CALLBACK_MEMBER( 2, uint32, unCurrentMatch ) // 
+END_DEFINE_CALLBACK_3()
+
+
+//-----------------------------------------------------------------------------
+// Purpose: page history status changed on the ability to go backwards and forward
+//-----------------------------------------------------------------------------
+DEFINE_CALLBACK( HTML_CanGoBackAndForward_t, k_iSteamHTMLSurfaceCallbacks + 10 )
+CALLBACK_MEMBER( 0, HHTMLBrowser, unBrowserHandle ) // the handle of the surface 
+CALLBACK_MEMBER( 1, bool, bCanGoBack ) // 
+CALLBACK_MEMBER( 2, bool, bCanGoForward ) // 
+END_DEFINE_CALLBACK_3()
+
+
+//-----------------------------------------------------------------------------
+// Purpose: details on the visibility and size of the horizontal scrollbar
+//-----------------------------------------------------------------------------
+DEFINE_CALLBACK( HTML_HorizontalScroll_t, k_iSteamHTMLSurfaceCallbacks + 11 )
+CALLBACK_MEMBER( 0, HHTMLBrowser, unBrowserHandle ) // the handle of the surface 
+CALLBACK_MEMBER( 1, uint32, unScrollMax ) // 
+CALLBACK_MEMBER( 2, uint32, unScrollCurrent ) // 
+CALLBACK_MEMBER( 3, float, flPageScale ) // 
+CALLBACK_MEMBER( 4, bool , bVisible ) // 
+CALLBACK_MEMBER( 5, uint32, unPageSize ) // 
+END_DEFINE_CALLBACK_6()
+
+
+//-----------------------------------------------------------------------------
+// Purpose: details on the visibility and size of the vertical scrollbar
+//-----------------------------------------------------------------------------
+DEFINE_CALLBACK( HTML_VerticalScroll_t, k_iSteamHTMLSurfaceCallbacks + 12 )
+CALLBACK_MEMBER( 0, HHTMLBrowser, unBrowserHandle ) // the handle of the surface 
+CALLBACK_MEMBER( 1, uint32, unScrollMax ) // 
+CALLBACK_MEMBER( 2, uint32, unScrollCurrent ) // 
+CALLBACK_MEMBER( 3, float, flPageScale ) // 
+CALLBACK_MEMBER( 4, bool, bVisible ) // 
+CALLBACK_MEMBER( 5, uint32, unPageSize ) // 
+END_DEFINE_CALLBACK_6()
+
+
+//-----------------------------------------------------------------------------
+// Purpose: response to GetLinkAtPosition call 
+//-----------------------------------------------------------------------------
+DEFINE_CALLBACK( HTML_LinkAtPosition_t, k_iSteamHTMLSurfaceCallbacks + 13 )
+CALLBACK_MEMBER( 0, HHTMLBrowser, unBrowserHandle ) // the handle of the surface 
+CALLBACK_MEMBER( 1, uint32, x ) // NOTE - Not currently set
+CALLBACK_MEMBER( 2, uint32, y ) // NOTE - Not currently set
+CALLBACK_MEMBER( 3, const char *, pchURL ) // 
+CALLBACK_MEMBER( 4, bool, bInput ) // 
+CALLBACK_MEMBER( 5, bool, bLiveLink ) // 
+END_DEFINE_CALLBACK_6()
+
+
+
+//-----------------------------------------------------------------------------
+// Purpose: show a Javascript alert dialog, call JSDialogResponse 
+//   when the user dismisses this dialog (or right away to ignore it)
+//-----------------------------------------------------------------------------
+DEFINE_CALLBACK( HTML_JSAlert_t, k_iSteamHTMLSurfaceCallbacks + 14 )
+CALLBACK_MEMBER( 0, HHTMLBrowser, unBrowserHandle ) // the handle of the surface 
+CALLBACK_MEMBER( 1, const char *, pchMessage ) // 
+END_DEFINE_CALLBACK_2()
+
+
+//-----------------------------------------------------------------------------
+// Purpose: show a Javascript confirmation dialog, call JSDialogResponse 
+//   when the user dismisses this dialog (or right away to ignore it)
+//-----------------------------------------------------------------------------
+DEFINE_CALLBACK( HTML_JSConfirm_t, k_iSteamHTMLSurfaceCallbacks + 15 )
+CALLBACK_MEMBER( 0, HHTMLBrowser, unBrowserHandle ) // the handle of the surface 
+CALLBACK_MEMBER( 1, const char *, pchMessage ) // 
+END_DEFINE_CALLBACK_2()
+
+
+//-----------------------------------------------------------------------------
+// Purpose: when received show a file open dialog
+//   then call FileLoadDialogResponse with the file(s) the user selected.
+//-----------------------------------------------------------------------------
+DEFINE_CALLBACK( HTML_FileOpenDialog_t, k_iSteamHTMLSurfaceCallbacks + 16 )
+CALLBACK_MEMBER( 0, HHTMLBrowser, unBrowserHandle ) // the handle of the surface 
+CALLBACK_MEMBER( 1, const char *, pchTitle ) // 
+CALLBACK_MEMBER( 2, const char *, pchInitialFile ) // 
+END_DEFINE_CALLBACK_3()
+
+
+//-----------------------------------------------------------------------------
+// Purpose: a new html window has been created 
+//-----------------------------------------------------------------------------
+DEFINE_CALLBACK( HTML_NewWindow_t, k_iSteamHTMLSurfaceCallbacks + 21 )
+CALLBACK_MEMBER( 0, HHTMLBrowser, unBrowserHandle ) // the handle of the current surface 
+CALLBACK_MEMBER( 1, const char *, pchURL ) // the page to load
+CALLBACK_MEMBER( 2, uint32, unX ) // the x pos into the page to display the popup
+CALLBACK_MEMBER( 3, uint32, unY ) // the y pos into the page to display the popup
+CALLBACK_MEMBER( 4, uint32, unWide ) // the total width of the pBGRA texture
+CALLBACK_MEMBER( 5, uint32, unTall ) // the total height of the pBGRA texture
+CALLBACK_MEMBER( 6, HHTMLBrowser, unNewWindow_BrowserHandle ) // the handle of the new window surface 
+END_DEFINE_CALLBACK_7()
+
+
+//-----------------------------------------------------------------------------
+// Purpose: change the cursor to display
+//-----------------------------------------------------------------------------
+DEFINE_CALLBACK( HTML_SetCursor_t, k_iSteamHTMLSurfaceCallbacks + 22 )
+CALLBACK_MEMBER( 0, HHTMLBrowser, unBrowserHandle ) // the handle of the surface 
+CALLBACK_MEMBER( 1, uint32, eMouseCursor ) // the EMouseCursor to display
+END_DEFINE_CALLBACK_2()
+
+
+//-----------------------------------------------------------------------------
+// Purpose: informational message from the browser
+//-----------------------------------------------------------------------------
+DEFINE_CALLBACK( HTML_StatusText_t, k_iSteamHTMLSurfaceCallbacks + 23 )
+CALLBACK_MEMBER( 0, HHTMLBrowser, unBrowserHandle ) // the handle of the surface 
+CALLBACK_MEMBER( 1, const char *, pchMsg ) // the EMouseCursor to display
+END_DEFINE_CALLBACK_2()
+
+
+//-----------------------------------------------------------------------------
+// Purpose: show a tooltip
+//-----------------------------------------------------------------------------
+DEFINE_CALLBACK( HTML_ShowToolTip_t, k_iSteamHTMLSurfaceCallbacks + 24 )
+CALLBACK_MEMBER( 0, HHTMLBrowser, unBrowserHandle ) // the handle of the surface 
+CALLBACK_MEMBER( 1, const char *, pchMsg ) // the EMouseCursor to display
+END_DEFINE_CALLBACK_2()
+
+
+//-----------------------------------------------------------------------------
+// Purpose: update the text of an existing tooltip
+//-----------------------------------------------------------------------------
+DEFINE_CALLBACK( HTML_UpdateToolTip_t, k_iSteamHTMLSurfaceCallbacks + 25 )
+CALLBACK_MEMBER( 0, HHTMLBrowser, unBrowserHandle ) // the handle of the surface 
+CALLBACK_MEMBER( 1, const char *, pchMsg ) // the EMouseCursor to display
+END_DEFINE_CALLBACK_2()
+
+
+//-----------------------------------------------------------------------------
+// Purpose: hide the tooltip you are showing
+//-----------------------------------------------------------------------------
+DEFINE_CALLBACK( HTML_HideToolTip_t, k_iSteamHTMLSurfaceCallbacks + 26 )
+CALLBACK_MEMBER( 0, HHTMLBrowser, unBrowserHandle ) // the handle of the surface 
+END_DEFINE_CALLBACK_1()
+
+
+#pragma pack( pop )
+
+
+#endif // ISTEAMHTMLSURFACE_H

--- a/Common/Chairloader/SteamAPI/isteamhttp.h
+++ b/Common/Chairloader/SteamAPI/isteamhttp.h
@@ -1,0 +1,210 @@
+//====== Copyright © 1996-2009, Valve Corporation, All rights reserved. =======
+//
+// Purpose: interface to http client 
+//
+//=============================================================================
+
+#ifndef ISTEAMHTTP_H
+#define ISTEAMHTTP_H
+#ifdef _WIN32
+#pragma once
+#endif
+
+#include "isteamclient.h"
+#include "steamhttpenums.h"
+
+// Handle to a HTTP Request handle
+typedef uint32 HTTPRequestHandle;
+#define INVALID_HTTPREQUEST_HANDLE		0
+
+typedef uint32 HTTPCookieContainerHandle;
+#define INVALID_HTTPCOOKIE_HANDLE		0
+
+//-----------------------------------------------------------------------------
+// Purpose: interface to http client
+//-----------------------------------------------------------------------------
+class ISteamHTTP
+{
+public:
+
+	// Initializes a new HTTP request, returning a handle to use in further operations on it.  Requires
+	// the method (GET or POST) and the absolute URL for the request.  Both http and https are supported,
+	// so this string must start with http:// or https:// and should look like http://store.steampowered.com/app/250/ 
+	// or such.
+	virtual HTTPRequestHandle CreateHTTPRequest( EHTTPMethod eHTTPRequestMethod, const char *pchAbsoluteURL ) = 0;
+
+	// Set a context value for the request, which will be returned in the HTTPRequestCompleted_t callback after
+	// sending the request.  This is just so the caller can easily keep track of which callbacks go with which request data.
+	virtual bool SetHTTPRequestContextValue( HTTPRequestHandle hRequest, uint64 ulContextValue ) = 0;
+
+	// Set a timeout in seconds for the HTTP request, must be called prior to sending the request.  Default
+	// timeout is 60 seconds if you don't call this.  Returns false if the handle is invalid, or the request
+	// has already been sent.
+	virtual bool SetHTTPRequestNetworkActivityTimeout( HTTPRequestHandle hRequest, uint32 unTimeoutSeconds ) = 0;
+
+	// Set a request header value for the request, must be called prior to sending the request.  Will 
+	// return false if the handle is invalid or the request is already sent.
+	virtual bool SetHTTPRequestHeaderValue( HTTPRequestHandle hRequest, const char *pchHeaderName, const char *pchHeaderValue ) = 0;
+
+	// Set a GET or POST parameter value on the request, which is set will depend on the EHTTPMethod specified
+	// when creating the request.  Must be called prior to sending the request.  Will return false if the 
+	// handle is invalid or the request is already sent.
+	virtual bool SetHTTPRequestGetOrPostParameter( HTTPRequestHandle hRequest, const char *pchParamName, const char *pchParamValue ) = 0;
+
+	// Sends the HTTP request, will return false on a bad handle, otherwise use SteamCallHandle to wait on
+	// asynchronous response via callback.
+	//
+	// Note: If the user is in offline mode in Steam, then this will add a only-if-cached cache-control 
+	// header and only do a local cache lookup rather than sending any actual remote request.
+	virtual bool SendHTTPRequest( HTTPRequestHandle hRequest, SteamAPICall_t *pCallHandle ) = 0;
+
+	// Sends the HTTP request, will return false on a bad handle, otherwise use SteamCallHandle to wait on
+	// asynchronous response via callback for completion, and listen for HTTPRequestHeadersReceived_t and 
+	// HTTPRequestDataReceived_t callbacks while streaming.
+	virtual bool SendHTTPRequestAndStreamResponse( HTTPRequestHandle hRequest, SteamAPICall_t *pCallHandle ) = 0;
+
+	// Defers a request you have sent, the actual HTTP client code may have many requests queued, and this will move
+	// the specified request to the tail of the queue.  Returns false on invalid handle, or if the request is not yet sent.
+	virtual bool DeferHTTPRequest( HTTPRequestHandle hRequest ) = 0;
+
+	// Prioritizes a request you have sent, the actual HTTP client code may have many requests queued, and this will move
+	// the specified request to the head of the queue.  Returns false on invalid handle, or if the request is not yet sent.
+	virtual bool PrioritizeHTTPRequest( HTTPRequestHandle hRequest ) = 0;
+
+	// Checks if a response header is present in a HTTP response given a handle from HTTPRequestCompleted_t, also 
+	// returns the size of the header value if present so the caller and allocate a correctly sized buffer for
+	// GetHTTPResponseHeaderValue.
+	virtual bool GetHTTPResponseHeaderSize( HTTPRequestHandle hRequest, const char *pchHeaderName, uint32 *unResponseHeaderSize ) = 0;
+
+	// Gets header values from a HTTP response given a handle from HTTPRequestCompleted_t, will return false if the
+	// header is not present or if your buffer is too small to contain it's value.  You should first call 
+	// BGetHTTPResponseHeaderSize to check for the presence of the header and to find out the size buffer needed.
+	virtual bool GetHTTPResponseHeaderValue( HTTPRequestHandle hRequest, const char *pchHeaderName, uint8 *pHeaderValueBuffer, uint32 unBufferSize ) = 0;
+
+	// Gets the size of the body data from a HTTP response given a handle from HTTPRequestCompleted_t, will return false if the 
+	// handle is invalid.
+	virtual bool GetHTTPResponseBodySize( HTTPRequestHandle hRequest, uint32 *unBodySize ) = 0;
+
+	// Gets the body data from a HTTP response given a handle from HTTPRequestCompleted_t, will return false if the 
+	// handle is invalid or is to a streaming response, or if the provided buffer is not the correct size.  Use BGetHTTPResponseBodySize first to find out
+	// the correct buffer size to use.
+	virtual bool GetHTTPResponseBodyData( HTTPRequestHandle hRequest, uint8 *pBodyDataBuffer, uint32 unBufferSize ) = 0;
+
+	// Gets the body data from a streaming HTTP response given a handle from HTTPRequestDataReceived_t. Will return false if the 
+	// handle is invalid or is to a non-streaming response (meaning it wasn't sent with SendHTTPRequestAndStreamResponse), or if the buffer size and offset 
+	// do not match the size and offset sent in HTTPRequestDataReceived_t.
+	virtual bool GetHTTPStreamingResponseBodyData( HTTPRequestHandle hRequest, uint32 cOffset, uint8 *pBodyDataBuffer, uint32 unBufferSize ) = 0;
+
+	// Releases an HTTP response handle, should always be called to free resources after receiving a HTTPRequestCompleted_t
+	// callback and finishing using the response.
+	virtual bool ReleaseHTTPRequest( HTTPRequestHandle hRequest ) = 0;
+
+	// Gets progress on downloading the body for the request.  This will be zero unless a response header has already been
+	// received which included a content-length field.  For responses that contain no content-length it will report
+	// zero for the duration of the request as the size is unknown until the connection closes.
+	virtual bool GetHTTPDownloadProgressPct( HTTPRequestHandle hRequest, float *pflPercentOut ) = 0;
+
+	// Sets the body for an HTTP Post request.  Will fail and return false on a GET request, and will fail if POST params
+	// have already been set for the request.  Setting this raw body makes it the only contents for the post, the pchContentType
+	// parameter will set the content-type header for the request so the server may know how to interpret the body.
+	virtual bool SetHTTPRequestRawPostBody( HTTPRequestHandle hRequest, const char *pchContentType, uint8 *pubBody, uint32 unBodyLen ) = 0;
+
+	// Creates a cookie container handle which you must later free with ReleaseCookieContainer().  If bAllowResponsesToModify=true
+	// than any response to your requests using this cookie container may add new cookies which may be transmitted with
+	// future requests.  If bAllowResponsesToModify=false than only cookies you explicitly set will be sent.  This API is just for
+	// during process lifetime, after steam restarts no cookies are persisted and you have no way to access the cookie container across
+	// repeat executions of your process.
+	virtual HTTPCookieContainerHandle CreateCookieContainer( bool bAllowResponsesToModify ) = 0;
+
+	// Release a cookie container you are finished using, freeing it's memory
+	virtual bool ReleaseCookieContainer( HTTPCookieContainerHandle hCookieContainer ) = 0;
+
+	// Adds a cookie to the specified cookie container that will be used with future requests.
+	virtual bool SetCookie( HTTPCookieContainerHandle hCookieContainer, const char *pchHost, const char *pchUrl, const char *pchCookie ) = 0;
+
+	// Set the cookie container to use for a HTTP request
+	virtual bool SetHTTPRequestCookieContainer( HTTPRequestHandle hRequest, HTTPCookieContainerHandle hCookieContainer ) = 0;
+
+	// Set the extra user agent info for a request, this doesn't clobber the normal user agent, it just adds the extra info on the end
+	virtual bool SetHTTPRequestUserAgentInfo( HTTPRequestHandle hRequest, const char *pchUserAgentInfo ) = 0;
+
+	// Set that https request should require verified SSL certificate via machines certificate trust store
+	virtual bool SetHTTPRequestRequiresVerifiedCertificate( HTTPRequestHandle hRequest, bool bRequireVerifiedCertificate ) = 0;
+
+	// Set an absolute timeout on the HTTP request, this is just a total time timeout different than the network activity timeout
+	// which can bump everytime we get more data
+	virtual bool SetHTTPRequestAbsoluteTimeoutMS( HTTPRequestHandle hRequest, uint32 unMilliseconds ) = 0;
+
+	// Check if the reason the request failed was because we timed it out (rather than some harder failure)
+	virtual bool GetHTTPRequestWasTimedOut( HTTPRequestHandle hRequest, bool *pbWasTimedOut ) = 0;
+};
+
+#define STEAMHTTP_INTERFACE_VERSION "STEAMHTTP_INTERFACE_VERSION002"
+
+// callbacks
+#if defined( VALVE_CALLBACK_PACK_SMALL )
+#pragma pack( push, 4 )
+#elif defined( VALVE_CALLBACK_PACK_LARGE )
+#pragma pack( push, 8 )
+#else
+#error isteamclient.h must be included
+#endif 
+
+struct HTTPRequestCompleted_t
+{
+	enum { k_iCallback = k_iClientHTTPCallbacks + 1 };
+
+	// Handle value for the request that has completed.
+	HTTPRequestHandle m_hRequest;
+
+	// Context value that the user defined on the request that this callback is associated with, 0 if
+	// no context value was set.
+	uint64 m_ulContextValue;
+
+	// This will be true if we actually got any sort of response from the server (even an error).  
+	// It will be false if we failed due to an internal error or client side network failure.
+	bool m_bRequestSuccessful;
+
+	// Will be the HTTP status code value returned by the server, k_EHTTPStatusCode200OK is the normal
+	// OK response, if you get something else you probably need to treat it as a failure.
+	EHTTPStatusCode m_eStatusCode;
+
+	uint32 m_unBodySize; // Same as GetHTTPResponseBodySize()
+};
+
+
+struct HTTPRequestHeadersReceived_t
+{
+	enum { k_iCallback = k_iClientHTTPCallbacks + 2 };
+
+	// Handle value for the request that has received headers.
+	HTTPRequestHandle m_hRequest;
+
+	// Context value that the user defined on the request that this callback is associated with, 0 if
+	// no context value was set.
+	uint64 m_ulContextValue;
+};
+
+struct HTTPRequestDataReceived_t
+{
+	enum { k_iCallback = k_iClientHTTPCallbacks + 3 };
+
+	// Handle value for the request that has received data.
+	HTTPRequestHandle m_hRequest;
+
+	// Context value that the user defined on the request that this callback is associated with, 0 if
+	// no context value was set.
+	uint64 m_ulContextValue;
+
+
+	// Offset to provide to GetHTTPStreamingResponseBodyData to get this chunk of data
+	uint32 m_cOffset;
+
+	// Size to provide to GetHTTPStreamingResponseBodyData to get this chunk of data
+	uint32 m_cBytesReceived;
+};
+
+
+#pragma pack( pop )
+
+#endif // ISTEAMHTTP_H

--- a/Common/Chairloader/SteamAPI/isteaminventory.h
+++ b/Common/Chairloader/SteamAPI/isteaminventory.h
@@ -1,0 +1,368 @@
+//====== Copyright © 1996-2014 Valve Corporation, All rights reserved. =======
+//
+// Purpose: interface to Steam Inventory
+//
+//=============================================================================
+
+#ifndef ISTEAMINVENTORY_H
+#define ISTEAMINVENTORY_H
+#ifdef _WIN32
+#pragma once
+#endif
+
+#include "isteamclient.h"
+
+// callbacks
+#if defined( VALVE_CALLBACK_PACK_SMALL )
+#pragma pack( push, 4 )
+#elif defined( VALVE_CALLBACK_PACK_LARGE )
+#pragma pack( push, 8 )
+#else
+#error isteamclient.h must be included
+#endif
+
+
+// Every individual instance of an item has a globally-unique ItemInstanceID.
+// This ID is unique to the combination of (player, specific item instance)
+// and will not be transferred to another player or re-used for another item.
+typedef uint64 SteamItemInstanceID_t;
+
+static const SteamItemInstanceID_t k_SteamItemInstanceIDInvalid = (SteamItemInstanceID_t)~0;
+
+// Types of items in your game are identified by a 32-bit "item definition number".
+// Valid definition numbers are between 1 and 999999999; numbers less than or equal to
+// zero are invalid, and numbers greater than or equal to one billion (1x10^9) are
+// reserved for internal Steam use.
+typedef int32 SteamItemDef_t;
+
+
+enum ESteamItemFlags
+{
+	// Item status flags - these flags are permanently attached to specific item instances
+	k_ESteamItemNoTrade = 1 << 0, // This item is account-locked and cannot be traded or given away.
+
+	// Action confirmation flags - these flags are set one time only, as part of a result set
+	k_ESteamItemRemoved = 1 << 8,	// The item has been destroyed, traded away, expired, or otherwise invalidated
+	k_ESteamItemConsumed = 1 << 9,	// The item quantity has been decreased by 1 via ConsumeItem API.
+
+	// All other flag bits are currently reserved for internal Steam use at this time.
+	// Do not assume anything about the state of other flags which are not defined here.
+};
+
+struct SteamItemDetails_t
+{
+	SteamItemInstanceID_t m_itemId;
+	SteamItemDef_t m_iDefinition;
+	uint16 m_unQuantity;
+	uint16 m_unFlags; // see ESteamItemFlags
+};
+
+typedef int32 SteamInventoryResult_t;
+
+static const SteamInventoryResult_t k_SteamInventoryResultInvalid = -1;
+
+
+//-----------------------------------------------------------------------------
+// Purpose: Steam Inventory query and manipulation API
+//-----------------------------------------------------------------------------
+class ISteamInventory
+{
+public:
+
+	// INVENTORY ASYNC RESULT MANAGEMENT
+	//
+	// Asynchronous inventory queries always output a result handle which can be used with
+	// GetResultStatus, GetResultItems, etc. A SteamInventoryResultReady_t callback will
+	// be triggered when the asynchronous result becomes ready (or fails).
+	//
+
+	// Find out the status of an asynchronous inventory result handle. Possible values:
+	//  k_EResultPending - still in progress
+	//  k_EResultOK - done, result ready
+	//  k_EResultExpired - done, result ready, maybe out of date (see DeserializeResult)
+	//  k_EResultInvalidParam - ERROR: invalid API call parameters
+	//  k_EResultServiceUnavailable - ERROR: service temporarily down, you may retry later
+	//  k_EResultLimitExceeded - ERROR: operation would exceed per-user inventory limits
+	//  k_EResultFail - ERROR: unknown / generic error
+	METHOD_DESC(Find out the status of an asynchronous inventory result handle.)
+	virtual EResult GetResultStatus( SteamInventoryResult_t resultHandle ) = 0;
+
+	// Copies the contents of a result set into a flat array. The specific
+	// contents of the result set depend on which query which was used.
+	METHOD_DESC(Copies the contents of a result set into a flat array. The specific contents of the result set depend on which query which was used.)
+	virtual bool GetResultItems( SteamInventoryResult_t resultHandle,
+								OUT_ARRAY_COUNT( punOutItemsArraySize,Output array) SteamItemDetails_t *pOutItemsArray,
+								uint32 *punOutItemsArraySize ) = 0;
+
+	// Returns the server time at which the result was generated. Compare against
+	// the value of IClientUtils::GetServerRealTime() to determine age.
+	METHOD_DESC(Returns the server time at which the result was generated. Compare against the value of IClientUtils::GetServerRealTime() to determine age.)
+	virtual uint32 GetResultTimestamp( SteamInventoryResult_t resultHandle ) = 0;
+
+	// Returns true if the result belongs to the target steam ID, false if the
+	// result does not. This is important when using DeserializeResult, to verify
+	// that a remote player is not pretending to have a different user's inventory.
+	METHOD_DESC(Returns true if the result belongs to the target steam ID or false if the result does not. This is important when using DeserializeResult to verify that a remote player is not pretending to have a different users inventory.)
+	virtual bool CheckResultSteamID( SteamInventoryResult_t resultHandle, CSteamID steamIDExpected ) = 0;
+
+	// Destroys a result handle and frees all associated memory.
+	METHOD_DESC(Destroys a result handle and frees all associated memory.)
+	virtual void DestroyResult( SteamInventoryResult_t resultHandle ) = 0;
+
+
+	// INVENTORY ASYNC QUERY
+	//
+
+	// Captures the entire state of the current user's Steam inventory.
+	// You must call DestroyResult on this handle when you are done with it.
+	// Returns false and sets *pResultHandle to zero if inventory is unavailable.
+	// Note: calls to this function are subject to rate limits and may return
+	// cached results if called too frequently. It is suggested that you call
+	// this function only when you are about to display the user's full inventory,
+	// or if you expect that the inventory may have changed.
+	METHOD_DESC(Captures the entire state of the current users Steam inventory.)
+	virtual bool GetAllItems( SteamInventoryResult_t *pResultHandle ) = 0;
+
+
+	// Captures the state of a subset of the current user's Steam inventory,
+	// identified by an array of item instance IDs. The results from this call
+	// can be serialized and passed to other players to "prove" that the current
+	// user owns specific items, without exposing the user's entire inventory.
+	// For example, you could call GetItemsByID with the IDs of the user's
+	// currently equipped cosmetic items and serialize this to a buffer, and
+	// then transmit this buffer to other players upon joining a game.
+	METHOD_DESC(Captures the state of a subset of the current users Steam inventory identified by an array of item instance IDs.)
+	virtual bool GetItemsByID( SteamInventoryResult_t *pResultHandle, ARRAY_COUNT( unCountInstanceIDs ) const SteamItemInstanceID_t *pInstanceIDs, uint32 unCountInstanceIDs ) = 0;
+
+
+	// RESULT SERIALIZATION AND AUTHENTICATION
+	//
+	// Serialized result sets contain a short signature which can't be forged
+	// or replayed across different game sessions. A result set can be serialized
+	// on the local client, transmitted to other players via your game networking,
+	// and deserialized by the remote players. This is a secure way of preventing
+	// hackers from lying about posessing rare/high-value items.
+
+	// Serializes a result set with signature bytes to an output buffer. Pass
+	// NULL as an output buffer to get the required size via punOutBufferSize.
+	// The size of a serialized result depends on the number items which are being
+	// serialized. When securely transmitting items to other players, it is
+	// recommended to use "GetItemsByID" first to create a minimal result set.
+	// Results have a built-in timestamp which will be considered "expired" after
+	// an hour has elapsed. See DeserializeResult for expiration handling.
+	virtual bool SerializeResult( SteamInventoryResult_t resultHandle, OUT_BUFFER_COUNT(punOutBufferSize) void *pOutBuffer, uint32 *punOutBufferSize ) = 0;
+
+	// Deserializes a result set and verifies the signature bytes. Returns false
+	// if bRequireFullOnlineVerify is set but Steam is running in Offline mode.
+	// Otherwise returns true and then delivers error codes via GetResultStatus.
+	//
+	// The bRESERVED_MUST_BE_FALSE flag is reserved for future use and should not
+	// be set to true by your game at this time.
+	//
+	// DeserializeResult has a potential soft-failure mode where the handle status
+	// is set to k_EResultExpired. GetResultItems() still succeeds in this mode.
+	// The "expired" result could indicate that the data may be out of date - not
+	// just due to timed expiration (one hour), but also because one of the items
+	// in the result set may have been traded or consumed since the result set was
+	// generated. You could compare the timestamp from GetResultTimestamp() to
+	// ISteamUtils::GetServerRealTime() to determine how old the data is. You could
+	// simply ignore the "expired" result code and continue as normal, or you
+	// could challenge the player with expired data to send an updated result set.
+	virtual bool DeserializeResult( SteamInventoryResult_t *pOutResultHandle, BUFFER_COUNT(punOutBufferSize) const void *pBuffer, uint32 unBufferSize, bool bRESERVED_MUST_BE_FALSE = false ) = 0;
+
+	
+	// INVENTORY ASYNC MODIFICATION
+	//
+	
+	// GenerateItems() creates one or more items and then generates a SteamInventoryCallback_t
+	// notification with a matching nCallbackContext parameter. This API is insecure, and could
+	// be abused by hacked clients. This call is normally disabled unless you explicitly enable 
+	// "Development mode" on the Inventory Service section of the Steamworks website.
+	// You should not enable this mode for a shipping game!
+	// Note that Steam accounts that belong to the publisher group for your game are granted
+	// an exception - as a developer, you may use this to generate and test items in your game.
+	// If punArrayQuantity is not NULL, it should be the same length as pArrayItems and should
+	// describe the quantity of each item to generate.
+	virtual bool GenerateItems( SteamInventoryResult_t *pResultHandle, ARRAY_COUNT(unArrayLength) const SteamItemDef_t *pArrayItemDefs, ARRAY_COUNT(unArrayLength) const uint32 *punArrayQuantity, uint32 unArrayLength ) = 0;
+
+	// GrantPromoItems() checks the list of promotional items for which the user may be eligible
+	// and grants the items (one time only).  On success, the result set will include items which
+	// were granted, if any. If no items were granted because the user isn't eligible for any
+	// promotions, this is still considered a success.
+	METHOD_DESC(GrantPromoItems() checks the list of promotional items for which the user may be eligible and grants the items (one time only).)
+	virtual bool GrantPromoItems( SteamInventoryResult_t *pResultHandle ) = 0;
+
+	// AddPromoItem() / AddPromoItems() are restricted versions of GrantPromoItems(). Instead of
+	// scanning for all eligible promotional items, the check is restricted to a single item
+	// definition or set of item definitions. This can be useful if your game has custom UI for
+	// showing a specific promo item to the user.
+	virtual bool AddPromoItem( SteamInventoryResult_t *pResultHandle, SteamItemDef_t itemDef ) = 0;
+	virtual bool AddPromoItems( SteamInventoryResult_t *pResultHandle, ARRAY_COUNT(unArrayLength) const SteamItemDef_t *pArrayItemDefs, uint32 unArrayLength ) = 0;
+
+	// ConsumeItem() removes items from the inventory, permanently. They cannot be recovered.
+	// Not for the faint of heart - if your game implements item removal at all, a high-friction
+	// UI confirmation process is highly recommended. Similar to GenerateItems, punArrayQuantity
+	// can be NULL or else an array of the same length as pArrayItems which describe the quantity
+	// of each item to destroy.
+	METHOD_DESC(ConsumeItem() removes items from the inventory permanently.)
+	virtual bool ConsumeItem( SteamInventoryResult_t *pResultHandle, SteamItemInstanceID_t itemConsume, uint32 unQuantity ) = 0;
+
+	// ExchangeItems() is an atomic combination of item generation and consumption. 
+	// It can be used to implement crafting recipes or transmutations, or items which unpack 
+	// themselves into other items (e.g., a chest). 
+	// ExchangeItems requires a whitelist - you must define recipes (lists of the components
+	// required for the exchange) on the target ItemDefinition. Exchanges that do not match
+	// a recipe, or do not provide the required amounts, will fail.
+	virtual bool ExchangeItems( SteamInventoryResult_t *pResultHandle,
+								ARRAY_COUNT(unArrayGenerateLength) const SteamItemDef_t *pArrayGenerate, ARRAY_COUNT(unArrayGenerateLength) const uint32 *punArrayGenerateQuantity, uint32 unArrayGenerateLength,
+								ARRAY_COUNT(unArrayDestroyLength) const SteamItemInstanceID_t *pArrayDestroy, ARRAY_COUNT(unArrayDestroyLength) const uint32 *punArrayDestroyQuantity, uint32 unArrayDestroyLength ) = 0;
+	
+
+	// TransferItemQuantity() is intended for use with items which are "stackable" (can have
+	// quantity greater than one). It can be used to split a stack into two, or to transfer
+	// quantity from one stack into another stack of identical items. To split one stack into
+	// two, pass k_SteamItemInstanceIDInvalid for itemIdDest and a new item will be generated.
+	virtual bool TransferItemQuantity( SteamInventoryResult_t *pResultHandle, SteamItemInstanceID_t itemIdSource, uint32 unQuantity, SteamItemInstanceID_t itemIdDest ) = 0;
+
+
+	// TIMED DROPS AND PLAYTIME CREDIT
+	//
+
+	// Deprecated. Calling this method is not required for proper playtime accounting.
+	METHOD_DESC( Deprecated method. Playtime accounting is performed on the Steam servers. )
+	virtual void SendItemDropHeartbeat() = 0;
+
+	// Playtime credit must be consumed and turned into item drops by your game. Only item
+	// definitions which are marked as "playtime item generators" can be spawned. The call
+	// will return an empty result set if there is not enough playtime credit for a drop.
+	// Your game should call TriggerItemDrop at an appropriate time for the user to receive
+	// new items, such as between rounds or while the player is dead. Note that players who
+	// hack their clients could modify the value of "dropListDefinition", so do not use it
+	// to directly control rarity.
+	// See your Steamworks configuration to set playtime drop rates for individual itemdefs.
+	// The client library will suppress too-frequent calls to this method.
+	METHOD_DESC(Playtime credit must be consumed and turned into item drops by your game.)
+	virtual bool TriggerItemDrop( SteamInventoryResult_t *pResultHandle, SteamItemDef_t dropListDefinition ) = 0;
+
+
+	// IN-GAME TRADING
+	//
+	// TradeItems() implements limited in-game trading of items, if you prefer not to use
+	// the overlay or an in-game web browser to perform Steam Trading through the website.
+	// You should implement a UI where both players can see and agree to a trade, and then
+	// each client should call TradeItems simultaneously (+/- 5 seconds) with matching
+	// (but reversed) parameters. The result is the same as if both players performed a
+	// Steam Trading transaction through the web. Each player will get an inventory result
+	// confirming the removal or quantity changes of the items given away, and the new
+	// item instance id numbers and quantities of the received items.
+	// (Note: new item instance IDs are generated whenever an item changes ownership.)
+	virtual bool TradeItems( SteamInventoryResult_t *pResultHandle, CSteamID steamIDTradePartner,
+							 ARRAY_COUNT(nArrayGiveLength) const SteamItemInstanceID_t *pArrayGive, ARRAY_COUNT(nArrayGiveLength) const uint32 *pArrayGiveQuantity, uint32 nArrayGiveLength,
+							 ARRAY_COUNT(nArrayGetLength) const SteamItemInstanceID_t *pArrayGet, ARRAY_COUNT(nArrayGetLength) const uint32 *pArrayGetQuantity, uint32 nArrayGetLength ) = 0;
+
+
+	// ITEM DEFINITIONS
+	//
+	// Item definitions are a mapping of "definition IDs" (integers between 1 and 1000000)
+	// to a set of string properties. Some of these properties are required to display items
+	// on the Steam community web site. Other properties can be defined by applications.
+	// Use of these functions is optional; there is no reason to call LoadItemDefinitions
+	// if your game hardcodes the numeric definition IDs (eg, purple face mask = 20, blue
+	// weapon mod = 55) and does not allow for adding new item types without a client patch.
+	//
+
+	// LoadItemDefinitions triggers the automatic load and refresh of item definitions.
+	// Every time new item definitions are available (eg, from the dynamic addition of new
+	// item types while players are still in-game), a SteamInventoryDefinitionUpdate_t
+	// callback will be fired.
+	METHOD_DESC(LoadItemDefinitions triggers the automatic load and refresh of item definitions.)
+	virtual bool LoadItemDefinitions() = 0;
+
+	// GetItemDefinitionIDs returns the set of all defined item definition IDs (which are
+	// defined via Steamworks configuration, and not necessarily contiguous integers).
+	// If pItemDefIDs is null, the call will return true and *punItemDefIDsArraySize will
+	// contain the total size necessary for a subsequent call. Otherwise, the call will
+	// return false if and only if there is not enough space in the output array.
+	virtual bool GetItemDefinitionIDs(
+				OUT_ARRAY_COUNT(punItemDefIDsArraySize,List of item definition IDs) SteamItemDef_t *pItemDefIDs,
+				DESC(Size of array is passed in and actual size used is returned in this param) uint32 *punItemDefIDsArraySize ) = 0;
+
+	// GetItemDefinitionProperty returns a string property from a given item definition.
+	// Note that some properties (for example, "name") may be localized and will depend
+	// on the current Steam language settings (see ISteamApps::GetCurrentGameLanguage).
+	// Property names are always composed of ASCII letters, numbers, and/or underscores.
+	// Pass a NULL pointer for pchPropertyName to get a comma - separated list of available
+	// property names. If pchValueBuffer is NULL, *punValueBufferSize will contain the 
+	// suggested buffer size. Otherwise it will be the number of bytes actually copied
+	// to pchValueBuffer. If the results do not fit in the given buffer, partial 
+	// results may be copied.
+	virtual bool GetItemDefinitionProperty( SteamItemDef_t iDefinition, const char *pchPropertyName,
+		OUT_STRING_COUNT(punValueBufferSizeOut) char *pchValueBuffer, uint32 *punValueBufferSizeOut ) = 0;
+
+	// Request the list of "eligible" promo items that can be manually granted to the given
+	// user.  These are promo items of type "manual" that won't be granted automatically.
+	// An example usage of this is an item that becomes available every week.
+	CALL_RESULT( SteamInventoryEligiblePromoItemDefIDs_t )
+	virtual SteamAPICall_t RequestEligiblePromoItemDefinitionsIDs( CSteamID steamID ) = 0;
+
+	// After handling a SteamInventoryEligiblePromoItemDefIDs_t call result, use this
+	// function to pull out the list of item definition ids that the user can be
+	// manually granted via the AddPromoItems() call.
+	virtual bool GetEligiblePromoItemDefinitionIDs(
+		CSteamID steamID,
+		OUT_ARRAY_COUNT(punItemDefIDsArraySize,List of item definition IDs) SteamItemDef_t *pItemDefIDs,
+		DESC(Size of array is passed in and actual size used is returned in this param) uint32 *punItemDefIDsArraySize ) = 0;
+};
+
+#define STEAMINVENTORY_INTERFACE_VERSION "STEAMINVENTORY_INTERFACE_V001"
+
+
+// SteamInventoryResultReady_t callbacks are fired whenever asynchronous
+// results transition from "Pending" to "OK" or an error state. There will
+// always be exactly one callback per handle.
+struct SteamInventoryResultReady_t
+{
+	enum { k_iCallback = k_iClientInventoryCallbacks + 0 };
+	SteamInventoryResult_t m_handle;
+	EResult m_result;
+};
+
+
+// SteamInventoryFullUpdate_t callbacks are triggered when GetAllItems
+// successfully returns a result which is newer / fresher than the last
+// known result. (It will not trigger if the inventory hasn't changed,
+// or if results from two overlapping calls are reversed in flight and
+// the earlier result is already known to be stale/out-of-date.)
+// The normal ResultReady callback will still be triggered immediately
+// afterwards; this is an additional notification for your convenience.
+struct SteamInventoryFullUpdate_t
+{
+	enum { k_iCallback = k_iClientInventoryCallbacks + 1 };
+	SteamInventoryResult_t m_handle;
+};
+
+
+// A SteamInventoryDefinitionUpdate_t callback is triggered whenever
+// item definitions have been updated, which could be in response to 
+// LoadItemDefinitions() or any other async request which required
+// a definition update in order to process results from the server.
+struct SteamInventoryDefinitionUpdate_t
+{
+	enum { k_iCallback = k_iClientInventoryCallbacks + 2 };
+};
+
+// Returned 
+struct SteamInventoryEligiblePromoItemDefIDs_t
+{
+	enum { k_iCallback = k_iClientInventoryCallbacks + 3 };
+	EResult m_result;
+	CSteamID m_steamID;
+	int m_numEligiblePromoItemDefs;
+	bool m_bCachedData;	// indicates that the data was retrieved from the cache and not the server
+};
+
+
+#pragma pack( pop )
+
+
+#endif // ISTEAMCONTROLLER_H

--- a/Common/Chairloader/SteamAPI/isteammasterserverupdater.h
+++ b/Common/Chairloader/SteamAPI/isteammasterserverupdater.h
@@ -1,0 +1,1 @@
+#error "This file isn't used any more"

--- a/Common/Chairloader/SteamAPI/isteammatchmaking.h
+++ b/Common/Chairloader/SteamAPI/isteammatchmaking.h
@@ -1,0 +1,751 @@
+//====== Copyright © 1996-2008, Valve Corporation, All rights reserved. =======
+//
+// Purpose: interface to steam managing game server/client match making
+//
+//=============================================================================
+
+#ifndef ISTEAMMATCHMAKING
+#define ISTEAMMATCHMAKING
+#ifdef _WIN32
+#pragma once
+#endif
+
+#include "steamtypes.h"
+#include "steamclientpublic.h"
+#include "matchmakingtypes.h" 
+#include "isteamclient.h"
+#include "isteamfriends.h"
+
+// lobby type description
+enum ELobbyType
+{
+	k_ELobbyTypePrivate = 0,		// only way to join the lobby is to invite to someone else
+	k_ELobbyTypeFriendsOnly = 1,	// shows for friends or invitees, but not in lobby list
+	k_ELobbyTypePublic = 2,			// visible for friends and in lobby list
+	k_ELobbyTypeInvisible = 3,		// returned by search, but not visible to other friends 
+									//    useful if you want a user in two lobbies, for example matching groups together
+									//	  a user can be in only one regular lobby, and up to two invisible lobbies
+};
+
+// lobby search filter tools
+enum ELobbyComparison
+{
+	k_ELobbyComparisonEqualToOrLessThan = -2,
+	k_ELobbyComparisonLessThan = -1,
+	k_ELobbyComparisonEqual = 0,
+	k_ELobbyComparisonGreaterThan = 1,
+	k_ELobbyComparisonEqualToOrGreaterThan = 2,
+	k_ELobbyComparisonNotEqual = 3,
+};
+
+// lobby search distance. Lobby results are sorted from closest to farthest.
+enum ELobbyDistanceFilter
+{
+	k_ELobbyDistanceFilterClose,		// only lobbies in the same immediate region will be returned
+	k_ELobbyDistanceFilterDefault,		// only lobbies in the same region or near by regions
+	k_ELobbyDistanceFilterFar,			// for games that don't have many latency requirements, will return lobbies about half-way around the globe
+	k_ELobbyDistanceFilterWorldwide,	// no filtering, will match lobbies as far as India to NY (not recommended, expect multiple seconds of latency between the clients)
+};
+
+// maximum number of characters a lobby metadata key can be
+#define k_nMaxLobbyKeyLength 255
+
+//-----------------------------------------------------------------------------
+// Purpose: Functions for match making services for clients to get to favorites
+//			and to operate on game lobbies.
+//-----------------------------------------------------------------------------
+class ISteamMatchmaking
+{
+public:
+	// game server favorites storage
+	// saves basic details about a multiplayer game server locally
+
+	// returns the number of favorites servers the user has stored
+	virtual int GetFavoriteGameCount() = 0;
+	
+	// returns the details of the game server
+	// iGame is of range [0,GetFavoriteGameCount())
+	// *pnIP, *pnConnPort are filled in the with IP:port of the game server
+	// *punFlags specify whether the game server was stored as an explicit favorite or in the history of connections
+	// *pRTime32LastPlayedOnServer is filled in the with the Unix time the favorite was added
+	virtual bool GetFavoriteGame( int iGame, AppId_t *pnAppID, uint32 *pnIP, uint16 *pnConnPort, uint16 *pnQueryPort, uint32 *punFlags, uint32 *pRTime32LastPlayedOnServer ) = 0;
+
+	// adds the game server to the local list; updates the time played of the server if it already exists in the list
+	virtual int AddFavoriteGame( AppId_t nAppID, uint32 nIP, uint16 nConnPort, uint16 nQueryPort, uint32 unFlags, uint32 rTime32LastPlayedOnServer ) = 0;
+	
+	// removes the game server from the local storage; returns true if one was removed
+	virtual bool RemoveFavoriteGame( AppId_t nAppID, uint32 nIP, uint16 nConnPort, uint16 nQueryPort, uint32 unFlags ) = 0;
+
+	///////
+	// Game lobby functions
+
+	// Get a list of relevant lobbies
+	// this is an asynchronous request
+	// results will be returned by LobbyMatchList_t callback & call result, with the number of lobbies found
+	// this will never return lobbies that are full
+	// to add more filter, the filter calls below need to be call before each and every RequestLobbyList() call
+	// use the CCallResult<> object in steam_api.h to match the SteamAPICall_t call result to a function in an object, e.g.
+	/*
+		class CMyLobbyListManager
+		{
+			CCallResult<CMyLobbyListManager, LobbyMatchList_t> m_CallResultLobbyMatchList;
+			void FindLobbies()
+			{
+				// SteamMatchmaking()->AddRequestLobbyListFilter*() functions would be called here, before RequestLobbyList()
+				SteamAPICall_t hSteamAPICall = SteamMatchmaking()->RequestLobbyList();
+				m_CallResultLobbyMatchList.Set( hSteamAPICall, this, &CMyLobbyListManager::OnLobbyMatchList );
+			}
+
+			void OnLobbyMatchList( LobbyMatchList_t *pLobbyMatchList, bool bIOFailure )
+			{
+				// lobby list has be retrieved from Steam back-end, use results
+			}
+		}
+	*/
+	// 
+	CALL_RESULT( LobbyMatchList_t )
+	virtual SteamAPICall_t RequestLobbyList() = 0;
+	// filters for lobbies
+	// this needs to be called before RequestLobbyList() to take effect
+	// these are cleared on each call to RequestLobbyList()
+	virtual void AddRequestLobbyListStringFilter( const char *pchKeyToMatch, const char *pchValueToMatch, ELobbyComparison eComparisonType ) = 0;
+	// numerical comparison
+	virtual void AddRequestLobbyListNumericalFilter( const char *pchKeyToMatch, int nValueToMatch, ELobbyComparison eComparisonType ) = 0;
+	// returns results closest to the specified value. Multiple near filters can be added, with early filters taking precedence
+	virtual void AddRequestLobbyListNearValueFilter( const char *pchKeyToMatch, int nValueToBeCloseTo ) = 0;
+	// returns only lobbies with the specified number of slots available
+	virtual void AddRequestLobbyListFilterSlotsAvailable( int nSlotsAvailable ) = 0;
+	// sets the distance for which we should search for lobbies (based on users IP address to location map on the Steam backed)
+	virtual void AddRequestLobbyListDistanceFilter( ELobbyDistanceFilter eLobbyDistanceFilter ) = 0;
+	// sets how many results to return, the lower the count the faster it is to download the lobby results & details to the client
+	virtual void AddRequestLobbyListResultCountFilter( int cMaxResults ) = 0;
+
+	virtual void AddRequestLobbyListCompatibleMembersFilter( CSteamID steamIDLobby ) = 0;
+
+	// returns the CSteamID of a lobby, as retrieved by a RequestLobbyList call
+	// should only be called after a LobbyMatchList_t callback is received
+	// iLobby is of the range [0, LobbyMatchList_t::m_nLobbiesMatching)
+	// the returned CSteamID::IsValid() will be false if iLobby is out of range
+	virtual CSteamID GetLobbyByIndex( int iLobby ) = 0;
+
+	// Create a lobby on the Steam servers.
+	// If private, then the lobby will not be returned by any RequestLobbyList() call; the CSteamID
+	// of the lobby will need to be communicated via game channels or via InviteUserToLobby()
+	// this is an asynchronous request
+	// results will be returned by LobbyCreated_t callback and call result; lobby is joined & ready to use at this point
+	// a LobbyEnter_t callback will also be received (since the local user is joining their own lobby)
+	CALL_RESULT( LobbyCreated_t )
+	virtual SteamAPICall_t CreateLobby( ELobbyType eLobbyType, int cMaxMembers ) = 0;
+
+	// Joins an existing lobby
+	// this is an asynchronous request
+	// results will be returned by LobbyEnter_t callback & call result, check m_EChatRoomEnterResponse to see if was successful
+	// lobby metadata is available to use immediately on this call completing
+	CALL_RESULT( LobbyEnter_t )
+	virtual SteamAPICall_t JoinLobby( CSteamID steamIDLobby ) = 0;
+
+	// Leave a lobby; this will take effect immediately on the client side
+	// other users in the lobby will be notified by a LobbyChatUpdate_t callback
+	virtual void LeaveLobby( CSteamID steamIDLobby ) = 0;
+
+	// Invite another user to the lobby
+	// the target user will receive a LobbyInvite_t callback
+	// will return true if the invite is successfully sent, whether or not the target responds
+	// returns false if the local user is not connected to the Steam servers
+	// if the other user clicks the join link, a GameLobbyJoinRequested_t will be posted if the user is in-game,
+	// or if the game isn't running yet the game will be launched with the parameter +connect_lobby <64-bit lobby id>
+	virtual bool InviteUserToLobby( CSteamID steamIDLobby, CSteamID steamIDInvitee ) = 0;
+
+	// Lobby iteration, for viewing details of users in a lobby
+	// only accessible if the lobby user is a member of the specified lobby
+	// persona information for other lobby members (name, avatar, etc.) will be asynchronously received
+	// and accessible via ISteamFriends interface
+	
+	// returns the number of users in the specified lobby
+	virtual int GetNumLobbyMembers( CSteamID steamIDLobby ) = 0;
+	// returns the CSteamID of a user in the lobby
+	// iMember is of range [0,GetNumLobbyMembers())
+	// note that the current user must be in a lobby to retrieve CSteamIDs of other users in that lobby
+	virtual CSteamID GetLobbyMemberByIndex( CSteamID steamIDLobby, int iMember ) = 0;
+
+	// Get data associated with this lobby
+	// takes a simple key, and returns the string associated with it
+	// "" will be returned if no value is set, or if steamIDLobby is invalid
+	virtual const char *GetLobbyData( CSteamID steamIDLobby, const char *pchKey ) = 0;
+	// Sets a key/value pair in the lobby metadata
+	// each user in the lobby will be broadcast this new value, and any new users joining will receive any existing data
+	// this can be used to set lobby names, map, etc.
+	// to reset a key, just set it to ""
+	// other users in the lobby will receive notification of the lobby data change via a LobbyDataUpdate_t callback
+	virtual bool SetLobbyData( CSteamID steamIDLobby, const char *pchKey, const char *pchValue ) = 0;
+
+	// returns the number of metadata keys set on the specified lobby
+	virtual int GetLobbyDataCount( CSteamID steamIDLobby ) = 0;
+
+	// returns a lobby metadata key/values pair by index, of range [0, GetLobbyDataCount())
+	virtual bool GetLobbyDataByIndex( CSteamID steamIDLobby, int iLobbyData, char *pchKey, int cchKeyBufferSize, char *pchValue, int cchValueBufferSize ) = 0;
+
+	// removes a metadata key from the lobby
+	virtual bool DeleteLobbyData( CSteamID steamIDLobby, const char *pchKey ) = 0;
+
+	// Gets per-user metadata for someone in this lobby
+	virtual const char *GetLobbyMemberData( CSteamID steamIDLobby, CSteamID steamIDUser, const char *pchKey ) = 0;
+	// Sets per-user metadata (for the local user implicitly)
+	virtual void SetLobbyMemberData( CSteamID steamIDLobby, const char *pchKey, const char *pchValue ) = 0;
+	
+	// Broadcasts a chat message to the all the users in the lobby
+	// users in the lobby (including the local user) will receive a LobbyChatMsg_t callback
+	// returns true if the message is successfully sent
+	// pvMsgBody can be binary or text data, up to 4k
+	// if pvMsgBody is text, cubMsgBody should be strlen( text ) + 1, to include the null terminator
+	virtual bool SendLobbyChatMsg( CSteamID steamIDLobby, const void *pvMsgBody, int cubMsgBody ) = 0;
+	// Get a chat message as specified in a LobbyChatMsg_t callback
+	// iChatID is the LobbyChatMsg_t::m_iChatID value in the callback
+	// *pSteamIDUser is filled in with the CSteamID of the member
+	// *pvData is filled in with the message itself
+	// return value is the number of bytes written into the buffer
+	virtual int GetLobbyChatEntry( CSteamID steamIDLobby, int iChatID, OUT_STRUCT() CSteamID *pSteamIDUser, void *pvData, int cubData, EChatEntryType *peChatEntryType ) = 0;
+
+	// Refreshes metadata for a lobby you're not necessarily in right now
+	// you never do this for lobbies you're a member of, only if your
+	// this will send down all the metadata associated with a lobby
+	// this is an asynchronous call
+	// returns false if the local user is not connected to the Steam servers
+	// results will be returned by a LobbyDataUpdate_t callback
+	// if the specified lobby doesn't exist, LobbyDataUpdate_t::m_bSuccess will be set to false
+	virtual bool RequestLobbyData( CSteamID steamIDLobby ) = 0;
+	
+	// sets the game server associated with the lobby
+	// usually at this point, the users will join the specified game server
+	// either the IP/Port or the steamID of the game server has to be valid, depending on how you want the clients to be able to connect
+	virtual void SetLobbyGameServer( CSteamID steamIDLobby, uint32 unGameServerIP, uint16 unGameServerPort, CSteamID steamIDGameServer ) = 0;
+	// returns the details of a game server set in a lobby - returns false if there is no game server set, or that lobby doesn't exist
+	virtual bool GetLobbyGameServer( CSteamID steamIDLobby, uint32 *punGameServerIP, uint16 *punGameServerPort, OUT_STRUCT() CSteamID *psteamIDGameServer ) = 0;
+
+	// set the limit on the # of users who can join the lobby
+	virtual bool SetLobbyMemberLimit( CSteamID steamIDLobby, int cMaxMembers ) = 0;
+	// returns the current limit on the # of users who can join the lobby; returns 0 if no limit is defined
+	virtual int GetLobbyMemberLimit( CSteamID steamIDLobby ) = 0;
+
+	// updates which type of lobby it is
+	// only lobbies that are k_ELobbyTypePublic or k_ELobbyTypeInvisible, and are set to joinable, will be returned by RequestLobbyList() calls
+	virtual bool SetLobbyType( CSteamID steamIDLobby, ELobbyType eLobbyType ) = 0;
+
+	// sets whether or not a lobby is joinable - defaults to true for a new lobby
+	// if set to false, no user can join, even if they are a friend or have been invited
+	virtual bool SetLobbyJoinable( CSteamID steamIDLobby, bool bLobbyJoinable ) = 0;
+
+	// returns the current lobby owner
+	// you must be a member of the lobby to access this
+	// there always one lobby owner - if the current owner leaves, another user will become the owner
+	// it is possible (bur rare) to join a lobby just as the owner is leaving, thus entering a lobby with self as the owner
+	virtual CSteamID GetLobbyOwner( CSteamID steamIDLobby ) = 0;
+
+	// changes who the lobby owner is
+	// you must be the lobby owner for this to succeed, and steamIDNewOwner must be in the lobby
+	// after completion, the local user will no longer be the owner
+	virtual bool SetLobbyOwner( CSteamID steamIDLobby, CSteamID steamIDNewOwner ) = 0;
+
+	// link two lobbies for the purposes of checking player compatibility
+	// you must be the lobby owner of both lobbies
+	virtual bool SetLinkedLobby( CSteamID steamIDLobby, CSteamID steamIDLobbyDependent ) = 0;
+
+#ifdef _PS3
+	// changes who the lobby owner is
+	// you must be the lobby owner for this to succeed, and steamIDNewOwner must be in the lobby
+	// after completion, the local user will no longer be the owner
+	virtual void CheckForPSNGameBootInvite( unsigned int iGameBootAttributes  ) = 0;
+#endif
+	CALL_BACK( LobbyChatUpdate_t )
+};
+#define STEAMMATCHMAKING_INTERFACE_VERSION "SteamMatchMaking009"
+
+
+//-----------------------------------------------------------------------------
+// Callback interfaces for server list functions (see ISteamMatchmakingServers below)
+//
+// The idea here is that your game code implements objects that implement these
+// interfaces to receive callback notifications after calling asynchronous functions
+// inside the ISteamMatchmakingServers() interface below.
+//
+// This is different than normal Steam callback handling due to the potentially
+// large size of server lists.
+//-----------------------------------------------------------------------------
+
+//-----------------------------------------------------------------------------
+// Typedef for handle type you will receive when requesting server list.
+//-----------------------------------------------------------------------------
+typedef void* HServerListRequest;
+
+//-----------------------------------------------------------------------------
+// Purpose: Callback interface for receiving responses after a server list refresh
+// or an individual server update.
+//
+// Since you get these callbacks after requesting full list refreshes you will
+// usually implement this interface inside an object like CServerBrowser.  If that
+// object is getting destructed you should use ISteamMatchMakingServers()->CancelQuery()
+// to cancel any in-progress queries so you don't get a callback into the destructed
+// object and crash.
+//-----------------------------------------------------------------------------
+class ISteamMatchmakingServerListResponse
+{
+public:
+	// Server has responded ok with updated data
+	virtual void ServerResponded( HServerListRequest hRequest, int iServer ) = 0; 
+
+	// Server has failed to respond
+	virtual void ServerFailedToRespond( HServerListRequest hRequest, int iServer ) = 0; 
+
+	// A list refresh you had initiated is now 100% completed
+	virtual void RefreshComplete( HServerListRequest hRequest, EMatchMakingServerResponse response ) = 0; 
+};
+
+
+//-----------------------------------------------------------------------------
+// Purpose: Callback interface for receiving responses after pinging an individual server 
+//
+// These callbacks all occur in response to querying an individual server
+// via the ISteamMatchmakingServers()->PingServer() call below.  If you are 
+// destructing an object that implements this interface then you should call 
+// ISteamMatchmakingServers()->CancelServerQuery() passing in the handle to the query
+// which is in progress.  Failure to cancel in progress queries when destructing
+// a callback handler may result in a crash when a callback later occurs.
+//-----------------------------------------------------------------------------
+class ISteamMatchmakingPingResponse
+{
+public:
+	// Server has responded successfully and has updated data
+	virtual void ServerResponded( gameserveritem_t &server ) = 0;
+
+	// Server failed to respond to the ping request
+	virtual void ServerFailedToRespond() = 0;
+};
+
+
+//-----------------------------------------------------------------------------
+// Purpose: Callback interface for receiving responses after requesting details on
+// who is playing on a particular server.
+//
+// These callbacks all occur in response to querying an individual server
+// via the ISteamMatchmakingServers()->PlayerDetails() call below.  If you are 
+// destructing an object that implements this interface then you should call 
+// ISteamMatchmakingServers()->CancelServerQuery() passing in the handle to the query
+// which is in progress.  Failure to cancel in progress queries when destructing
+// a callback handler may result in a crash when a callback later occurs.
+//-----------------------------------------------------------------------------
+class ISteamMatchmakingPlayersResponse
+{
+public:
+	// Got data on a new player on the server -- you'll get this callback once per player
+	// on the server which you have requested player data on.
+	virtual void AddPlayerToList( const char *pchName, int nScore, float flTimePlayed ) = 0;
+
+	// The server failed to respond to the request for player details
+	virtual void PlayersFailedToRespond() = 0;
+
+	// The server has finished responding to the player details request 
+	// (ie, you won't get anymore AddPlayerToList callbacks)
+	virtual void PlayersRefreshComplete() = 0;
+};
+
+
+//-----------------------------------------------------------------------------
+// Purpose: Callback interface for receiving responses after requesting rules
+// details on a particular server.
+//
+// These callbacks all occur in response to querying an individual server
+// via the ISteamMatchmakingServers()->ServerRules() call below.  If you are 
+// destructing an object that implements this interface then you should call 
+// ISteamMatchmakingServers()->CancelServerQuery() passing in the handle to the query
+// which is in progress.  Failure to cancel in progress queries when destructing
+// a callback handler may result in a crash when a callback later occurs.
+//-----------------------------------------------------------------------------
+class ISteamMatchmakingRulesResponse
+{
+public:
+	// Got data on a rule on the server -- you'll get one of these per rule defined on
+	// the server you are querying
+	virtual void RulesResponded( const char *pchRule, const char *pchValue ) = 0;
+
+	// The server failed to respond to the request for rule details
+	virtual void RulesFailedToRespond() = 0;
+
+	// The server has finished responding to the rule details request 
+	// (ie, you won't get anymore RulesResponded callbacks)
+	virtual void RulesRefreshComplete() = 0;
+};
+
+
+//-----------------------------------------------------------------------------
+// Typedef for handle type you will receive when querying details on an individual server.
+//-----------------------------------------------------------------------------
+typedef int HServerQuery;
+const int HSERVERQUERY_INVALID = 0xffffffff;
+
+//-----------------------------------------------------------------------------
+// Purpose: Functions for match making services for clients to get to game lists and details
+//-----------------------------------------------------------------------------
+class ISteamMatchmakingServers
+{
+public:
+	// Request a new list of servers of a particular type.  These calls each correspond to one of the EMatchMakingType values.
+	// Each call allocates a new asynchronous request object.
+	// Request object must be released by calling ReleaseRequest( hServerListRequest )
+	virtual HServerListRequest RequestInternetServerList( AppId_t iApp, ARRAY_COUNT(nFilters) MatchMakingKeyValuePair_t **ppchFilters, uint32 nFilters, ISteamMatchmakingServerListResponse *pRequestServersResponse ) = 0;
+	virtual HServerListRequest RequestLANServerList( AppId_t iApp, ISteamMatchmakingServerListResponse *pRequestServersResponse ) = 0;
+	virtual HServerListRequest RequestFriendsServerList( AppId_t iApp, ARRAY_COUNT(nFilters) MatchMakingKeyValuePair_t **ppchFilters, uint32 nFilters, ISteamMatchmakingServerListResponse *pRequestServersResponse ) = 0;
+	virtual HServerListRequest RequestFavoritesServerList( AppId_t iApp, ARRAY_COUNT(nFilters) MatchMakingKeyValuePair_t **ppchFilters, uint32 nFilters, ISteamMatchmakingServerListResponse *pRequestServersResponse ) = 0;
+	virtual HServerListRequest RequestHistoryServerList( AppId_t iApp, ARRAY_COUNT(nFilters) MatchMakingKeyValuePair_t **ppchFilters, uint32 nFilters, ISteamMatchmakingServerListResponse *pRequestServersResponse ) = 0;
+	virtual HServerListRequest RequestSpectatorServerList( AppId_t iApp, ARRAY_COUNT(nFilters) MatchMakingKeyValuePair_t **ppchFilters, uint32 nFilters, ISteamMatchmakingServerListResponse *pRequestServersResponse ) = 0;
+
+	// Releases the asynchronous request object and cancels any pending query on it if there's a pending query in progress.
+	// RefreshComplete callback is not posted when request is released.
+	virtual void ReleaseRequest( HServerListRequest hServerListRequest ) = 0;
+
+	/* the filter operation codes that go in the key part of MatchMakingKeyValuePair_t should be one of these:
+
+		"map"
+			- Server passes the filter if the server is playing the specified map.
+		"gamedataand"
+			- Server passes the filter if the server's game data (ISteamGameServer::SetGameData) contains all of the
+			specified strings.  The value field is a comma-delimited list of strings to match.
+		"gamedataor"
+			- Server passes the filter if the server's game data (ISteamGameServer::SetGameData) contains at least one of the
+			specified strings.  The value field is a comma-delimited list of strings to match.
+		"gamedatanor"
+			- Server passes the filter if the server's game data (ISteamGameServer::SetGameData) does not contain any
+			of the specified strings.  The value field is a comma-delimited list of strings to check.
+		"gametagsand"
+			- Server passes the filter if the server's game tags (ISteamGameServer::SetGameTags) contains all
+			of the specified strings.  The value field is a comma-delimited list of strings to check.
+		"gametagsnor"
+			- Server passes the filter if the server's game tags (ISteamGameServer::SetGameTags) does not contain any
+			of the specified strings.  The value field is a comma-delimited list of strings to check.
+		"and" (x1 && x2 && ... && xn)
+		"or" (x1 || x2 || ... || xn)
+		"nand" !(x1 && x2 && ... && xn)
+		"nor" !(x1 || x2 || ... || xn)
+			- Performs Boolean operation on the following filters.  The operand to this filter specifies
+			the "size" of the Boolean inputs to the operation, in Key/value pairs.  (The keyvalue
+			pairs must immediately follow, i.e. this is a prefix logical operator notation.)
+			In the simplest case where Boolean expressions are not nested, this is simply
+			the number of operands.
+
+			For example, to match servers on a particular map or with a particular tag, would would
+			use these filters.
+
+				( server.map == "cp_dustbowl" || server.gametags.contains("payload") )
+				"or", "2"
+				"map", "cp_dustbowl"
+				"gametagsand", "payload"
+
+			If logical inputs are nested, then the operand specifies the size of the entire
+			"length" of its operands, not the number of immediate children.
+
+				( server.map == "cp_dustbowl" || ( server.gametags.contains("payload") && !server.gametags.contains("payloadrace") ) )
+				"or", "4"
+				"map", "cp_dustbowl"
+				"and", "2"
+				"gametagsand", "payload"
+				"gametagsnor", "payloadrace"
+
+			Unary NOT can be achieved using either "nand" or "nor" with a single operand.
+
+		"addr"
+			- Server passes the filter if the server's query address matches the specified IP or IP:port.
+		"gameaddr"
+			- Server passes the filter if the server's game address matches the specified IP or IP:port.
+
+		The following filter operations ignore the "value" part of MatchMakingKeyValuePair_t
+
+		"dedicated"
+			- Server passes the filter if it passed true to SetDedicatedServer.
+		"secure"
+			- Server passes the filter if the server is VAC-enabled.
+		"notfull"
+			- Server passes the filter if the player count is less than the reported max player count.
+		"hasplayers"
+			- Server passes the filter if the player count is greater than zero.
+		"noplayers"
+			- Server passes the filter if it doesn't have any players.
+		"linux"
+			- Server passes the filter if it's a linux server
+	*/
+
+	// Get details on a given server in the list, you can get the valid range of index
+	// values by calling GetServerCount().  You will also receive index values in 
+	// ISteamMatchmakingServerListResponse::ServerResponded() callbacks
+	virtual gameserveritem_t *GetServerDetails( HServerListRequest hRequest, int iServer ) = 0; 
+
+	// Cancel an request which is operation on the given list type.  You should call this to cancel
+	// any in-progress requests before destructing a callback object that may have been passed 
+	// to one of the above list request calls.  Not doing so may result in a crash when a callback
+	// occurs on the destructed object.
+	// Canceling a query does not release the allocated request handle.
+	// The request handle must be released using ReleaseRequest( hRequest )
+	virtual void CancelQuery( HServerListRequest hRequest ) = 0; 
+
+	// Ping every server in your list again but don't update the list of servers
+	// Query callback installed when the server list was requested will be used
+	// again to post notifications and RefreshComplete, so the callback must remain
+	// valid until another RefreshComplete is called on it or the request
+	// is released with ReleaseRequest( hRequest )
+	virtual void RefreshQuery( HServerListRequest hRequest ) = 0; 
+
+	// Returns true if the list is currently refreshing its server list
+	virtual bool IsRefreshing( HServerListRequest hRequest ) = 0; 
+
+	// How many servers in the given list, GetServerDetails above takes 0... GetServerCount() - 1
+	virtual int GetServerCount( HServerListRequest hRequest ) = 0; 
+
+	// Refresh a single server inside of a query (rather than all the servers )
+	virtual void RefreshServer( HServerListRequest hRequest, int iServer ) = 0; 
+
+
+	//-----------------------------------------------------------------------------
+	// Queries to individual servers directly via IP/Port
+	//-----------------------------------------------------------------------------
+
+	// Request updated ping time and other details from a single server
+	virtual HServerQuery PingServer( uint32 unIP, uint16 usPort, ISteamMatchmakingPingResponse *pRequestServersResponse ) = 0; 
+
+	// Request the list of players currently playing on a server
+	virtual HServerQuery PlayerDetails( uint32 unIP, uint16 usPort, ISteamMatchmakingPlayersResponse *pRequestServersResponse ) = 0;
+
+	// Request the list of rules that the server is running (See ISteamGameServer::SetKeyValue() to set the rules server side)
+	virtual HServerQuery ServerRules( uint32 unIP, uint16 usPort, ISteamMatchmakingRulesResponse *pRequestServersResponse ) = 0; 
+
+	// Cancel an outstanding Ping/Players/Rules query from above.  You should call this to cancel
+	// any in-progress requests before destructing a callback object that may have been passed 
+	// to one of the above calls to avoid crashing when callbacks occur.
+	virtual void CancelServerQuery( HServerQuery hServerQuery ) = 0; 
+};
+#define STEAMMATCHMAKINGSERVERS_INTERFACE_VERSION "SteamMatchMakingServers002"
+
+// game server flags
+const uint32 k_unFavoriteFlagNone			= 0x00;
+const uint32 k_unFavoriteFlagFavorite		= 0x01; // this game favorite entry is for the favorites list
+const uint32 k_unFavoriteFlagHistory		= 0x02; // this game favorite entry is for the history list
+
+
+//-----------------------------------------------------------------------------
+// Purpose: Used in ChatInfo messages - fields specific to a chat member - must fit in a uint32
+//-----------------------------------------------------------------------------
+enum EChatMemberStateChange
+{
+	// Specific to joining / leaving the chatroom
+	k_EChatMemberStateChangeEntered			= 0x0001,		// This user has joined or is joining the chat room
+	k_EChatMemberStateChangeLeft			= 0x0002,		// This user has left or is leaving the chat room
+	k_EChatMemberStateChangeDisconnected	= 0x0004,		// User disconnected without leaving the chat first
+	k_EChatMemberStateChangeKicked			= 0x0008,		// User kicked
+	k_EChatMemberStateChangeBanned			= 0x0010,		// User kicked and banned
+};
+
+// returns true of the flags indicate that a user has been removed from the chat
+#define BChatMemberStateChangeRemoved( rgfChatMemberStateChangeFlags ) ( rgfChatMemberStateChangeFlags & ( k_EChatMemberStateChangeDisconnected | k_EChatMemberStateChangeLeft | k_EChatMemberStateChangeKicked | k_EChatMemberStateChangeBanned ) )
+
+
+//-----------------------------------------------------------------------------
+// Callbacks for ISteamMatchmaking (which go through the regular Steam callback registration system)
+#if defined( VALVE_CALLBACK_PACK_SMALL )
+#pragma pack( push, 4 )
+#elif defined( VALVE_CALLBACK_PACK_LARGE )
+#pragma pack( push, 8 )
+#else
+#error isteamclient.h must be included
+#endif 
+
+//-----------------------------------------------------------------------------
+// Purpose: a server was added/removed from the favorites list, you should refresh now
+//-----------------------------------------------------------------------------
+struct FavoritesListChanged_t
+{
+	enum { k_iCallback = k_iSteamMatchmakingCallbacks + 2 };
+	uint32 m_nIP; // an IP of 0 means reload the whole list, any other value means just one server
+	uint32 m_nQueryPort;
+	uint32 m_nConnPort;
+	uint32 m_nAppID;
+	uint32 m_nFlags;
+	bool m_bAdd; // true if this is adding the entry, otherwise it is a remove
+	AccountID_t m_unAccountId;
+};
+
+
+//-----------------------------------------------------------------------------
+// Purpose: Someone has invited you to join a Lobby
+//			normally you don't need to do anything with this, since
+//			the Steam UI will also display a '<user> has invited you to the lobby, join?' dialog
+//
+//			if the user outside a game chooses to join, your game will be launched with the parameter "+connect_lobby <64-bit lobby id>",
+//			or with the callback GameLobbyJoinRequested_t if they're already in-game
+//-----------------------------------------------------------------------------
+struct LobbyInvite_t
+{
+	enum { k_iCallback = k_iSteamMatchmakingCallbacks + 3 };
+
+	uint64 m_ulSteamIDUser;		// Steam ID of the person making the invite
+	uint64 m_ulSteamIDLobby;	// Steam ID of the Lobby
+	uint64 m_ulGameID;			// GameID of the Lobby
+};
+
+
+//-----------------------------------------------------------------------------
+// Purpose: Sent on entering a lobby, or on failing to enter
+//			m_EChatRoomEnterResponse will be set to k_EChatRoomEnterResponseSuccess on success,
+//			or a higher value on failure (see enum EChatRoomEnterResponse)
+//-----------------------------------------------------------------------------
+struct LobbyEnter_t
+{
+	enum { k_iCallback = k_iSteamMatchmakingCallbacks + 4 };
+
+	uint64 m_ulSteamIDLobby;							// SteamID of the Lobby you have entered
+	uint32 m_rgfChatPermissions;						// Permissions of the current user
+	bool m_bLocked;										// If true, then only invited users may join
+	uint32 m_EChatRoomEnterResponse;	// EChatRoomEnterResponse
+};
+
+
+//-----------------------------------------------------------------------------
+// Purpose: The lobby metadata has changed
+//			if m_ulSteamIDMember is the steamID of a lobby member, use GetLobbyMemberData() to access per-user details
+//			if m_ulSteamIDMember == m_ulSteamIDLobby, use GetLobbyData() to access lobby metadata
+//-----------------------------------------------------------------------------
+struct LobbyDataUpdate_t
+{
+	enum { k_iCallback = k_iSteamMatchmakingCallbacks + 5 };
+
+	uint64 m_ulSteamIDLobby;		// steamID of the Lobby
+	uint64 m_ulSteamIDMember;		// steamID of the member whose data changed, or the room itself
+	uint8 m_bSuccess;				// true if we lobby data was successfully changed; 
+									// will only be false if RequestLobbyData() was called on a lobby that no longer exists
+};
+
+
+//-----------------------------------------------------------------------------
+// Purpose: The lobby chat room state has changed
+//			this is usually sent when a user has joined or left the lobby
+//-----------------------------------------------------------------------------
+struct LobbyChatUpdate_t
+{
+	enum { k_iCallback = k_iSteamMatchmakingCallbacks + 6 };
+
+	uint64 m_ulSteamIDLobby;			// Lobby ID
+	uint64 m_ulSteamIDUserChanged;		// user who's status in the lobby just changed - can be recipient
+	uint64 m_ulSteamIDMakingChange;		// Chat member who made the change (different from SteamIDUserChange if kicking, muting, etc.)
+										// for example, if one user kicks another from the lobby, this will be set to the id of the user who initiated the kick
+	uint32 m_rgfChatMemberStateChange;	// bitfield of EChatMemberStateChange values
+};
+
+
+//-----------------------------------------------------------------------------
+// Purpose: A chat message for this lobby has been sent
+//			use GetLobbyChatEntry( m_iChatID ) to retrieve the contents of this message
+//-----------------------------------------------------------------------------
+struct LobbyChatMsg_t
+{
+	enum { k_iCallback = k_iSteamMatchmakingCallbacks + 7 };
+
+	uint64 m_ulSteamIDLobby;			// the lobby id this is in
+	uint64 m_ulSteamIDUser;			// steamID of the user who has sent this message
+	uint8 m_eChatEntryType;			// type of message
+	uint32 m_iChatID;				// index of the chat entry to lookup
+};
+
+
+//-----------------------------------------------------------------------------
+// Purpose: A game created a game for all the members of the lobby to join,
+//			as triggered by a SetLobbyGameServer()
+//			it's up to the individual clients to take action on this; the usual
+//			game behavior is to leave the lobby and connect to the specified game server
+//-----------------------------------------------------------------------------
+struct LobbyGameCreated_t
+{
+	enum { k_iCallback = k_iSteamMatchmakingCallbacks + 9 };
+
+	uint64 m_ulSteamIDLobby;		// the lobby we were in
+	uint64 m_ulSteamIDGameServer;	// the new game server that has been created or found for the lobby members
+	uint32 m_unIP;					// IP & Port of the game server (if any)
+	uint16 m_usPort;
+};
+
+
+//-----------------------------------------------------------------------------
+// Purpose: Number of matching lobbies found
+//			iterate the returned lobbies with GetLobbyByIndex(), from values 0 to m_nLobbiesMatching-1
+//-----------------------------------------------------------------------------
+struct LobbyMatchList_t
+{
+	enum { k_iCallback = k_iSteamMatchmakingCallbacks + 10 };
+	uint32 m_nLobbiesMatching;		// Number of lobbies that matched search criteria and we have SteamIDs for
+};
+
+
+//-----------------------------------------------------------------------------
+// Purpose: posted if a user is forcefully removed from a lobby
+//			can occur if a user loses connection to Steam
+//-----------------------------------------------------------------------------
+struct LobbyKicked_t
+{
+	enum { k_iCallback = k_iSteamMatchmakingCallbacks + 12 };
+	uint64 m_ulSteamIDLobby;			// Lobby
+	uint64 m_ulSteamIDAdmin;			// User who kicked you - possibly the ID of the lobby itself
+	uint8 m_bKickedDueToDisconnect;		// true if you were kicked from the lobby due to the user losing connection to Steam (currently always true)
+};
+
+
+//-----------------------------------------------------------------------------
+// Purpose: Result of our request to create a Lobby
+//			m_eResult == k_EResultOK on success
+//			at this point, the lobby has been joined and is ready for use
+//			a LobbyEnter_t callback will also be received (since the local user is joining their own lobby)
+//-----------------------------------------------------------------------------
+struct LobbyCreated_t
+{
+	enum { k_iCallback = k_iSteamMatchmakingCallbacks + 13 };
+	
+	EResult m_eResult;		// k_EResultOK - the lobby was successfully created
+							// k_EResultNoConnection - your Steam client doesn't have a connection to the back-end
+							// k_EResultTimeout - you the message to the Steam servers, but it didn't respond
+							// k_EResultFail - the server responded, but with an unknown internal error
+							// k_EResultAccessDenied - your game isn't set to allow lobbies, or your client does haven't rights to play the game
+							// k_EResultLimitExceeded - your game client has created too many lobbies
+
+	uint64 m_ulSteamIDLobby;		// chat room, zero if failed
+};
+
+// used by now obsolete RequestFriendsLobbiesResponse_t
+// enum { k_iCallback = k_iSteamMatchmakingCallbacks + 14 };
+
+
+//-----------------------------------------------------------------------------
+// Purpose: Result of CheckForPSNGameBootInvite
+//			m_eResult == k_EResultOK on success
+//			at this point, the local user may not have finishing joining this lobby;
+//			game code should wait until the subsequent LobbyEnter_t callback is received
+//-----------------------------------------------------------------------------
+struct PSNGameBootInviteResult_t
+{
+	enum { k_iCallback = k_iSteamMatchmakingCallbacks + 15 };
+
+	bool m_bGameBootInviteExists;
+	CSteamID m_steamIDLobby;		// Should be valid if m_bGameBootInviteExists == true
+};
+
+
+//-----------------------------------------------------------------------------
+// Purpose: Result of our request to create a Lobby
+//			m_eResult == k_EResultOK on success
+//			at this point, the lobby has been joined and is ready for use
+//			a LobbyEnter_t callback will also be received (since the local user is joining their own lobby)
+//-----------------------------------------------------------------------------
+struct FavoritesListAccountsUpdated_t
+{
+	enum { k_iCallback = k_iSteamMatchmakingCallbacks + 16 };
+	
+	EResult m_eResult;
+};
+
+#pragma pack( pop )
+
+
+#endif // ISTEAMMATCHMAKING

--- a/Common/Chairloader/SteamAPI/isteammusic.h
+++ b/Common/Chairloader/SteamAPI/isteammusic.h
@@ -1,0 +1,67 @@
+//============ Copyright (c) Valve Corporation, All rights reserved. ============
+
+#ifndef ISTEAMMUSIC_H
+#define ISTEAMMUSIC_H
+#ifdef _WIN32
+#pragma once
+#endif
+
+#include "isteamclient.h"
+
+//-----------------------------------------------------------------------------
+// Purpose: 
+//-----------------------------------------------------------------------------
+enum AudioPlayback_Status
+{
+	AudioPlayback_Undefined = 0, 
+	AudioPlayback_Playing = 1,
+	AudioPlayback_Paused = 2,
+	AudioPlayback_Idle = 3
+};
+
+
+//-----------------------------------------------------------------------------
+// Purpose: Functions to control music playback in the steam client
+//-----------------------------------------------------------------------------
+class ISteamMusic
+{
+public:
+	virtual bool BIsEnabled() = 0;
+	virtual bool BIsPlaying() = 0;
+	
+	virtual AudioPlayback_Status GetPlaybackStatus() = 0; 
+
+	virtual void Play() = 0;
+	virtual void Pause() = 0;
+	virtual void PlayPrevious() = 0;
+	virtual void PlayNext() = 0;
+
+	// volume is between 0.0 and 1.0
+	virtual void SetVolume( float flVolume ) = 0;
+	virtual float GetVolume() = 0;
+	
+};
+
+#define STEAMMUSIC_INTERFACE_VERSION "STEAMMUSIC_INTERFACE_VERSION001"
+
+// callbacks
+#if defined( VALVE_CALLBACK_PACK_SMALL )
+#pragma pack( push, 4 )
+#elif defined( VALVE_CALLBACK_PACK_LARGE )
+#pragma pack( push, 8 )
+#else
+#error isteamclient.h must be included
+#endif 
+
+
+DEFINE_CALLBACK( PlaybackStatusHasChanged_t, k_iSteamMusicCallbacks + 1 )
+END_DEFINE_CALLBACK_0()
+
+DEFINE_CALLBACK( VolumeHasChanged_t, k_iSteamMusicCallbacks + 2 )
+ 	CALLBACK_MEMBER( 0,	float, m_flNewVolume )
+END_DEFINE_CALLBACK_1()
+
+#pragma pack( pop )
+
+
+#endif // #define ISTEAMMUSIC_H

--- a/Common/Chairloader/SteamAPI/isteammusicremote.h
+++ b/Common/Chairloader/SteamAPI/isteammusicremote.h
@@ -1,0 +1,129 @@
+//============ Copyright (c) Valve Corporation, All rights reserved. ============
+
+#ifndef ISTEAMMUSICREMOTE_H
+#define ISTEAMMUSICREMOTE_H
+#ifdef _WIN32
+#pragma once
+#endif
+
+#include "isteamclient.h"
+#include "isteammusic.h"
+
+#define k_SteamMusicNameMaxLength 255
+#define k_SteamMusicPNGMaxLength 65535
+ 
+
+class ISteamMusicRemote
+{
+public: 
+	// Service Definition
+ 	virtual bool RegisterSteamMusicRemote( const char *pchName ) = 0;
+ 	virtual bool DeregisterSteamMusicRemote() = 0;
+	virtual bool BIsCurrentMusicRemote() = 0;
+	virtual bool BActivationSuccess( bool bValue ) = 0;
+
+	virtual bool SetDisplayName( const char *pchDisplayName ) = 0;
+	virtual bool SetPNGIcon_64x64( void *pvBuffer, uint32 cbBufferLength ) = 0;
+	
+	// Abilities for the user interface
+	virtual bool EnablePlayPrevious(bool bValue) = 0;
+	virtual bool EnablePlayNext( bool bValue ) = 0;
+	virtual bool EnableShuffled( bool bValue ) = 0;
+	virtual bool EnableLooped( bool bValue ) = 0;
+	virtual bool EnableQueue( bool bValue ) = 0;
+	virtual bool EnablePlaylists( bool bValue ) = 0;
+
+	// Status
+ 	virtual bool UpdatePlaybackStatus( AudioPlayback_Status nStatus ) = 0;
+	virtual bool UpdateShuffled( bool bValue ) = 0;
+	virtual bool UpdateLooped( bool bValue ) = 0;
+	virtual bool UpdateVolume( float flValue ) = 0; // volume is between 0.0 and 1.0
+
+	// Current Entry
+	virtual bool CurrentEntryWillChange() = 0;
+	virtual bool CurrentEntryIsAvailable( bool bAvailable ) = 0;
+	virtual bool UpdateCurrentEntryText( const char *pchText ) = 0;
+	virtual bool UpdateCurrentEntryElapsedSeconds( int nValue ) = 0;
+	virtual bool UpdateCurrentEntryCoverArt( void *pvBuffer, uint32 cbBufferLength ) = 0;
+	virtual bool CurrentEntryDidChange() = 0;
+
+	// Queue
+	virtual bool QueueWillChange() = 0;
+	virtual bool ResetQueueEntries() = 0;
+	virtual bool SetQueueEntry( int nID, int nPosition, const char *pchEntryText ) = 0;
+	virtual bool SetCurrentQueueEntry( int nID ) = 0;
+	virtual bool QueueDidChange() = 0;
+
+	// Playlist
+	virtual bool PlaylistWillChange() = 0;
+	virtual bool ResetPlaylistEntries() = 0;
+	virtual bool SetPlaylistEntry( int nID, int nPosition, const char *pchEntryText ) = 0;
+	virtual bool SetCurrentPlaylistEntry( int nID ) = 0;
+	virtual bool PlaylistDidChange() = 0;
+};
+
+#define STEAMMUSICREMOTE_INTERFACE_VERSION "STEAMMUSICREMOTE_INTERFACE_VERSION001"
+
+// callbacks
+#if defined( VALVE_CALLBACK_PACK_SMALL )
+#pragma pack( push, 4 )
+#elif defined( VALVE_CALLBACK_PACK_LARGE )
+#pragma pack( push, 8 )
+#else
+#error isteamclient.h must be included
+#endif 
+
+
+DEFINE_CALLBACK( MusicPlayerRemoteWillActivate_t, k_iSteamMusicRemoteCallbacks + 1)
+END_DEFINE_CALLBACK_0()
+
+DEFINE_CALLBACK( MusicPlayerRemoteWillDeactivate_t, k_iSteamMusicRemoteCallbacks + 2 )
+END_DEFINE_CALLBACK_0()
+
+DEFINE_CALLBACK( MusicPlayerRemoteToFront_t, k_iSteamMusicRemoteCallbacks + 3 )
+END_DEFINE_CALLBACK_0()
+
+DEFINE_CALLBACK( MusicPlayerWillQuit_t, k_iSteamMusicRemoteCallbacks + 4 )
+END_DEFINE_CALLBACK_0()
+
+DEFINE_CALLBACK( MusicPlayerWantsPlay_t, k_iSteamMusicRemoteCallbacks + 5 )
+END_DEFINE_CALLBACK_0()
+
+DEFINE_CALLBACK( MusicPlayerWantsPause_t, k_iSteamMusicRemoteCallbacks + 6 )
+END_DEFINE_CALLBACK_0()
+
+DEFINE_CALLBACK( MusicPlayerWantsPlayPrevious_t, k_iSteamMusicRemoteCallbacks + 7 )
+END_DEFINE_CALLBACK_0()
+
+DEFINE_CALLBACK( MusicPlayerWantsPlayNext_t, k_iSteamMusicRemoteCallbacks + 8 )
+END_DEFINE_CALLBACK_0()
+
+DEFINE_CALLBACK( MusicPlayerWantsShuffled_t, k_iSteamMusicRemoteCallbacks + 9 )
+	CALLBACK_MEMBER( 0, bool, m_bShuffled )
+END_DEFINE_CALLBACK_1()
+
+DEFINE_CALLBACK( MusicPlayerWantsLooped_t, k_iSteamMusicRemoteCallbacks + 10 )
+	CALLBACK_MEMBER(0, bool, m_bLooped )
+END_DEFINE_CALLBACK_1()
+
+DEFINE_CALLBACK( MusicPlayerWantsVolume_t, k_iSteamMusicCallbacks + 11 )
+	CALLBACK_MEMBER(0, float, m_flNewVolume)
+END_DEFINE_CALLBACK_1()
+
+DEFINE_CALLBACK( MusicPlayerSelectsQueueEntry_t, k_iSteamMusicCallbacks + 12 )
+	CALLBACK_MEMBER(0, int, nID )
+END_DEFINE_CALLBACK_1()
+
+DEFINE_CALLBACK( MusicPlayerSelectsPlaylistEntry_t, k_iSteamMusicCallbacks + 13 )
+	CALLBACK_MEMBER(0, int, nID )
+END_DEFINE_CALLBACK_1()
+
+DEFINE_CALLBACK( MusicPlayerWantsPlayingRepeatStatus_t, k_iSteamMusicRemoteCallbacks + 14 )
+	CALLBACK_MEMBER(0, int, m_nPlayingRepeatStatus )
+END_DEFINE_CALLBACK_1()
+
+#pragma pack( pop )
+
+
+
+#endif // #define ISTEAMMUSICREMOTE_H

--- a/Common/Chairloader/SteamAPI/isteamnetworking.h
+++ b/Common/Chairloader/SteamAPI/isteamnetworking.h
@@ -1,0 +1,306 @@
+//====== Copyright © 1996-2008, Valve Corporation, All rights reserved. =======
+//
+// Purpose: interface to steam managing network connections between game clients & servers
+//
+//=============================================================================
+
+#ifndef ISTEAMNETWORKING
+#define ISTEAMNETWORKING
+#ifdef _WIN32
+#pragma once
+#endif
+
+#include "steamtypes.h"
+#include "steamclientpublic.h"
+
+
+// list of possible errors returned by SendP2PPacket() API
+// these will be posted in the P2PSessionConnectFail_t callback
+enum EP2PSessionError
+{
+	k_EP2PSessionErrorNone = 0,
+	k_EP2PSessionErrorNotRunningApp = 1,			// target is not running the same game
+	k_EP2PSessionErrorNoRightsToApp = 2,			// local user doesn't own the app that is running
+	k_EP2PSessionErrorDestinationNotLoggedIn = 3,	// target user isn't connected to Steam
+	k_EP2PSessionErrorTimeout = 4,					// target isn't responding, perhaps not calling AcceptP2PSessionWithUser()
+													// corporate firewalls can also block this (NAT traversal is not firewall traversal)
+													// make sure that UDP ports 3478, 4379, and 4380 are open in an outbound direction
+	k_EP2PSessionErrorMax = 5
+};
+
+// SendP2PPacket() send types
+// Typically k_EP2PSendUnreliable is what you want for UDP-like packets, k_EP2PSendReliable for TCP-like packets
+enum EP2PSend
+{
+	// Basic UDP send. Packets can't be bigger than 1200 bytes (your typical MTU size). Can be lost, or arrive out of order (rare).
+	// The sending API does have some knowledge of the underlying connection, so if there is no NAT-traversal accomplished or
+	// there is a recognized adjustment happening on the connection, the packet will be batched until the connection is open again.
+	k_EP2PSendUnreliable = 0,
+
+	// As above, but if the underlying p2p connection isn't yet established the packet will just be thrown away. Using this on the first
+	// packet sent to a remote host almost guarantees the packet will be dropped.
+	// This is only really useful for kinds of data that should never buffer up, i.e. voice payload packets
+	k_EP2PSendUnreliableNoDelay = 1,
+
+	// Reliable message send. Can send up to 1MB of data in a single message. 
+	// Does fragmentation/re-assembly of messages under the hood, as well as a sliding window for efficient sends of large chunks of data. 
+	k_EP2PSendReliable = 2,
+
+	// As above, but applies the Nagle algorithm to the send - sends will accumulate 
+	// until the current MTU size (typically ~1200 bytes, but can change) or ~200ms has passed (Nagle algorithm). 
+	// Useful if you want to send a set of smaller messages but have the coalesced into a single packet
+	// Since the reliable stream is all ordered, you can do several small message sends with k_EP2PSendReliableWithBuffering and then
+	// do a normal k_EP2PSendReliable to force all the buffered data to be sent.
+	k_EP2PSendReliableWithBuffering = 3,
+
+};
+
+
+// connection state to a specified user, returned by GetP2PSessionState()
+// this is under-the-hood info about what's going on with a SendP2PPacket(), shouldn't be needed except for debuggin
+#if defined( VALVE_CALLBACK_PACK_SMALL )
+#pragma pack( push, 4 )
+#elif defined( VALVE_CALLBACK_PACK_LARGE )
+#pragma pack( push, 8 )
+#else
+#error isteamclient.h must be included
+#endif 
+struct P2PSessionState_t
+{
+	uint8 m_bConnectionActive;		// true if we've got an active open connection
+	uint8 m_bConnecting;			// true if we're currently trying to establish a connection
+	uint8 m_eP2PSessionError;		// last error recorded (see enum above)
+	uint8 m_bUsingRelay;			// true if it's going through a relay server (TURN)
+	int32 m_nBytesQueuedForSend;
+	int32 m_nPacketsQueuedForSend;
+	uint32 m_nRemoteIP;				// potential IP:Port of remote host. Could be TURN server. 
+	uint16 m_nRemotePort;			// Only exists for compatibility with older authentication api's
+};
+#pragma pack( pop )
+
+
+// handle to a socket
+typedef uint32 SNetSocket_t;		// CreateP2PConnectionSocket()
+typedef uint32 SNetListenSocket_t;	// CreateListenSocket()
+
+// connection progress indicators, used by CreateP2PConnectionSocket()
+enum ESNetSocketState
+{
+	k_ESNetSocketStateInvalid = 0,						
+
+	// communication is valid
+	k_ESNetSocketStateConnected = 1,				
+	
+	// states while establishing a connection
+	k_ESNetSocketStateInitiated = 10,				// the connection state machine has started
+
+	// p2p connections
+	k_ESNetSocketStateLocalCandidatesFound = 11,	// we've found our local IP info
+	k_ESNetSocketStateReceivedRemoteCandidates = 12,// we've received information from the remote machine, via the Steam back-end, about their IP info
+
+	// direct connections
+	k_ESNetSocketStateChallengeHandshake = 15,		// we've received a challenge packet from the server
+
+	// failure states
+	k_ESNetSocketStateDisconnecting = 21,			// the API shut it down, and we're in the process of telling the other end	
+	k_ESNetSocketStateLocalDisconnect = 22,			// the API shut it down, and we've completed shutdown
+	k_ESNetSocketStateTimeoutDuringConnect = 23,	// we timed out while trying to creating the connection
+	k_ESNetSocketStateRemoteEndDisconnected = 24,	// the remote end has disconnected from us
+	k_ESNetSocketStateConnectionBroken = 25,		// connection has been broken; either the other end has disappeared or our local network connection has broke
+
+};
+
+// describes how the socket is currently connected
+enum ESNetSocketConnectionType
+{
+	k_ESNetSocketConnectionTypeNotConnected = 0,
+	k_ESNetSocketConnectionTypeUDP = 1,
+	k_ESNetSocketConnectionTypeUDPRelay = 2,
+};
+
+
+//-----------------------------------------------------------------------------
+// Purpose: Functions for making connections and sending data between clients,
+//			traversing NAT's where possible
+//-----------------------------------------------------------------------------
+class ISteamNetworking
+{
+public:
+	////////////////////////////////////////////////////////////////////////////////////////////
+	// Session-less connection functions
+	//    automatically establishes NAT-traversing or Relay server connections
+
+	// Sends a P2P packet to the specified user
+	// UDP-like, unreliable and a max packet size of 1200 bytes
+	// the first packet send may be delayed as the NAT-traversal code runs
+	// if we can't get through to the user, an error will be posted via the callback P2PSessionConnectFail_t
+	// see EP2PSend enum above for the descriptions of the different ways of sending packets
+	//
+	// nChannel is a routing number you can use to help route message to different systems 	- you'll have to call ReadP2PPacket() 
+	// with the same channel number in order to retrieve the data on the other end
+	// using different channels to talk to the same user will still use the same underlying p2p connection, saving on resources
+	virtual bool SendP2PPacket( CSteamID steamIDRemote, const void *pubData, uint32 cubData, EP2PSend eP2PSendType, int nChannel = 0 ) = 0;
+
+	// returns true if any data is available for read, and the amount of data that will need to be read
+	virtual bool IsP2PPacketAvailable( uint32 *pcubMsgSize, int nChannel = 0 ) = 0;
+
+	// reads in a packet that has been sent from another user via SendP2PPacket()
+	// returns the size of the message and the steamID of the user who sent it in the last two parameters
+	// if the buffer passed in is too small, the message will be truncated
+	// this call is not blocking, and will return false if no data is available
+	virtual bool ReadP2PPacket( void *pubDest, uint32 cubDest, uint32 *pcubMsgSize, CSteamID *psteamIDRemote, int nChannel = 0 ) = 0;
+
+	// AcceptP2PSessionWithUser() should only be called in response to a P2PSessionRequest_t callback
+	// P2PSessionRequest_t will be posted if another user tries to send you a packet that you haven't talked to yet
+	// if you don't want to talk to the user, just ignore the request
+	// if the user continues to send you packets, another P2PSessionRequest_t will be posted periodically
+	// this may be called multiple times for a single user
+	// (if you've called SendP2PPacket() on the other user, this implicitly accepts the session request)
+	virtual bool AcceptP2PSessionWithUser( CSteamID steamIDRemote ) = 0;
+
+	// call CloseP2PSessionWithUser() when you're done talking to a user, will free up resources under-the-hood
+	// if the remote user tries to send data to you again, another P2PSessionRequest_t callback will be posted
+	virtual bool CloseP2PSessionWithUser( CSteamID steamIDRemote ) = 0;
+
+	// call CloseP2PChannelWithUser() when you're done talking to a user on a specific channel. Once all channels
+	// open channels to a user have been closed, the open session to the user will be closed and new data from this
+	// user will trigger a P2PSessionRequest_t callback
+	virtual bool CloseP2PChannelWithUser( CSteamID steamIDRemote, int nChannel ) = 0;
+
+	// fills out P2PSessionState_t structure with details about the underlying connection to the user
+	// should only needed for debugging purposes
+	// returns false if no connection exists to the specified user
+	virtual bool GetP2PSessionState( CSteamID steamIDRemote, P2PSessionState_t *pConnectionState ) = 0;
+
+	// Allow P2P connections to fall back to being relayed through the Steam servers if a direct connection
+	// or NAT-traversal cannot be established. Only applies to connections created after setting this value,
+	// or to existing connections that need to automatically reconnect after this value is set.
+	//
+	// P2P packet relay is allowed by default
+	virtual bool AllowP2PPacketRelay( bool bAllow ) = 0;
+
+
+	////////////////////////////////////////////////////////////////////////////////////////////
+	// LISTEN / CONNECT style interface functions
+	//
+	// This is an older set of functions designed around the Berkeley TCP sockets model
+	// it's preferential that you use the above P2P functions, they're more robust
+	// and these older functions will be removed eventually
+	//
+	////////////////////////////////////////////////////////////////////////////////////////////
+
+
+	// creates a socket and listens others to connect
+	// will trigger a SocketStatusCallback_t callback on another client connecting
+	// nVirtualP2PPort is the unique ID that the client will connect to, in case you have multiple ports
+	//		this can usually just be 0 unless you want multiple sets of connections
+	// unIP is the local IP address to bind to
+	//		pass in 0 if you just want the default local IP
+	// unPort is the port to use
+	//		pass in 0 if you don't want users to be able to connect via IP/Port, but expect to be always peer-to-peer connections only
+	virtual SNetListenSocket_t CreateListenSocket( int nVirtualP2PPort, uint32 nIP, uint16 nPort, bool bAllowUseOfPacketRelay ) = 0;
+
+	// creates a socket and begin connection to a remote destination
+	// can connect via a known steamID (client or game server), or directly to an IP
+	// on success will trigger a SocketStatusCallback_t callback
+	// on failure or timeout will trigger a SocketStatusCallback_t callback with a failure code in m_eSNetSocketState
+	virtual SNetSocket_t CreateP2PConnectionSocket( CSteamID steamIDTarget, int nVirtualPort, int nTimeoutSec, bool bAllowUseOfPacketRelay ) = 0;
+	virtual SNetSocket_t CreateConnectionSocket( uint32 nIP, uint16 nPort, int nTimeoutSec ) = 0;
+
+	// disconnects the connection to the socket, if any, and invalidates the handle
+	// any unread data on the socket will be thrown away
+	// if bNotifyRemoteEnd is set, socket will not be completely destroyed until the remote end acknowledges the disconnect
+	virtual bool DestroySocket( SNetSocket_t hSocket, bool bNotifyRemoteEnd ) = 0;
+	// destroying a listen socket will automatically kill all the regular sockets generated from it
+	virtual bool DestroyListenSocket( SNetListenSocket_t hSocket, bool bNotifyRemoteEnd ) = 0;
+
+	// sending data
+	// must be a handle to a connected socket
+	// data is all sent via UDP, and thus send sizes are limited to 1200 bytes; after this, many routers will start dropping packets
+	// use the reliable flag with caution; although the resend rate is pretty aggressive,
+	// it can still cause stalls in receiving data (like TCP)
+	virtual bool SendDataOnSocket( SNetSocket_t hSocket, void *pubData, uint32 cubData, bool bReliable ) = 0;
+
+	// receiving data
+	// returns false if there is no data remaining
+	// fills out *pcubMsgSize with the size of the next message, in bytes
+	virtual bool IsDataAvailableOnSocket( SNetSocket_t hSocket, uint32 *pcubMsgSize ) = 0; 
+
+	// fills in pubDest with the contents of the message
+	// messages are always complete, of the same size as was sent (i.e. packetized, not streaming)
+	// if *pcubMsgSize < cubDest, only partial data is written
+	// returns false if no data is available
+	virtual bool RetrieveDataFromSocket( SNetSocket_t hSocket, void *pubDest, uint32 cubDest, uint32 *pcubMsgSize ) = 0; 
+
+	// checks for data from any socket that has been connected off this listen socket
+	// returns false if there is no data remaining
+	// fills out *pcubMsgSize with the size of the next message, in bytes
+	// fills out *phSocket with the socket that data is available on
+	virtual bool IsDataAvailable( SNetListenSocket_t hListenSocket, uint32 *pcubMsgSize, SNetSocket_t *phSocket ) = 0;
+
+	// retrieves data from any socket that has been connected off this listen socket
+	// fills in pubDest with the contents of the message
+	// messages are always complete, of the same size as was sent (i.e. packetized, not streaming)
+	// if *pcubMsgSize < cubDest, only partial data is written
+	// returns false if no data is available
+	// fills out *phSocket with the socket that data is available on
+	virtual bool RetrieveData( SNetListenSocket_t hListenSocket, void *pubDest, uint32 cubDest, uint32 *pcubMsgSize, SNetSocket_t *phSocket ) = 0;
+
+	// returns information about the specified socket, filling out the contents of the pointers
+	virtual bool GetSocketInfo( SNetSocket_t hSocket, CSteamID *pSteamIDRemote, int *peSocketStatus, uint32 *punIPRemote, uint16 *punPortRemote ) = 0;
+
+	// returns which local port the listen socket is bound to
+	// *pnIP and *pnPort will be 0 if the socket is set to listen for P2P connections only
+	virtual bool GetListenSocketInfo( SNetListenSocket_t hListenSocket, uint32 *pnIP, uint16 *pnPort ) = 0;
+
+	// returns true to describe how the socket ended up connecting
+	virtual ESNetSocketConnectionType GetSocketConnectionType( SNetSocket_t hSocket ) = 0;
+
+	// max packet size, in bytes
+	virtual int GetMaxPacketSize( SNetSocket_t hSocket ) = 0;
+};
+#define STEAMNETWORKING_INTERFACE_VERSION "SteamNetworking005"
+
+// callbacks
+#if defined( VALVE_CALLBACK_PACK_SMALL )
+#pragma pack( push, 4 )
+#elif defined( VALVE_CALLBACK_PACK_LARGE )
+#pragma pack( push, 8 )
+#else
+#error isteamclient.h must be included
+#endif 
+
+// callback notification - a user wants to talk to us over the P2P channel via the SendP2PPacket() API
+// in response, a call to AcceptP2PPacketsFromUser() needs to be made, if you want to talk with them
+struct P2PSessionRequest_t
+{ 
+	enum { k_iCallback = k_iSteamNetworkingCallbacks + 2 };
+	CSteamID m_steamIDRemote;			// user who wants to talk to us
+};
+
+
+// callback notification - packets can't get through to the specified user via the SendP2PPacket() API
+// all packets queued packets unsent at this point will be dropped
+// further attempts to send will retry making the connection (but will be dropped if we fail again)
+struct P2PSessionConnectFail_t
+{ 
+	enum { k_iCallback = k_iSteamNetworkingCallbacks + 3 };
+	CSteamID m_steamIDRemote;			// user we were sending packets to
+	uint8 m_eP2PSessionError;			// EP2PSessionError indicating why we're having trouble
+};
+
+
+// callback notification - status of a socket has changed
+// used as part of the CreateListenSocket() / CreateP2PConnectionSocket() 
+struct SocketStatusCallback_t
+{ 
+	enum { k_iCallback = k_iSteamNetworkingCallbacks + 1 };
+	SNetSocket_t m_hSocket;				// the socket used to send/receive data to the remote host
+	SNetListenSocket_t m_hListenSocket;	// this is the server socket that we were listening on; NULL if this was an outgoing connection
+	CSteamID m_steamIDRemote;			// remote steamID we have connected to, if it has one
+	int m_eSNetSocketState;				// socket state, ESNetSocketState
+};
+
+#pragma pack( pop )
+
+#endif // ISTEAMNETWORKING

--- a/Common/Chairloader/SteamAPI/isteamps3overlayrenderer.h
+++ b/Common/Chairloader/SteamAPI/isteamps3overlayrenderer.h
@@ -1,0 +1,91 @@
+//====== Copyright © 1996-2010, Valve Corporation, All rights reserved. =======
+//
+// Purpose: interface the game must provide Steam with on PS3 in order for the
+// Steam overlay to render.
+//
+//=============================================================================
+
+#ifndef ISTEAMPS3OVERLAYRENDERER_H
+#define ISTEAMPS3OVERLAYRENDERER_H
+#ifdef _WIN32
+#pragma once
+#endif
+
+#include "cell/pad.h"
+
+//-----------------------------------------------------------------------------
+// Purpose: Enum for supported gradient directions
+//-----------------------------------------------------------------------------
+enum EOverlayGradientDirection
+{
+	k_EOverlayGradientHorizontal = 1,
+	k_EOverlayGradientVertical = 2,
+	k_EOverlayGradientNone = 3,
+};
+
+// Helpers for fetching individual color components from ARGB packed DWORD colors Steam PS3 overlay renderer uses.
+#define STEAM_COLOR_RED( color ) \
+	(int)(((color)>>16)&0xff)
+
+#define STEAM_COLOR_GREEN( color ) \
+	(int)(((color)>>8)&0xff)
+
+#define STEAM_COLOR_BLUE( color ) \
+	(int)((color)&0xff)
+
+#define STEAM_COLOR_ALPHA( color ) \
+	(int)(((color)>>24)&0xff)
+
+
+//-----------------------------------------------------------------------------
+// Purpose: Interface the game must expose to Steam for rendering
+//-----------------------------------------------------------------------------
+class ISteamPS3OverlayRenderHost
+{
+public:
+
+	// Interface for game engine to implement which Steam requires to render.
+
+	// Draw a textured rect.  This may use only part of the texture and will pass texture coords, it will also possibly request a gradient and will specify colors for vertexes.
+	virtual void DrawTexturedRect( int x0, int y0, int x1, int y1, float u0, float v0, float u1, float v1, int32 iTextureID, DWORD colorStart, DWORD colorEnd, EOverlayGradientDirection eDirection ) = 0;
+
+	// Load a RGBA texture for Steam, or update a previously loaded one.  Updates may be partial.  You must not evict or remove this texture once Steam has uploaded it.
+	virtual void LoadOrUpdateTexture( int32 iTextureID, bool bIsFullTexture, int x0, int y0, uint32 uWidth, uint32 uHeight, int32 iBytes, char *pData ) = 0;
+
+	// Delete a texture Steam previously uploaded
+	virtual void DeleteTexture( int32 iTextureID ) = 0;
+
+	// Delete all previously uploaded textures
+	virtual void DeleteAllTextures() = 0;
+};
+
+
+//-----------------------------------------------------------------------------
+// Purpose: Interface Steam exposes for the game to tell it when to render, etc.
+//-----------------------------------------------------------------------------
+class ISteamPS3OverlayRender
+{
+public:
+
+	// Call once at startup to initialize the Steam overlay and pass it your host interface ptr
+	virtual bool BHostInitialize( uint32 unScreenWidth, uint32 unScreenHeight, uint32 unRefreshRate, ISteamPS3OverlayRenderHost *pRenderHost, void *CellFontLib ) = 0;
+
+	// Call this once a frame when you are ready for the Steam overlay to render (ie, right before flipping buffers, after all your rendering)
+	virtual void Render() = 0;
+
+	// Call this everytime you read input on PS3.
+	// 
+	// If this returns true, then the overlay is active and has consumed the input, your game
+	// should then ignore all the input until BHandleCellPadData once again returns false, which
+	// will mean the overlay is deactivated.
+	virtual bool BHandleCellPadData( const CellPadData &padData ) = 0;
+
+	// Call this if you detect no controllers connected or that the XMB is intercepting input
+	// 
+	// This is important to clear input state for the overlay, so keys left down during XMB activation
+	// are not continued to be processed.
+	virtual bool BResetInputState() = 0;
+};
+
+
+#endif // ISTEAMPS3OVERLAYRENDERER_H

--- a/Common/Chairloader/SteamAPI/isteamremotestorage.h
+++ b/Common/Chairloader/SteamAPI/isteamremotestorage.h
@@ -1,0 +1,681 @@
+//====== Copyright � 1996-2008, Valve Corporation, All rights reserved. =======
+//
+// Purpose: public interface to user remote file storage in Steam
+//
+//=============================================================================
+
+#ifndef ISTEAMREMOTESTORAGE_H
+#define ISTEAMREMOTESTORAGE_H
+#ifdef _WIN32
+#pragma once
+#endif
+
+#include "isteamclient.h"
+
+
+//-----------------------------------------------------------------------------
+// Purpose: Defines the largest allowed file size. Cloud files cannot be written
+// in a single chunk over 100MB (and cannot be over 200MB total.)
+//-----------------------------------------------------------------------------
+const uint32 k_unMaxCloudFileChunkSize = 100 * 1024 * 1024;
+
+
+//-----------------------------------------------------------------------------
+// Purpose: Structure that contains an array of const char * strings and the number of those strings
+//-----------------------------------------------------------------------------
+#if defined( VALVE_CALLBACK_PACK_SMALL )
+#pragma pack( push, 4 )
+#elif defined( VALVE_CALLBACK_PACK_LARGE )
+#pragma pack( push, 8 )
+#else
+#error isteamclient.h must be included
+#endif 
+struct SteamParamStringArray_t
+{
+	const char ** m_ppStrings;
+	int32 m_nNumStrings;
+};
+#pragma pack( pop )
+
+// A handle to a piece of user generated content
+typedef uint64 UGCHandle_t;
+typedef uint64 PublishedFileUpdateHandle_t;
+typedef uint64 PublishedFileId_t;
+const PublishedFileId_t k_PublishedFileIdInvalid = 0;
+const UGCHandle_t k_UGCHandleInvalid = 0xffffffffffffffffull;
+const PublishedFileUpdateHandle_t k_PublishedFileUpdateHandleInvalid = 0xffffffffffffffffull;
+
+// Handle for writing to Steam Cloud
+typedef uint64 UGCFileWriteStreamHandle_t;
+const UGCFileWriteStreamHandle_t k_UGCFileStreamHandleInvalid = 0xffffffffffffffffull;
+
+const uint32 k_cchPublishedDocumentTitleMax = 128 + 1;
+const uint32 k_cchPublishedDocumentDescriptionMax = 8000;
+const uint32 k_cchPublishedDocumentChangeDescriptionMax = 8000;
+const uint32 k_unEnumeratePublishedFilesMaxResults = 50;
+const uint32 k_cchTagListMax = 1024 + 1;
+const uint32 k_cchFilenameMax = 260;
+const uint32 k_cchPublishedFileURLMax = 256;
+
+
+enum ERemoteStoragePlatform
+{
+	k_ERemoteStoragePlatformNone		= 0,
+	k_ERemoteStoragePlatformWindows		= (1 << 0),
+	k_ERemoteStoragePlatformOSX			= (1 << 1),
+	k_ERemoteStoragePlatformPS3			= (1 << 2),
+	k_ERemoteStoragePlatformLinux		= (1 << 3),
+	k_ERemoteStoragePlatformReserved2	= (1 << 4),
+
+	k_ERemoteStoragePlatformAll = 0xffffffff
+};
+
+enum ERemoteStoragePublishedFileVisibility
+{
+	k_ERemoteStoragePublishedFileVisibilityPublic = 0,
+	k_ERemoteStoragePublishedFileVisibilityFriendsOnly = 1,
+	k_ERemoteStoragePublishedFileVisibilityPrivate = 2,
+};
+
+
+enum EWorkshopFileType
+{
+	k_EWorkshopFileTypeFirst = 0,
+
+	k_EWorkshopFileTypeCommunity			  = 0,		// normal Workshop item that can be subscribed to
+	k_EWorkshopFileTypeMicrotransaction		  = 1,		// Workshop item that is meant to be voted on for the purpose of selling in-game
+	k_EWorkshopFileTypeCollection			  = 2,		// a collection of Workshop or Greenlight items
+	k_EWorkshopFileTypeArt					  = 3,		// artwork
+	k_EWorkshopFileTypeVideo				  = 4,		// external video
+	k_EWorkshopFileTypeScreenshot			  = 5,		// screenshot
+	k_EWorkshopFileTypeGame					  = 6,		// Greenlight game entry
+	k_EWorkshopFileTypeSoftware				  = 7,		// Greenlight software entry
+	k_EWorkshopFileTypeConcept				  = 8,		// Greenlight concept
+	k_EWorkshopFileTypeWebGuide				  = 9,		// Steam web guide
+	k_EWorkshopFileTypeIntegratedGuide		  = 10,		// application integrated guide
+	k_EWorkshopFileTypeMerch				  = 11,		// Workshop merchandise meant to be voted on for the purpose of being sold
+	k_EWorkshopFileTypeControllerBinding	  = 12,		// Steam Controller bindings
+	k_EWorkshopFileTypeSteamworksAccessInvite = 13,		// internal
+	k_EWorkshopFileTypeSteamVideo			  = 14,		// Steam video
+	k_EWorkshopFileTypeGameManagedItem		  = 15,		// managed completely by the game, not the user, and not shown on the web
+
+	// Update k_EWorkshopFileTypeMax if you add values.
+	k_EWorkshopFileTypeMax = 16
+	
+};
+
+enum EWorkshopVote
+{
+	k_EWorkshopVoteUnvoted = 0,
+	k_EWorkshopVoteFor = 1,
+	k_EWorkshopVoteAgainst = 2,
+	k_EWorkshopVoteLater = 3,
+};
+
+enum EWorkshopFileAction
+{
+	k_EWorkshopFileActionPlayed = 0,
+	k_EWorkshopFileActionCompleted = 1,
+};
+
+enum EWorkshopEnumerationType
+{
+	k_EWorkshopEnumerationTypeRankedByVote = 0,
+	k_EWorkshopEnumerationTypeRecent = 1,
+	k_EWorkshopEnumerationTypeTrending = 2,
+	k_EWorkshopEnumerationTypeFavoritesOfFriends = 3,
+	k_EWorkshopEnumerationTypeVotedByFriends = 4,
+	k_EWorkshopEnumerationTypeContentByFriends = 5,
+	k_EWorkshopEnumerationTypeRecentFromFollowedUsers = 6,
+};
+
+enum EWorkshopVideoProvider
+{
+	k_EWorkshopVideoProviderNone = 0,
+	k_EWorkshopVideoProviderYoutube = 1
+};
+
+
+enum EUGCReadAction
+{
+	// Keeps the file handle open unless the last byte is read.  You can use this when reading large files (over 100MB) in sequential chunks.
+	// If the last byte is read, this will behave the same as k_EUGCRead_Close.  Otherwise, it behaves the same as k_EUGCRead_ContinueReading.
+	// This value maintains the same behavior as before the EUGCReadAction parameter was introduced.
+	k_EUGCRead_ContinueReadingUntilFinished = 0,
+
+	// Keeps the file handle open.  Use this when using UGCRead to seek to different parts of the file.
+	// When you are done seeking around the file, make a final call with k_EUGCRead_Close to close it.
+	k_EUGCRead_ContinueReading = 1,
+
+	// Frees the file handle.  Use this when you're done reading the content.  
+	// To read the file from Steam again you will need to call UGCDownload again. 
+	k_EUGCRead_Close = 2,	
+};
+
+
+//-----------------------------------------------------------------------------
+// Purpose: Functions for accessing, reading and writing files stored remotely 
+//			and cached locally
+//-----------------------------------------------------------------------------
+class ISteamRemoteStorage
+{
+	public:
+		// NOTE
+		//
+		// Filenames are case-insensitive, and will be converted to lowercase automatically.
+		// So "foo.bar" and "Foo.bar" are the same file, and if you write "Foo.bar" then
+		// iterate the files, the filename returned will be "foo.bar".
+		//
+
+		// file operations
+		virtual bool	FileWrite( const char *pchFile, const void *pvData, int32 cubData ) = 0;
+		virtual int32	FileRead( const char *pchFile, void *pvData, int32 cubDataToRead ) = 0;
+		
+		CALL_RESULT( RemoteStorageFileWriteAsyncComplete_t )
+		virtual SteamAPICall_t FileWriteAsync( const char *pchFile, const void *pvData, uint32 cubData ) = 0;
+		
+		CALL_RESULT( RemoteStorageFileReadAsyncComplete_t )
+		virtual SteamAPICall_t FileReadAsync( const char *pchFile, uint32 nOffset, uint32 cubToRead ) = 0;
+		virtual bool	FileReadAsyncComplete( SteamAPICall_t hReadCall, void *pvBuffer, uint32 cubToRead ) = 0;
+		
+		virtual bool	FileForget( const char *pchFile ) = 0;
+		virtual bool	FileDelete( const char *pchFile ) = 0;
+		CALL_RESULT( RemoteStorageFileShareResult_t )
+		virtual SteamAPICall_t FileShare( const char *pchFile ) = 0;
+		virtual bool	SetSyncPlatforms( const char *pchFile, ERemoteStoragePlatform eRemoteStoragePlatform ) = 0;
+
+		// file operations that cause network IO
+		virtual UGCFileWriteStreamHandle_t FileWriteStreamOpen( const char *pchFile ) = 0;
+		virtual bool FileWriteStreamWriteChunk( UGCFileWriteStreamHandle_t writeHandle, const void *pvData, int32 cubData ) = 0;
+		virtual bool FileWriteStreamClose( UGCFileWriteStreamHandle_t writeHandle ) = 0;
+		virtual bool FileWriteStreamCancel( UGCFileWriteStreamHandle_t writeHandle ) = 0;
+
+		// file information
+		virtual bool	FileExists( const char *pchFile ) = 0;
+		virtual bool	FilePersisted( const char *pchFile ) = 0;
+		virtual int32	GetFileSize( const char *pchFile ) = 0;
+		virtual int64	GetFileTimestamp( const char *pchFile ) = 0;
+		virtual ERemoteStoragePlatform GetSyncPlatforms( const char *pchFile ) = 0;
+
+		// iteration
+		virtual int32 GetFileCount() = 0;
+		virtual const char *GetFileNameAndSize( int iFile, int32 *pnFileSizeInBytes ) = 0;
+
+		// configuration management
+		virtual bool GetQuota( uint64 *pnTotalBytes, uint64 *puAvailableBytes ) = 0;
+		virtual bool IsCloudEnabledForAccount() = 0;
+		virtual bool IsCloudEnabledForApp() = 0;
+		virtual void SetCloudEnabledForApp( bool bEnabled ) = 0;
+
+		// user generated content
+
+		// Downloads a UGC file.  A priority value of 0 will download the file immediately,
+		// otherwise it will wait to download the file until all downloads with a lower priority
+		// value are completed.  Downloads with equal priority will occur simultaneously.
+		CALL_RESULT( RemoteStorageDownloadUGCResult_t )
+		virtual SteamAPICall_t UGCDownload( UGCHandle_t hContent, uint32 unPriority ) = 0;
+		
+		// Gets the amount of data downloaded so far for a piece of content. pnBytesExpected can be 0 if function returns false
+		// or if the transfer hasn't started yet, so be careful to check for that before dividing to get a percentage
+		virtual bool	GetUGCDownloadProgress( UGCHandle_t hContent, int32 *pnBytesDownloaded, int32 *pnBytesExpected ) = 0;
+
+		// Gets metadata for a file after it has been downloaded. This is the same metadata given in the RemoteStorageDownloadUGCResult_t call result
+		virtual bool	GetUGCDetails( UGCHandle_t hContent, AppId_t *pnAppID, OUT_STRING() char **ppchName, int32 *pnFileSizeInBytes, OUT_STRUCT() CSteamID *pSteamIDOwner ) = 0;
+
+		// After download, gets the content of the file.  
+		// Small files can be read all at once by calling this function with an offset of 0 and cubDataToRead equal to the size of the file.
+		// Larger files can be read in chunks to reduce memory usage (since both sides of the IPC client and the game itself must allocate
+		// enough memory for each chunk).  Once the last byte is read, the file is implicitly closed and further calls to UGCRead will fail
+		// unless UGCDownload is called again.
+		// For especially large files (anything over 100MB) it is a requirement that the file is read in chunks.
+		virtual int32	UGCRead( UGCHandle_t hContent, void *pvData, int32 cubDataToRead, uint32 cOffset, EUGCReadAction eAction ) = 0;
+
+		// Functions to iterate through UGC that has finished downloading but has not yet been read via UGCRead()
+		virtual int32	GetCachedUGCCount() = 0;
+		virtual	UGCHandle_t GetCachedUGCHandle( int32 iCachedContent ) = 0;
+
+		// The following functions are only necessary on the Playstation 3. On PC & Mac, the Steam client will handle these operations for you
+		// On Playstation 3, the game controls which files are stored in the cloud, via FilePersist, FileFetch, and FileForget.
+			
+#if defined(_PS3) || defined(_SERVER)
+		// Connect to Steam and get a list of files in the Cloud - results in a RemoteStorageAppSyncStatusCheck_t callback
+		virtual void GetFileListFromServer() = 0;
+		// Indicate this file should be downloaded in the next sync
+		virtual bool FileFetch( const char *pchFile ) = 0;
+		// Indicate this file should be persisted in the next sync
+		virtual bool FilePersist( const char *pchFile ) = 0;
+		// Pull any requested files down from the Cloud - results in a RemoteStorageAppSyncedClient_t callback
+		virtual bool SynchronizeToClient() = 0;
+		// Upload any requested files to the Cloud - results in a RemoteStorageAppSyncedServer_t callback
+		virtual bool SynchronizeToServer() = 0;
+		// Reset any fetch/persist/etc requests
+		virtual bool ResetFileRequestState() = 0;
+#endif
+
+		// publishing UGC
+		CALL_RESULT( RemoteStoragePublishFileProgress_t )
+		virtual SteamAPICall_t	PublishWorkshopFile( const char *pchFile, const char *pchPreviewFile, AppId_t nConsumerAppId, const char *pchTitle, const char *pchDescription, ERemoteStoragePublishedFileVisibility eVisibility, SteamParamStringArray_t *pTags, EWorkshopFileType eWorkshopFileType ) = 0;
+		virtual PublishedFileUpdateHandle_t CreatePublishedFileUpdateRequest( PublishedFileId_t unPublishedFileId ) = 0;
+		virtual bool UpdatePublishedFileFile( PublishedFileUpdateHandle_t updateHandle, const char *pchFile ) = 0;
+		virtual bool UpdatePublishedFilePreviewFile( PublishedFileUpdateHandle_t updateHandle, const char *pchPreviewFile ) = 0;
+		virtual bool UpdatePublishedFileTitle( PublishedFileUpdateHandle_t updateHandle, const char *pchTitle ) = 0;
+		virtual bool UpdatePublishedFileDescription( PublishedFileUpdateHandle_t updateHandle, const char *pchDescription ) = 0;
+		virtual bool UpdatePublishedFileVisibility( PublishedFileUpdateHandle_t updateHandle, ERemoteStoragePublishedFileVisibility eVisibility ) = 0;
+		virtual bool UpdatePublishedFileTags( PublishedFileUpdateHandle_t updateHandle, SteamParamStringArray_t *pTags ) = 0;
+		CALL_RESULT( RemoteStorageUpdatePublishedFileResult_t )
+		virtual SteamAPICall_t	CommitPublishedFileUpdate( PublishedFileUpdateHandle_t updateHandle ) = 0;
+		// Gets published file details for the given publishedfileid.  If unMaxSecondsOld is greater than 0,
+		// cached data may be returned, depending on how long ago it was cached.  A value of 0 will force a refresh.
+		// A value of k_WorkshopForceLoadPublishedFileDetailsFromCache will use cached data if it exists, no matter how old it is.
+		CALL_RESULT( RemoteStorageGetPublishedFileDetailsResult_t )
+		virtual SteamAPICall_t	GetPublishedFileDetails( PublishedFileId_t unPublishedFileId, uint32 unMaxSecondsOld ) = 0;
+		CALL_RESULT( RemoteStorageDeletePublishedFileResult_t )
+		virtual SteamAPICall_t	DeletePublishedFile( PublishedFileId_t unPublishedFileId ) = 0;
+		// enumerate the files that the current user published with this app
+		CALL_RESULT( RemoteStorageEnumerateUserPublishedFilesResult_t )
+		virtual SteamAPICall_t	EnumerateUserPublishedFiles( uint32 unStartIndex ) = 0;
+		CALL_RESULT( RemoteStorageSubscribePublishedFileResult_t )
+		virtual SteamAPICall_t	SubscribePublishedFile( PublishedFileId_t unPublishedFileId ) = 0;
+		CALL_RESULT( RemoteStorageEnumerateUserSubscribedFilesResult_t )
+		virtual SteamAPICall_t	EnumerateUserSubscribedFiles( uint32 unStartIndex ) = 0;
+		CALL_RESULT( RemoteStorageUnsubscribePublishedFileResult_t )
+		virtual SteamAPICall_t	UnsubscribePublishedFile( PublishedFileId_t unPublishedFileId ) = 0;
+		virtual bool UpdatePublishedFileSetChangeDescription( PublishedFileUpdateHandle_t updateHandle, const char *pchChangeDescription ) = 0;
+		CALL_RESULT( RemoteStorageGetPublishedItemVoteDetailsResult_t )
+		virtual SteamAPICall_t	GetPublishedItemVoteDetails( PublishedFileId_t unPublishedFileId ) = 0;
+		CALL_RESULT( RemoteStorageUpdateUserPublishedItemVoteResult_t )
+		virtual SteamAPICall_t	UpdateUserPublishedItemVote( PublishedFileId_t unPublishedFileId, bool bVoteUp ) = 0;
+		CALL_RESULT( RemoteStorageGetPublishedItemVoteDetailsResult_t )
+		virtual SteamAPICall_t	GetUserPublishedItemVoteDetails( PublishedFileId_t unPublishedFileId ) = 0;
+		CALL_RESULT( RemoteStorageEnumerateUserPublishedFilesResult_t )
+		virtual SteamAPICall_t	EnumerateUserSharedWorkshopFiles( CSteamID steamId, uint32 unStartIndex, SteamParamStringArray_t *pRequiredTags, SteamParamStringArray_t *pExcludedTags ) = 0;
+		CALL_RESULT( RemoteStoragePublishFileProgress_t )
+		virtual SteamAPICall_t	PublishVideo( EWorkshopVideoProvider eVideoProvider, const char *pchVideoAccount, const char *pchVideoIdentifier, const char *pchPreviewFile, AppId_t nConsumerAppId, const char *pchTitle, const char *pchDescription, ERemoteStoragePublishedFileVisibility eVisibility, SteamParamStringArray_t *pTags ) = 0;
+		CALL_RESULT( RemoteStorageSetUserPublishedFileActionResult_t )
+		virtual SteamAPICall_t	SetUserPublishedFileAction( PublishedFileId_t unPublishedFileId, EWorkshopFileAction eAction ) = 0;
+		CALL_RESULT( RemoteStorageEnumeratePublishedFilesByUserActionResult_t )
+		virtual SteamAPICall_t	EnumeratePublishedFilesByUserAction( EWorkshopFileAction eAction, uint32 unStartIndex ) = 0;
+		// this method enumerates the public view of workshop files
+		CALL_RESULT( RemoteStorageEnumerateWorkshopFilesResult_t )
+		virtual SteamAPICall_t	EnumeratePublishedWorkshopFiles( EWorkshopEnumerationType eEnumerationType, uint32 unStartIndex, uint32 unCount, uint32 unDays, SteamParamStringArray_t *pTags, SteamParamStringArray_t *pUserTags ) = 0;
+
+		CALL_RESULT( RemoteStorageDownloadUGCResult_t )
+		virtual SteamAPICall_t UGCDownloadToLocation( UGCHandle_t hContent, const char *pchLocation, uint32 unPriority ) = 0;
+};
+
+#define STEAMREMOTESTORAGE_INTERFACE_VERSION "STEAMREMOTESTORAGE_INTERFACE_VERSION014"
+
+
+// callbacks
+#if defined( VALVE_CALLBACK_PACK_SMALL )
+#pragma pack( push, 4 )
+#elif defined( VALVE_CALLBACK_PACK_LARGE )
+#pragma pack( push, 8 )
+#else
+#error isteamclient.h must be included
+#endif 
+
+//-----------------------------------------------------------------------------
+// Purpose: sent when the local file cache is fully synced with the server for an app
+//          That means that an application can be started and has all latest files
+//-----------------------------------------------------------------------------
+struct RemoteStorageAppSyncedClient_t
+{
+	enum { k_iCallback = k_iClientRemoteStorageCallbacks + 1 };
+	AppId_t m_nAppID;
+	EResult m_eResult;
+	int m_unNumDownloads;
+};
+
+//-----------------------------------------------------------------------------
+// Purpose: sent when the server is fully synced with the local file cache for an app
+//          That means that we can shutdown Steam and our data is stored on the server
+//-----------------------------------------------------------------------------
+struct RemoteStorageAppSyncedServer_t
+{
+	enum { k_iCallback = k_iClientRemoteStorageCallbacks + 2 };
+	AppId_t m_nAppID;
+	EResult m_eResult;
+	int m_unNumUploads;
+};
+
+//-----------------------------------------------------------------------------
+// Purpose: Status of up and downloads during a sync session
+//       
+//-----------------------------------------------------------------------------
+struct RemoteStorageAppSyncProgress_t
+{
+	enum { k_iCallback = k_iClientRemoteStorageCallbacks + 3 };
+	char m_rgchCurrentFile[k_cchFilenameMax];				// Current file being transferred
+	AppId_t m_nAppID;							// App this info relates to
+	uint32 m_uBytesTransferredThisChunk;		// Bytes transferred this chunk
+	double m_dAppPercentComplete;				// Percent complete that this app's transfers are
+	bool m_bUploading;							// if false, downloading
+};
+
+//
+// IMPORTANT! k_iClientRemoteStorageCallbacks + 4 is used, see iclientremotestorage.h
+//
+
+
+//-----------------------------------------------------------------------------
+// Purpose: Sent after we've determined the list of files that are out of sync
+//          with the server.
+//-----------------------------------------------------------------------------
+struct RemoteStorageAppSyncStatusCheck_t
+{
+	enum { k_iCallback = k_iClientRemoteStorageCallbacks + 5 };
+	AppId_t m_nAppID;
+	EResult m_eResult;
+};
+
+
+//-----------------------------------------------------------------------------
+// Purpose: The result of a call to FileShare()
+//-----------------------------------------------------------------------------
+struct RemoteStorageFileShareResult_t
+{
+	enum { k_iCallback = k_iClientRemoteStorageCallbacks + 7 };
+	EResult m_eResult;			// The result of the operation
+	UGCHandle_t m_hFile;		// The handle that can be shared with users and features
+	char m_rgchFilename[k_cchFilenameMax]; // The name of the file that was shared
+};
+
+
+// k_iClientRemoteStorageCallbacks + 8 is deprecated! Do not reuse
+
+
+//-----------------------------------------------------------------------------
+// Purpose: The result of a call to PublishFile()
+//-----------------------------------------------------------------------------
+struct RemoteStoragePublishFileResult_t
+{
+	enum { k_iCallback = k_iClientRemoteStorageCallbacks + 9 };
+	EResult m_eResult;				// The result of the operation.
+	PublishedFileId_t m_nPublishedFileId;
+	bool m_bUserNeedsToAcceptWorkshopLegalAgreement;
+};
+
+
+//-----------------------------------------------------------------------------
+// Purpose: The result of a call to DeletePublishedFile()
+//-----------------------------------------------------------------------------
+struct RemoteStorageDeletePublishedFileResult_t
+{
+	enum { k_iCallback = k_iClientRemoteStorageCallbacks + 11 };
+	EResult m_eResult;				// The result of the operation.
+	PublishedFileId_t m_nPublishedFileId;
+};
+
+
+//-----------------------------------------------------------------------------
+// Purpose: The result of a call to EnumerateUserPublishedFiles()
+//-----------------------------------------------------------------------------
+struct RemoteStorageEnumerateUserPublishedFilesResult_t
+{
+	enum { k_iCallback = k_iClientRemoteStorageCallbacks + 12 };
+	EResult m_eResult;				// The result of the operation.
+	int32 m_nResultsReturned;
+	int32 m_nTotalResultCount;
+	PublishedFileId_t m_rgPublishedFileId[ k_unEnumeratePublishedFilesMaxResults ];
+};
+
+
+//-----------------------------------------------------------------------------
+// Purpose: The result of a call to SubscribePublishedFile()
+//-----------------------------------------------------------------------------
+struct RemoteStorageSubscribePublishedFileResult_t
+{
+	enum { k_iCallback = k_iClientRemoteStorageCallbacks + 13 };
+	EResult m_eResult;				// The result of the operation.
+	PublishedFileId_t m_nPublishedFileId;
+};
+
+
+//-----------------------------------------------------------------------------
+// Purpose: The result of a call to EnumerateSubscribePublishedFiles()
+//-----------------------------------------------------------------------------
+struct RemoteStorageEnumerateUserSubscribedFilesResult_t
+{
+	enum { k_iCallback = k_iClientRemoteStorageCallbacks + 14 };
+	EResult m_eResult;				// The result of the operation.
+	int32 m_nResultsReturned;
+	int32 m_nTotalResultCount;
+	PublishedFileId_t m_rgPublishedFileId[ k_unEnumeratePublishedFilesMaxResults ];
+	uint32 m_rgRTimeSubscribed[ k_unEnumeratePublishedFilesMaxResults ];
+};
+
+#if defined(VALVE_CALLBACK_PACK_SMALL)
+	VALVE_COMPILE_TIME_ASSERT( sizeof( RemoteStorageEnumerateUserSubscribedFilesResult_t ) == (1 + 1 + 1 + 50 + 100) * 4 );
+#elif defined(VALVE_CALLBACK_PACK_LARGE)
+	VALVE_COMPILE_TIME_ASSERT( sizeof( RemoteStorageEnumerateUserSubscribedFilesResult_t ) == (1 + 1 + 1 + 50 + 100) * 4 + 4 );
+#else
+#warning You must first include isteamclient.h
+#endif
+
+//-----------------------------------------------------------------------------
+// Purpose: The result of a call to UnsubscribePublishedFile()
+//-----------------------------------------------------------------------------
+struct RemoteStorageUnsubscribePublishedFileResult_t
+{
+	enum { k_iCallback = k_iClientRemoteStorageCallbacks + 15 };
+	EResult m_eResult;				// The result of the operation.
+	PublishedFileId_t m_nPublishedFileId;
+};
+
+
+//-----------------------------------------------------------------------------
+// Purpose: The result of a call to CommitPublishedFileUpdate()
+//-----------------------------------------------------------------------------
+struct RemoteStorageUpdatePublishedFileResult_t
+{
+	enum { k_iCallback = k_iClientRemoteStorageCallbacks + 16 };
+	EResult m_eResult;				// The result of the operation.
+	PublishedFileId_t m_nPublishedFileId;
+	bool m_bUserNeedsToAcceptWorkshopLegalAgreement;
+};
+
+
+//-----------------------------------------------------------------------------
+// Purpose: The result of a call to UGCDownload()
+//-----------------------------------------------------------------------------
+struct RemoteStorageDownloadUGCResult_t
+{
+	enum { k_iCallback = k_iClientRemoteStorageCallbacks + 17 };
+	EResult m_eResult;				// The result of the operation.
+	UGCHandle_t m_hFile;			// The handle to the file that was attempted to be downloaded.
+	AppId_t m_nAppID;				// ID of the app that created this file.
+	int32 m_nSizeInBytes;			// The size of the file that was downloaded, in bytes.
+	char m_pchFileName[k_cchFilenameMax];		// The name of the file that was downloaded. 
+	uint64 m_ulSteamIDOwner;		// Steam ID of the user who created this content.
+};
+
+
+//-----------------------------------------------------------------------------
+// Purpose: The result of a call to GetPublishedFileDetails()
+//-----------------------------------------------------------------------------
+struct RemoteStorageGetPublishedFileDetailsResult_t
+{
+	enum { k_iCallback = k_iClientRemoteStorageCallbacks + 18 };
+	EResult m_eResult;				// The result of the operation.
+	PublishedFileId_t m_nPublishedFileId;
+	AppId_t m_nCreatorAppID;		// ID of the app that created this file.
+	AppId_t m_nConsumerAppID;		// ID of the app that will consume this file.
+	char m_rgchTitle[k_cchPublishedDocumentTitleMax];		// title of document
+	char m_rgchDescription[k_cchPublishedDocumentDescriptionMax];	// description of document
+	UGCHandle_t m_hFile;			// The handle of the primary file
+	UGCHandle_t m_hPreviewFile;		// The handle of the preview file
+	uint64 m_ulSteamIDOwner;		// Steam ID of the user who created this content.
+	uint32 m_rtimeCreated;			// time when the published file was created
+	uint32 m_rtimeUpdated;			// time when the published file was last updated
+	ERemoteStoragePublishedFileVisibility m_eVisibility;
+	bool m_bBanned;
+	char m_rgchTags[k_cchTagListMax];	// comma separated list of all tags associated with this file
+	bool m_bTagsTruncated;			// whether the list of tags was too long to be returned in the provided buffer
+	char m_pchFileName[k_cchFilenameMax];		// The name of the primary file
+	int32 m_nFileSize;				// Size of the primary file
+	int32 m_nPreviewFileSize;		// Size of the preview file
+	char m_rgchURL[k_cchPublishedFileURLMax];	// URL (for a video or a website)
+	EWorkshopFileType m_eFileType;	// Type of the file
+	bool m_bAcceptedForUse;			// developer has specifically flagged this item as accepted in the Workshop
+};
+
+
+struct RemoteStorageEnumerateWorkshopFilesResult_t
+{
+	enum { k_iCallback = k_iClientRemoteStorageCallbacks + 19 };
+	EResult m_eResult;
+	int32 m_nResultsReturned;
+	int32 m_nTotalResultCount;
+	PublishedFileId_t m_rgPublishedFileId[ k_unEnumeratePublishedFilesMaxResults ];
+	float m_rgScore[ k_unEnumeratePublishedFilesMaxResults ];
+	AppId_t m_nAppId;
+	uint32 m_unStartIndex;
+};
+
+
+//-----------------------------------------------------------------------------
+// Purpose: The result of GetPublishedItemVoteDetails
+//-----------------------------------------------------------------------------
+struct RemoteStorageGetPublishedItemVoteDetailsResult_t
+{
+	enum { k_iCallback = k_iClientRemoteStorageCallbacks + 20 };
+	EResult m_eResult;
+	PublishedFileId_t m_unPublishedFileId;
+	int32 m_nVotesFor;
+	int32 m_nVotesAgainst;
+	int32 m_nReports;
+	float m_fScore;
+};
+
+
+//-----------------------------------------------------------------------------
+// Purpose: User subscribed to a file for the app (from within the app or on the web)
+//-----------------------------------------------------------------------------
+struct RemoteStoragePublishedFileSubscribed_t
+{
+	enum { k_iCallback = k_iClientRemoteStorageCallbacks + 21 };
+	PublishedFileId_t m_nPublishedFileId;	// The published file id
+	AppId_t m_nAppID;						// ID of the app that will consume this file.
+};
+
+//-----------------------------------------------------------------------------
+// Purpose: User unsubscribed from a file for the app (from within the app or on the web)
+//-----------------------------------------------------------------------------
+struct RemoteStoragePublishedFileUnsubscribed_t
+{
+	enum { k_iCallback = k_iClientRemoteStorageCallbacks + 22 };
+	PublishedFileId_t m_nPublishedFileId;	// The published file id
+	AppId_t m_nAppID;						// ID of the app that will consume this file.
+};
+
+
+//-----------------------------------------------------------------------------
+// Purpose: Published file that a user owns was deleted (from within the app or the web)
+//-----------------------------------------------------------------------------
+struct RemoteStoragePublishedFileDeleted_t
+{
+	enum { k_iCallback = k_iClientRemoteStorageCallbacks + 23 };
+	PublishedFileId_t m_nPublishedFileId;	// The published file id
+	AppId_t m_nAppID;						// ID of the app that will consume this file.
+};
+
+
+//-----------------------------------------------------------------------------
+// Purpose: The result of a call to UpdateUserPublishedItemVote()
+//-----------------------------------------------------------------------------
+struct RemoteStorageUpdateUserPublishedItemVoteResult_t
+{
+	enum { k_iCallback = k_iClientRemoteStorageCallbacks + 24 };
+	EResult m_eResult;				// The result of the operation.
+	PublishedFileId_t m_nPublishedFileId;	// The published file id
+};
+
+
+//-----------------------------------------------------------------------------
+// Purpose: The result of a call to GetUserPublishedItemVoteDetails()
+//-----------------------------------------------------------------------------
+struct RemoteStorageUserVoteDetails_t
+{
+	enum { k_iCallback = k_iClientRemoteStorageCallbacks + 25 };
+	EResult m_eResult;				// The result of the operation.
+	PublishedFileId_t m_nPublishedFileId;	// The published file id
+	EWorkshopVote m_eVote;			// what the user voted
+};
+
+struct RemoteStorageEnumerateUserSharedWorkshopFilesResult_t
+{
+	enum { k_iCallback = k_iClientRemoteStorageCallbacks + 26 };
+	EResult m_eResult;				// The result of the operation.
+	int32 m_nResultsReturned;
+	int32 m_nTotalResultCount;
+	PublishedFileId_t m_rgPublishedFileId[ k_unEnumeratePublishedFilesMaxResults ];
+};
+
+struct RemoteStorageSetUserPublishedFileActionResult_t
+{
+	enum { k_iCallback = k_iClientRemoteStorageCallbacks + 27 };
+	EResult m_eResult;				// The result of the operation.
+	PublishedFileId_t m_nPublishedFileId;	// The published file id
+	EWorkshopFileAction m_eAction;	// the action that was attempted
+};
+
+struct RemoteStorageEnumeratePublishedFilesByUserActionResult_t
+{
+	enum { k_iCallback = k_iClientRemoteStorageCallbacks + 28 };
+	EResult m_eResult;				// The result of the operation.
+	EWorkshopFileAction m_eAction;	// the action that was filtered on
+	int32 m_nResultsReturned;
+	int32 m_nTotalResultCount;
+	PublishedFileId_t m_rgPublishedFileId[ k_unEnumeratePublishedFilesMaxResults ];
+	uint32 m_rgRTimeUpdated[ k_unEnumeratePublishedFilesMaxResults ];
+};
+
+
+//-----------------------------------------------------------------------------
+// Purpose: Called periodically while a PublishWorkshopFile is in progress
+//-----------------------------------------------------------------------------
+struct RemoteStoragePublishFileProgress_t
+{
+	enum { k_iCallback = k_iClientRemoteStorageCallbacks + 29 };
+	double m_dPercentFile;
+	bool m_bPreview;
+};
+
+
+//-----------------------------------------------------------------------------
+// Purpose: Called when the content for a published file is updated
+//-----------------------------------------------------------------------------
+struct RemoteStoragePublishedFileUpdated_t
+{
+	enum { k_iCallback = k_iClientRemoteStorageCallbacks + 30 };
+	PublishedFileId_t m_nPublishedFileId;	// The published file id
+	AppId_t m_nAppID;						// ID of the app that will consume this file.
+	uint64 m_ulUnused;						// not used anymore
+};
+
+//-----------------------------------------------------------------------------
+// Purpose: Called when a FileWriteAsync completes
+//-----------------------------------------------------------------------------
+struct RemoteStorageFileWriteAsyncComplete_t
+{
+	enum { k_iCallback = k_iClientRemoteStorageCallbacks + 31 };
+	EResult	m_eResult;						// result
+};
+
+//-----------------------------------------------------------------------------
+// Purpose: Called when a FileReadAsync completes
+//-----------------------------------------------------------------------------
+struct RemoteStorageFileReadAsyncComplete_t
+{
+	enum { k_iCallback = k_iClientRemoteStorageCallbacks + 32 };
+	SteamAPICall_t m_hFileReadAsync;		// call handle of the async read which was made
+	EResult	m_eResult;						// result
+	uint32 m_nOffset;						// offset in the file this read was at
+	uint32 m_cubRead;						// amount read - will the <= the amount requested
+};
+
+#pragma pack( pop )
+
+
+#endif // ISTEAMREMOTESTORAGE_H

--- a/Common/Chairloader/SteamAPI/isteamscreenshots.h
+++ b/Common/Chairloader/SteamAPI/isteamscreenshots.h
@@ -1,0 +1,116 @@
+//====== Copyright � 1996-2008, Valve Corporation, All rights reserved. =======
+//
+// Purpose: public interface to user remote file storage in Steam
+//
+//=============================================================================
+
+#ifndef ISTEAMSCREENSHOTS_H
+#define ISTEAMSCREENSHOTS_H
+#ifdef _WIN32
+#pragma once
+#endif
+
+#include "isteamclient.h"
+
+const uint32 k_nScreenshotMaxTaggedUsers = 32;
+const uint32 k_nScreenshotMaxTaggedPublishedFiles = 32;
+const int k_cubUFSTagTypeMax = 255;
+const int k_cubUFSTagValueMax = 255;
+
+// Required with of a thumbnail provided to AddScreenshotToLibrary.  If you do not provide a thumbnail
+// one will be generated.
+const int k_ScreenshotThumbWidth = 200;
+
+// Handle is valid for the lifetime of your process and no longer
+typedef uint32 ScreenshotHandle; 
+#define INVALID_SCREENSHOT_HANDLE 0
+
+enum EVRScreenshotType
+{
+	k_EVRScreenshotType_None			= 0,
+	k_EVRScreenshotType_Mono			= 1,
+	k_EVRScreenshotType_Stereo			= 2,
+	k_EVRScreenshotType_MonoCubemap		= 3,
+	k_EVRScreenshotType_MonoPanorama	= 4,
+	k_EVRScreenshotType_StereoPanorama	= 5
+};
+
+//-----------------------------------------------------------------------------
+// Purpose: Functions for adding screenshots to the user's screenshot library
+//-----------------------------------------------------------------------------
+class ISteamScreenshots
+{
+public:
+	// Writes a screenshot to the user's screenshot library given the raw image data, which must be in RGB format.
+	// The return value is a handle that is valid for the duration of the game process and can be used to apply tags.
+	virtual ScreenshotHandle WriteScreenshot( void *pubRGB, uint32 cubRGB, int nWidth, int nHeight ) = 0;
+
+	// Adds a screenshot to the user's screenshot library from disk.  If a thumbnail is provided, it must be 200 pixels wide and the same aspect ratio
+	// as the screenshot, otherwise a thumbnail will be generated if the user uploads the screenshot.  The screenshots must be in either JPEG or TGA format.
+	// The return value is a handle that is valid for the duration of the game process and can be used to apply tags.
+	// JPEG, TGA, and PNG formats are supported.
+	virtual ScreenshotHandle AddScreenshotToLibrary( const char *pchFilename, const char *pchThumbnailFilename, int nWidth, int nHeight ) = 0;
+
+	// Causes the Steam overlay to take a screenshot.  If screenshots are being hooked by the game then a ScreenshotRequested_t callback is sent back to the game instead. 
+	virtual void TriggerScreenshot() = 0;
+
+	// Toggles whether the overlay handles screenshots when the user presses the screenshot hotkey, or the game handles them.  If the game is hooking screenshots,
+	// then the ScreenshotRequested_t callback will be sent if the user presses the hotkey, and the game is expected to call WriteScreenshot or AddScreenshotToLibrary
+	// in response.
+	virtual void HookScreenshots( bool bHook ) = 0;
+
+	// Sets metadata about a screenshot's location (for example, the name of the map)
+	virtual bool SetLocation( ScreenshotHandle hScreenshot, const char *pchLocation ) = 0;
+	
+	// Tags a user as being visible in the screenshot
+	virtual bool TagUser( ScreenshotHandle hScreenshot, CSteamID steamID ) = 0;
+
+	// Tags a published file as being visible in the screenshot
+	virtual bool TagPublishedFile( ScreenshotHandle hScreenshot, PublishedFileId_t unPublishedFileID ) = 0;
+
+	// Returns true if the app has hooked the screenshot
+	virtual bool IsScreenshotsHooked() = 0;
+
+	// Adds a VR screenshot to the user's screenshot library from disk in the supported type.
+	// pchFilename should be the normal 2D image used in the library view
+	// pchVRFilename should contain the image that matches the correct type
+	// The return value is a handle that is valid for the duration of the game process and can be used to apply tags.
+	// JPEG, TGA, and PNG formats are supported.
+	virtual ScreenshotHandle AddVRScreenshotToLibrary( EVRScreenshotType eType, const char *pchFilename, const char *pchVRFilename ) = 0;
+};
+
+#define STEAMSCREENSHOTS_INTERFACE_VERSION "STEAMSCREENSHOTS_INTERFACE_VERSION003"
+
+// callbacks
+#if defined( VALVE_CALLBACK_PACK_SMALL )
+#pragma pack( push, 4 )
+#elif defined( VALVE_CALLBACK_PACK_LARGE )
+#pragma pack( push, 8 )
+#else
+#error isteamclient.h must be included
+#endif 
+//-----------------------------------------------------------------------------
+// Purpose: Screenshot successfully written or otherwise added to the library
+// and can now be tagged
+//-----------------------------------------------------------------------------
+struct ScreenshotReady_t
+{
+	enum { k_iCallback = k_iSteamScreenshotsCallbacks + 1 };
+	ScreenshotHandle m_hLocal;
+	EResult m_eResult;
+};
+
+//-----------------------------------------------------------------------------
+// Purpose: Screenshot has been requested by the user.  Only sent if
+// HookScreenshots() has been called, in which case Steam will not take
+// the screenshot itself.
+//-----------------------------------------------------------------------------
+struct ScreenshotRequested_t
+{
+	enum { k_iCallback = k_iSteamScreenshotsCallbacks + 2 };
+};
+
+#pragma pack( pop )
+
+#endif // ISTEAMSCREENSHOTS_H
+

--- a/Common/Chairloader/SteamAPI/isteamugc.h
+++ b/Common/Chairloader/SteamAPI/isteamugc.h
@@ -1,0 +1,453 @@
+//====== Copyright 1996-2013, Valve Corporation, All rights reserved. =======
+//
+// Purpose: interface to steam ugc
+//
+//=============================================================================
+
+#ifndef ISTEAMUGC_H
+#define ISTEAMUGC_H
+#ifdef _WIN32
+#pragma once
+#endif
+
+#include "isteamclient.h"
+
+// callbacks
+#if defined( VALVE_CALLBACK_PACK_SMALL )
+#pragma pack( push, 4 )
+#elif defined( VALVE_CALLBACK_PACK_LARGE )
+#pragma pack( push, 8 )
+#else
+#error isteamclient.h must be included
+#endif 
+
+
+typedef uint64 UGCQueryHandle_t;
+typedef uint64 UGCUpdateHandle_t;
+
+
+const UGCQueryHandle_t k_UGCQueryHandleInvalid = 0xffffffffffffffffull;
+const UGCUpdateHandle_t k_UGCUpdateHandleInvalid = 0xffffffffffffffffull;
+
+
+// Matching UGC types for queries
+enum EUGCMatchingUGCType
+{
+	k_EUGCMatchingUGCType_Items				 = 0,		// both mtx items and ready-to-use items
+	k_EUGCMatchingUGCType_Items_Mtx			 = 1,
+	k_EUGCMatchingUGCType_Items_ReadyToUse	 = 2,
+	k_EUGCMatchingUGCType_Collections		 = 3,
+	k_EUGCMatchingUGCType_Artwork			 = 4,
+	k_EUGCMatchingUGCType_Videos			 = 5,
+	k_EUGCMatchingUGCType_Screenshots		 = 6,
+	k_EUGCMatchingUGCType_AllGuides			 = 7,		// both web guides and integrated guides
+	k_EUGCMatchingUGCType_WebGuides			 = 8,
+	k_EUGCMatchingUGCType_IntegratedGuides	 = 9,
+	k_EUGCMatchingUGCType_UsableInGame		 = 10,		// ready-to-use items and integrated guides
+	k_EUGCMatchingUGCType_ControllerBindings = 11,
+	k_EUGCMatchingUGCType_GameManagedItems	 = 12,		// game managed items (not managed by users)
+	k_EUGCMatchingUGCType_All				 = ~0,		// return everything
+};
+
+// Different lists of published UGC for a user.
+// If the current logged in user is different than the specified user, then some options may not be allowed.
+enum EUserUGCList
+{
+	k_EUserUGCList_Published,
+	k_EUserUGCList_VotedOn,
+	k_EUserUGCList_VotedUp,
+	k_EUserUGCList_VotedDown,
+	k_EUserUGCList_WillVoteLater,
+	k_EUserUGCList_Favorited,
+	k_EUserUGCList_Subscribed,
+	k_EUserUGCList_UsedOrPlayed,
+	k_EUserUGCList_Followed,
+};
+
+// Sort order for user published UGC lists (defaults to creation order descending)
+enum EUserUGCListSortOrder
+{
+	k_EUserUGCListSortOrder_CreationOrderDesc,
+	k_EUserUGCListSortOrder_CreationOrderAsc,
+	k_EUserUGCListSortOrder_TitleAsc,
+	k_EUserUGCListSortOrder_LastUpdatedDesc,
+	k_EUserUGCListSortOrder_SubscriptionDateDesc,
+	k_EUserUGCListSortOrder_VoteScoreDesc,
+	k_EUserUGCListSortOrder_ForModeration,
+};
+
+// Combination of sorting and filtering for queries across all UGC
+enum EUGCQuery
+{
+	k_EUGCQuery_RankedByVote								  = 0,
+	k_EUGCQuery_RankedByPublicationDate						  = 1,
+	k_EUGCQuery_AcceptedForGameRankedByAcceptanceDate		  = 2,
+	k_EUGCQuery_RankedByTrend								  = 3,
+	k_EUGCQuery_FavoritedByFriendsRankedByPublicationDate	  = 4,
+	k_EUGCQuery_CreatedByFriendsRankedByPublicationDate		  = 5,
+	k_EUGCQuery_RankedByNumTimesReported					  = 6,
+	k_EUGCQuery_CreatedByFollowedUsersRankedByPublicationDate = 7,
+	k_EUGCQuery_NotYetRated									  = 8,
+	k_EUGCQuery_RankedByTotalVotesAsc						  = 9,
+	k_EUGCQuery_RankedByVotesUp								  = 10,
+	k_EUGCQuery_RankedByTextSearch							  = 11,
+	k_EUGCQuery_RankedByTotalUniqueSubscriptions			  = 12,
+	k_EUGCQuery_RankedByPlaytimeTrend						  = 13,
+	k_EUGCQuery_RankedByTotalPlaytime						  = 14,
+	k_EUGCQuery_RankedByAveragePlaytimeTrend				  = 15,
+	k_EUGCQuery_RankedByLifetimeAveragePlaytime				  = 16,
+	k_EUGCQuery_RankedByPlaytimeSessionsTrend				  = 17,
+	k_EUGCQuery_RankedByLifetimePlaytimeSessions			  = 18,
+};
+
+enum EItemUpdateStatus
+{
+	k_EItemUpdateStatusInvalid 				= 0, // The item update handle was invalid, job might be finished, listen too SubmitItemUpdateResult_t
+	k_EItemUpdateStatusPreparingConfig 		= 1, // The item update is processing configuration data
+	k_EItemUpdateStatusPreparingContent		= 2, // The item update is reading and processing content files
+	k_EItemUpdateStatusUploadingContent		= 3, // The item update is uploading content changes to Steam
+	k_EItemUpdateStatusUploadingPreviewFile	= 4, // The item update is uploading new preview file image
+	k_EItemUpdateStatusCommittingChanges	= 5  // The item update is committing all changes
+};
+
+enum EItemState
+{
+	k_EItemStateNone			= 0,	// item not tracked on client
+	k_EItemStateSubscribed		= 1,	// current user is subscribed to this item. Not just cached.
+	k_EItemStateLegacyItem		= 2,	// item was created with ISteamRemoteStorage
+	k_EItemStateInstalled		= 4,	// item is installed and usable (but maybe out of date)
+	k_EItemStateNeedsUpdate		= 8,	// items needs an update. Either because it's not installed yet or creator updated content
+	k_EItemStateDownloading		= 16,	// item update is currently downloading
+	k_EItemStateDownloadPending	= 32,	// DownloadItem() was called for this item, content isn't available until DownloadItemResult_t is fired
+};
+
+enum EItemStatistic
+{
+	k_EItemStatistic_NumSubscriptions		= 0,
+	k_EItemStatistic_NumFavorites			= 1,
+	k_EItemStatistic_NumFollowers			= 2,
+	k_EItemStatistic_NumUniqueSubscriptions = 3,
+	k_EItemStatistic_NumUniqueFavorites		= 4,
+	k_EItemStatistic_NumUniqueFollowers		= 5,
+	k_EItemStatistic_NumUniqueWebsiteViews	= 6,
+	k_EItemStatistic_ReportScore			= 7,
+	k_EItemStatistic_NumSecondsPlayed		= 8,
+	k_EItemStatistic_NumPlaytimeSessions	= 9,
+	k_EItemStatistic_NumComments			= 10,
+};
+
+enum EItemPreviewType
+{
+	k_EItemPreviewType_Image							= 0,	// standard image file expected (e.g. jpg, png, gif, etc.)
+	k_EItemPreviewType_YouTubeVideo						= 1,	// video id is stored
+	k_EItemPreviewType_Sketchfab						= 2,	// model id is stored
+	k_EItemPreviewType_EnvironmentMap_HorizontalCross	= 3,	// standard image file expected - cube map in the layout
+																// +---+---+-------+
+																// |   |Up |       |
+																// +---+---+---+---+
+																// | L | F | R | B |
+																// +---+---+---+---+
+																// |   |Dn |       |
+																// +---+---+---+---+
+	k_EItemPreviewType_EnvironmentMap_LatLong			= 4,	// standard image file expected
+	k_EItemPreviewType_ReservedMax						= 255,	// you can specify your own types above this value
+};
+
+const uint32 kNumUGCResultsPerPage = 50;
+const uint32 k_cchDeveloperMetadataMax = 5000;
+
+// Details for a single published file/UGC
+struct SteamUGCDetails_t
+{
+	PublishedFileId_t m_nPublishedFileId;
+	EResult m_eResult;												// The result of the operation.	
+	EWorkshopFileType m_eFileType;									// Type of the file
+	AppId_t m_nCreatorAppID;										// ID of the app that created this file.
+	AppId_t m_nConsumerAppID;										// ID of the app that will consume this file.
+	char m_rgchTitle[k_cchPublishedDocumentTitleMax];				// title of document
+	char m_rgchDescription[k_cchPublishedDocumentDescriptionMax];	// description of document
+	uint64 m_ulSteamIDOwner;										// Steam ID of the user who created this content.
+	uint32 m_rtimeCreated;											// time when the published file was created
+	uint32 m_rtimeUpdated;											// time when the published file was last updated
+	uint32 m_rtimeAddedToUserList;									// time when the user added the published file to their list (not always applicable)
+	ERemoteStoragePublishedFileVisibility m_eVisibility;			// visibility
+	bool m_bBanned;													// whether the file was banned
+	bool m_bAcceptedForUse;											// developer has specifically flagged this item as accepted in the Workshop
+	bool m_bTagsTruncated;											// whether the list of tags was too long to be returned in the provided buffer
+	char m_rgchTags[k_cchTagListMax];								// comma separated list of all tags associated with this file	
+	// file/url information
+	UGCHandle_t m_hFile;											// The handle of the primary file
+	UGCHandle_t m_hPreviewFile;										// The handle of the preview file
+	char m_pchFileName[k_cchFilenameMax];							// The cloud filename of the primary file
+	int32 m_nFileSize;												// Size of the primary file
+	int32 m_nPreviewFileSize;										// Size of the preview file
+	char m_rgchURL[k_cchPublishedFileURLMax];						// URL (for a video or a website)
+	// voting information
+	uint32 m_unVotesUp;												// number of votes up
+	uint32 m_unVotesDown;											// number of votes down
+	float m_flScore;												// calculated score
+	// collection details
+	uint32 m_unNumChildren;							
+};
+
+//-----------------------------------------------------------------------------
+// Purpose: Steam UGC support API
+//-----------------------------------------------------------------------------
+class ISteamUGC
+{
+public:
+
+	// Query UGC associated with a user. Creator app id or consumer app id must be valid and be set to the current running app. unPage should start at 1.
+	virtual UGCQueryHandle_t CreateQueryUserUGCRequest( AccountID_t unAccountID, EUserUGCList eListType, EUGCMatchingUGCType eMatchingUGCType, EUserUGCListSortOrder eSortOrder, AppId_t nCreatorAppID, AppId_t nConsumerAppID, uint32 unPage ) = 0;
+
+	// Query for all matching UGC. Creator app id or consumer app id must be valid and be set to the current running app. unPage should start at 1.
+	virtual UGCQueryHandle_t CreateQueryAllUGCRequest( EUGCQuery eQueryType, EUGCMatchingUGCType eMatchingeMatchingUGCTypeFileType, AppId_t nCreatorAppID, AppId_t nConsumerAppID, uint32 unPage ) = 0;
+
+	// Query for the details of the given published file ids (the RequestUGCDetails call is deprecated and replaced with this)
+	virtual UGCQueryHandle_t CreateQueryUGCDetailsRequest( PublishedFileId_t *pvecPublishedFileID, uint32 unNumPublishedFileIDs ) = 0;
+
+	// Send the query to Steam
+	CALL_RESULT( SteamUGCQueryCompleted_t )
+	virtual SteamAPICall_t SendQueryUGCRequest( UGCQueryHandle_t handle ) = 0;
+
+	// Retrieve an individual result after receiving the callback for querying UGC
+	virtual bool GetQueryUGCResult( UGCQueryHandle_t handle, uint32 index, SteamUGCDetails_t *pDetails ) = 0;
+	virtual bool GetQueryUGCPreviewURL( UGCQueryHandle_t handle, uint32 index, OUT_STRING_COUNT(cchURLSize) char *pchURL, uint32 cchURLSize ) = 0;
+	virtual bool GetQueryUGCMetadata( UGCQueryHandle_t handle, uint32 index, OUT_STRING_COUNT(cchMetadatasize) char *pchMetadata, uint32 cchMetadatasize ) = 0;
+	virtual bool GetQueryUGCChildren( UGCQueryHandle_t handle, uint32 index, PublishedFileId_t* pvecPublishedFileID, uint32 cMaxEntries ) = 0;
+	virtual bool GetQueryUGCStatistic( UGCQueryHandle_t handle, uint32 index, EItemStatistic eStatType, uint64 *pStatValue ) = 0;
+	virtual uint32 GetQueryUGCNumAdditionalPreviews( UGCQueryHandle_t handle, uint32 index ) = 0;
+	virtual bool GetQueryUGCAdditionalPreview( UGCQueryHandle_t handle, uint32 index, uint32 previewIndex, OUT_STRING_COUNT(cchURLSize) char *pchURLOrVideoID, uint32 cchURLSize, OUT_STRING_COUNT(cchURLSize) char *pchOriginalFileName, uint32 cchOriginalFileNameSize, EItemPreviewType *pPreviewType ) = 0;
+	virtual uint32 GetQueryUGCNumKeyValueTags( UGCQueryHandle_t handle, uint32 index ) = 0;
+	virtual bool GetQueryUGCKeyValueTag( UGCQueryHandle_t handle, uint32 index, uint32 keyValueTagIndex, OUT_STRING_COUNT(cchKeySize) char *pchKey, uint32 cchKeySize, OUT_STRING_COUNT(cchValueSize) char *pchValue, uint32 cchValueSize ) = 0;
+
+	// Release the request to free up memory, after retrieving results
+	virtual bool ReleaseQueryUGCRequest( UGCQueryHandle_t handle ) = 0;
+
+	// Options to set for querying UGC
+	virtual bool AddRequiredTag( UGCQueryHandle_t handle, const char *pTagName ) = 0;
+	virtual bool AddExcludedTag( UGCQueryHandle_t handle, const char *pTagName ) = 0;
+	virtual bool SetReturnOnlyIDs( UGCQueryHandle_t handle, bool bReturnOnlyIDs ) = 0;
+	virtual bool SetReturnKeyValueTags( UGCQueryHandle_t handle, bool bReturnKeyValueTags ) = 0;
+	virtual bool SetReturnLongDescription( UGCQueryHandle_t handle, bool bReturnLongDescription ) = 0;
+	virtual bool SetReturnMetadata( UGCQueryHandle_t handle, bool bReturnMetadata ) = 0;
+	virtual bool SetReturnChildren( UGCQueryHandle_t handle, bool bReturnChildren ) = 0;
+	virtual bool SetReturnAdditionalPreviews( UGCQueryHandle_t handle, bool bReturnAdditionalPreviews ) = 0;
+	virtual bool SetReturnTotalOnly( UGCQueryHandle_t handle, bool bReturnTotalOnly ) = 0;
+	virtual bool SetLanguage( UGCQueryHandle_t handle, const char *pchLanguage ) = 0;
+	virtual bool SetAllowCachedResponse( UGCQueryHandle_t handle, uint32 unMaxAgeSeconds ) = 0;
+
+	// Options only for querying user UGC
+	virtual bool SetCloudFileNameFilter( UGCQueryHandle_t handle, const char *pMatchCloudFileName ) = 0;
+
+	// Options only for querying all UGC
+	virtual bool SetMatchAnyTag( UGCQueryHandle_t handle, bool bMatchAnyTag ) = 0;
+	virtual bool SetSearchText( UGCQueryHandle_t handle, const char *pSearchText ) = 0;
+	virtual bool SetRankedByTrendDays( UGCQueryHandle_t handle, uint32 unDays ) = 0;
+	virtual bool AddRequiredKeyValueTag( UGCQueryHandle_t handle, const char *pKey, const char *pValue ) = 0;
+
+	// DEPRECATED - Use CreateQueryUGCDetailsRequest call above instead!
+	virtual SteamAPICall_t RequestUGCDetails( PublishedFileId_t nPublishedFileID, uint32 unMaxAgeSeconds ) = 0;
+
+	// Steam Workshop Creator API
+	CALL_RESULT( CreateItemResult_t )
+	virtual SteamAPICall_t CreateItem( AppId_t nConsumerAppId, EWorkshopFileType eFileType ) = 0; // create new item for this app with no content attached yet
+
+	virtual UGCUpdateHandle_t StartItemUpdate( AppId_t nConsumerAppId, PublishedFileId_t nPublishedFileID ) = 0; // start an UGC item update. Set changed properties before commiting update with CommitItemUpdate()
+
+	virtual bool SetItemTitle( UGCUpdateHandle_t handle, const char *pchTitle ) = 0; // change the title of an UGC item
+	virtual bool SetItemDescription( UGCUpdateHandle_t handle, const char *pchDescription ) = 0; // change the description of an UGC item
+	virtual bool SetItemUpdateLanguage( UGCUpdateHandle_t handle, const char *pchLanguage ) = 0; // specify the language of the title or description that will be set
+	virtual bool SetItemMetadata( UGCUpdateHandle_t handle, const char *pchMetaData ) = 0; // change the metadata of an UGC item (max = k_cchDeveloperMetadataMax)
+	virtual bool SetItemVisibility( UGCUpdateHandle_t handle, ERemoteStoragePublishedFileVisibility eVisibility ) = 0; // change the visibility of an UGC item
+	virtual bool SetItemTags( UGCUpdateHandle_t updateHandle, const SteamParamStringArray_t *pTags ) = 0; // change the tags of an UGC item
+	virtual bool SetItemContent( UGCUpdateHandle_t handle, const char *pszContentFolder ) = 0; // update item content from this local folder
+	virtual bool SetItemPreview( UGCUpdateHandle_t handle, const char *pszPreviewFile ) = 0; //  change preview image file for this item. pszPreviewFile points to local image file, which must be under 1MB in size
+	virtual bool RemoveItemKeyValueTags( UGCUpdateHandle_t handle, const char *pchKey ) = 0; // remove any existing key-value tags with the specified key
+	virtual bool AddItemKeyValueTag( UGCUpdateHandle_t handle, const char *pchKey, const char *pchValue ) = 0; // add new key-value tags for the item. Note that there can be multiple values for a tag.
+	virtual bool AddItemPreviewFile( UGCUpdateHandle_t handle, const char *pszPreviewFile, EItemPreviewType type ) = 0; //  add preview file for this item. pszPreviewFile points to local file, which must be under 1MB in size
+	virtual bool AddItemPreviewVideo( UGCUpdateHandle_t handle, const char *pszVideoID ) = 0; //  add preview video for this item
+	virtual bool UpdateItemPreviewFile( UGCUpdateHandle_t handle, uint32 index, const char *pszPreviewFile ) = 0; //  updates an existing preview file for this item. pszPreviewFile points to local file, which must be under 1MB in size
+	virtual bool UpdateItemPreviewVideo( UGCUpdateHandle_t handle, uint32 index, const char *pszVideoID ) = 0; //  updates an existing preview video for this item
+	virtual bool RemoveItemPreview( UGCUpdateHandle_t handle, uint32 index ) = 0; // remove a preview by index starting at 0 (previews are sorted)
+
+	CALL_RESULT( SubmitItemUpdateResult_t )
+	virtual SteamAPICall_t SubmitItemUpdate( UGCUpdateHandle_t handle, const char *pchChangeNote ) = 0; // commit update process started with StartItemUpdate()
+	virtual EItemUpdateStatus GetItemUpdateProgress( UGCUpdateHandle_t handle, uint64 *punBytesProcessed, uint64* punBytesTotal ) = 0;
+
+	// Steam Workshop Consumer API
+	CALL_RESULT( SetUserItemVoteResult_t )
+	virtual SteamAPICall_t SetUserItemVote( PublishedFileId_t nPublishedFileID, bool bVoteUp ) = 0;
+	CALL_RESULT( GetUserItemVoteResult_t )
+	virtual SteamAPICall_t GetUserItemVote( PublishedFileId_t nPublishedFileID ) = 0;
+	CALL_RESULT( UserFavoriteItemsListChanged_t )
+	virtual SteamAPICall_t AddItemToFavorites( AppId_t nAppId, PublishedFileId_t nPublishedFileID ) = 0;
+	CALL_RESULT( UserFavoriteItemsListChanged_t )
+	virtual SteamAPICall_t RemoveItemFromFavorites( AppId_t nAppId, PublishedFileId_t nPublishedFileID ) = 0;
+	CALL_RESULT( RemoteStorageSubscribePublishedFileResult_t )
+	virtual SteamAPICall_t SubscribeItem( PublishedFileId_t nPublishedFileID ) = 0; // subscribe to this item, will be installed ASAP
+	CALL_RESULT( RemoteStorageUnsubscribePublishedFileResult_t )
+	virtual SteamAPICall_t UnsubscribeItem( PublishedFileId_t nPublishedFileID ) = 0; // unsubscribe from this item, will be uninstalled after game quits
+	virtual uint32 GetNumSubscribedItems() = 0; // number of subscribed items 
+	virtual uint32 GetSubscribedItems( PublishedFileId_t* pvecPublishedFileID, uint32 cMaxEntries ) = 0; // all subscribed item PublishFileIDs
+
+	// get EItemState flags about item on this client
+	virtual uint32 GetItemState( PublishedFileId_t nPublishedFileID ) = 0;
+
+	// get info about currently installed content on disc for items that have k_EItemStateInstalled set
+	// if k_EItemStateLegacyItem is set, pchFolder contains the path to the legacy file itself (not a folder)
+	virtual bool GetItemInstallInfo( PublishedFileId_t nPublishedFileID, uint64 *punSizeOnDisk, OUT_STRING_COUNT( cchFolderSize ) char *pchFolder, uint32 cchFolderSize, uint32 *punTimeStamp ) = 0;
+
+	// get info about pending update for items that have k_EItemStateNeedsUpdate set. punBytesTotal will be valid after download started once
+	virtual bool GetItemDownloadInfo( PublishedFileId_t nPublishedFileID, uint64 *punBytesDownloaded, uint64 *punBytesTotal ) = 0;
+		
+	// download new or update already installed item. If function returns true, wait for DownloadItemResult_t. If the item is already installed,
+	// then files on disk should not be used until callback received. If item is not subscribed to, it will be cached for some time.
+	// If bHighPriority is set, any other item download will be suspended and this item downloaded ASAP.
+	virtual bool DownloadItem( PublishedFileId_t nPublishedFileID, bool bHighPriority ) = 0;
+
+	// game servers can set a specific workshop folder before issuing any UGC commands.
+	// This is helpful if you want to support multiple game servers running out of the same install folder
+	virtual bool BInitWorkshopForGameServer( DepotId_t unWorkshopDepotID, const char *pszFolder ) = 0;
+
+	// SuspendDownloads( true ) will suspend all workshop downloads until SuspendDownloads( false ) is called or the game ends
+	virtual void SuspendDownloads( bool bSuspend ) = 0;
+
+	// usage tracking
+	CALL_RESULT( StartPlaytimeTrackingResult_t )
+	virtual SteamAPICall_t StartPlaytimeTracking( PublishedFileId_t *pvecPublishedFileID, uint32 unNumPublishedFileIDs ) = 0;
+	CALL_RESULT( StopPlaytimeTrackingResult_t )
+	virtual SteamAPICall_t StopPlaytimeTracking( PublishedFileId_t *pvecPublishedFileID, uint32 unNumPublishedFileIDs ) = 0;
+	CALL_RESULT( StopPlaytimeTrackingResult_t )
+	virtual SteamAPICall_t StopPlaytimeTrackingForAllItems() = 0;
+};
+
+#define STEAMUGC_INTERFACE_VERSION "STEAMUGC_INTERFACE_VERSION009"
+
+//-----------------------------------------------------------------------------
+// Purpose: Callback for querying UGC
+//-----------------------------------------------------------------------------
+struct SteamUGCQueryCompleted_t
+{
+	enum { k_iCallback = k_iClientUGCCallbacks + 1 };
+	UGCQueryHandle_t m_handle;
+	EResult m_eResult;
+	uint32 m_unNumResultsReturned;
+	uint32 m_unTotalMatchingResults;
+	bool m_bCachedData;	// indicates whether this data was retrieved from the local on-disk cache
+};
+
+
+//-----------------------------------------------------------------------------
+// Purpose: Callback for requesting details on one piece of UGC
+//-----------------------------------------------------------------------------
+struct SteamUGCRequestUGCDetailsResult_t
+{
+	enum { k_iCallback = k_iClientUGCCallbacks + 2 };
+	SteamUGCDetails_t m_details;
+	bool m_bCachedData; // indicates whether this data was retrieved from the local on-disk cache
+};
+
+
+//-----------------------------------------------------------------------------
+// Purpose: result for ISteamUGC::CreateItem() 
+//-----------------------------------------------------------------------------
+struct CreateItemResult_t
+{
+	enum { k_iCallback = k_iClientUGCCallbacks + 3 };
+	EResult m_eResult;
+	PublishedFileId_t m_nPublishedFileId; // new item got this UGC PublishFileID
+	bool m_bUserNeedsToAcceptWorkshopLegalAgreement;
+};
+
+
+//-----------------------------------------------------------------------------
+// Purpose: result for ISteamUGC::SubmitItemUpdate() 
+//-----------------------------------------------------------------------------
+struct SubmitItemUpdateResult_t
+{
+	enum { k_iCallback = k_iClientUGCCallbacks + 4 };
+	EResult m_eResult;
+	bool m_bUserNeedsToAcceptWorkshopLegalAgreement;
+};
+
+
+//-----------------------------------------------------------------------------
+// Purpose: a Workshop item has been installed or updated
+//-----------------------------------------------------------------------------
+struct ItemInstalled_t
+{
+	enum { k_iCallback = k_iClientUGCCallbacks + 5 };
+	AppId_t m_unAppID;
+	PublishedFileId_t m_nPublishedFileId;
+};
+
+
+//-----------------------------------------------------------------------------
+// Purpose: result of DownloadItem(), existing item files can be accessed again
+//-----------------------------------------------------------------------------
+struct DownloadItemResult_t
+{
+	enum { k_iCallback = k_iClientUGCCallbacks + 6 };
+	AppId_t m_unAppID;
+	PublishedFileId_t m_nPublishedFileId;
+	EResult m_eResult;
+};
+
+//-----------------------------------------------------------------------------
+// Purpose: result of AddItemToFavorites() or RemoveItemFromFavorites()
+//-----------------------------------------------------------------------------
+struct UserFavoriteItemsListChanged_t
+{
+	enum { k_iCallback = k_iClientUGCCallbacks + 7 };
+	PublishedFileId_t m_nPublishedFileId;
+	EResult m_eResult;
+	bool m_bWasAddRequest;
+};
+
+//-----------------------------------------------------------------------------
+// Purpose: The result of a call to SetUserItemVote()
+//-----------------------------------------------------------------------------
+struct SetUserItemVoteResult_t
+{
+	enum { k_iCallback = k_iClientUGCCallbacks + 8 };
+	PublishedFileId_t m_nPublishedFileId;
+	EResult m_eResult;
+	bool m_bVoteUp;
+};
+
+//-----------------------------------------------------------------------------
+// Purpose: The result of a call to GetUserItemVote()
+//-----------------------------------------------------------------------------
+struct GetUserItemVoteResult_t
+{
+	enum { k_iCallback = k_iClientUGCCallbacks + 9 };
+	PublishedFileId_t m_nPublishedFileId;
+	EResult m_eResult;
+	bool m_bVotedUp;
+	bool m_bVotedDown;
+	bool m_bVoteSkipped;
+};
+
+//-----------------------------------------------------------------------------
+// Purpose: The result of a call to StartPlaytimeTracking()
+//-----------------------------------------------------------------------------
+struct StartPlaytimeTrackingResult_t
+{
+	enum { k_iCallback = k_iClientUGCCallbacks + 10 };
+	EResult m_eResult;
+};
+
+//-----------------------------------------------------------------------------
+// Purpose: The result of a call to StopPlaytimeTracking()
+//-----------------------------------------------------------------------------
+struct StopPlaytimeTrackingResult_t
+{
+	enum { k_iCallback = k_iClientUGCCallbacks + 11 };
+	EResult m_eResult;
+};
+
+
+#pragma pack( pop )
+
+#endif // ISTEAMUGC_H

--- a/Common/Chairloader/SteamAPI/isteamunifiedmessages.h
+++ b/Common/Chairloader/SteamAPI/isteamunifiedmessages.h
@@ -1,0 +1,63 @@
+//====== Copyright � 1996-2007, Valve Corporation, All rights reserved. =======
+//
+// Purpose: Interface to unified messages client
+//
+//		You should not need to use this interface except if your product is using a language other than C++.
+//		Contact your Steam Tech contact for more details.
+//
+//=============================================================================
+
+#ifndef ISTEAMUNIFIEDMESSAGES_H
+#define ISTEAMUNIFIEDMESSAGES_H
+#ifdef _WIN32
+#pragma once
+#endif
+
+typedef uint64 ClientUnifiedMessageHandle;
+
+class ISteamUnifiedMessages
+{
+public:
+	static const ClientUnifiedMessageHandle k_InvalidUnifiedMessageHandle = 0;
+
+	// Sends a service method (in binary serialized form) using the Steam Client.
+	// Returns a unified message handle (k_InvalidUnifiedMessageHandle if could not send the message).
+	virtual ClientUnifiedMessageHandle SendMethod( const char *pchServiceMethod, const void *pRequestBuffer, uint32 unRequestBufferSize, uint64 unContext ) = 0;
+
+	// Gets the size of the response and the EResult. Returns false if the response is not ready yet.
+	virtual bool GetMethodResponseInfo( ClientUnifiedMessageHandle hHandle, uint32 *punResponseSize, EResult *peResult ) = 0;
+
+	// Gets a response in binary serialized form (and optionally release the corresponding allocated memory).
+	virtual bool GetMethodResponseData( ClientUnifiedMessageHandle hHandle, void *pResponseBuffer, uint32 unResponseBufferSize, bool bAutoRelease ) = 0;
+
+	// Releases the message and its corresponding allocated memory.
+	virtual bool ReleaseMethod( ClientUnifiedMessageHandle hHandle ) = 0;
+
+	// Sends a service notification (in binary serialized form) using the Steam Client.
+	// Returns true if the notification was sent successfully.
+	virtual bool SendNotification( const char *pchServiceNotification, const void *pNotificationBuffer, uint32 unNotificationBufferSize ) = 0;
+};
+
+#define STEAMUNIFIEDMESSAGES_INTERFACE_VERSION "STEAMUNIFIEDMESSAGES_INTERFACE_VERSION001"
+
+// callbacks
+#if defined( VALVE_CALLBACK_PACK_SMALL )
+#pragma pack( push, 4 )
+#elif defined( VALVE_CALLBACK_PACK_LARGE )
+#pragma pack( push, 8 )
+#else
+#error isteamclient.h must be included
+#endif 
+
+struct SteamUnifiedMessagesSendMethodResult_t
+{
+	enum { k_iCallback = k_iClientUnifiedMessagesCallbacks + 1 };
+	ClientUnifiedMessageHandle m_hHandle;	// The handle returned by SendMethod().
+	uint64 m_unContext;						// Context provided when calling SendMethod().
+	EResult m_eResult;						// The result of the method call.
+	uint32 m_unResponseSize;				// The size of the response.
+};
+
+#pragma pack( pop )
+
+#endif // ISTEAMUNIFIEDMESSAGES_H

--- a/Common/Chairloader/SteamAPI/isteamuser.h
+++ b/Common/Chairloader/SteamAPI/isteamuser.h
@@ -1,0 +1,355 @@
+//====== Copyright (c) 1996-2008, Valve Corporation, All rights reserved. =======
+//
+// Purpose: interface to user account information in Steam
+//
+//=============================================================================
+
+#ifndef ISTEAMUSER_H
+#define ISTEAMUSER_H
+#ifdef _WIN32
+#pragma once
+#endif
+
+#include "isteamclient.h"
+
+// structure that contains client callback data
+// see callbacks documentation for more details
+#if defined( VALVE_CALLBACK_PACK_SMALL )
+#pragma pack( push, 4 )
+#elif defined( VALVE_CALLBACK_PACK_LARGE )
+#pragma pack( push, 8 )
+#else
+#error isteamclient.h must be included
+#endif 
+struct CallbackMsg_t
+{
+	HSteamUser m_hSteamUser;
+	int m_iCallback;
+	uint8 *m_pubParam;
+	int m_cubParam;
+};
+#pragma pack( pop )
+
+
+//-----------------------------------------------------------------------------
+// Purpose: Functions for accessing and manipulating a steam account
+//			associated with one client instance
+//-----------------------------------------------------------------------------
+class ISteamUser
+{
+public:
+	// returns the HSteamUser this interface represents
+	// this is only used internally by the API, and by a few select interfaces that support multi-user
+	virtual HSteamUser GetHSteamUser() = 0;
+
+	// returns true if the Steam client current has a live connection to the Steam servers. 
+	// If false, it means there is no active connection due to either a networking issue on the local machine, or the Steam server is down/busy.
+	// The Steam client will automatically be trying to recreate the connection as often as possible.
+	virtual bool BLoggedOn() = 0;
+
+	// returns the CSteamID of the account currently logged into the Steam client
+	// a CSteamID is a unique identifier for an account, and used to differentiate users in all parts of the Steamworks API
+	virtual CSteamID GetSteamID() = 0;
+
+	// Multiplayer Authentication functions
+	
+	// InitiateGameConnection() starts the state machine for authenticating the game client with the game server
+	// It is the client portion of a three-way handshake between the client, the game server, and the steam servers
+	//
+	// Parameters:
+	// void *pAuthBlob - a pointer to empty memory that will be filled in with the authentication token.
+	// int cbMaxAuthBlob - the number of bytes of allocated memory in pBlob. Should be at least 2048 bytes.
+	// CSteamID steamIDGameServer - the steamID of the game server, received from the game server by the client
+	// CGameID gameID - the ID of the current game. For games without mods, this is just CGameID( <appID> )
+	// uint32 unIPServer, uint16 usPortServer - the IP address of the game server
+	// bool bSecure - whether or not the client thinks that the game server is reporting itself as secure (i.e. VAC is running)
+	//
+	// return value - returns the number of bytes written to pBlob. If the return is 0, then the buffer passed in was too small, and the call has failed
+	// The contents of pBlob should then be sent to the game server, for it to use to complete the authentication process.
+	virtual int InitiateGameConnection( void *pAuthBlob, int cbMaxAuthBlob, CSteamID steamIDGameServer, uint32 unIPServer, uint16 usPortServer, bool bSecure ) = 0;
+
+	// notify of disconnect
+	// needs to occur when the game client leaves the specified game server, needs to match with the InitiateGameConnection() call
+	virtual void TerminateGameConnection( uint32 unIPServer, uint16 usPortServer ) = 0;
+
+	// Legacy functions
+
+	// used by only a few games to track usage events
+	virtual void TrackAppUsageEvent( CGameID gameID, int eAppUsageEvent, const char *pchExtraInfo = "" ) = 0;
+
+	// get the local storage folder for current Steam account to write application data, e.g. save games, configs etc.
+	// this will usually be something like "C:\Progam Files\Steam\userdata\<SteamID>\<AppID>\local"
+	virtual bool GetUserDataFolder( char *pchBuffer, int cubBuffer ) = 0;
+
+	// Starts voice recording. Once started, use GetVoice() to get the data
+	virtual void StartVoiceRecording( ) = 0;
+
+	// Stops voice recording. Because people often release push-to-talk keys early, the system will keep recording for
+	// a little bit after this function is called. GetVoice() should continue to be called until it returns
+	// k_eVoiceResultNotRecording
+	virtual void StopVoiceRecording( ) = 0;
+
+	// Determine the amount of captured audio data that is available in bytes.
+	// This provides both the compressed and uncompressed data. Please note that the uncompressed
+	// data is not the raw feed from the microphone: data may only be available if audible 
+	// levels of speech are detected.
+	// nUncompressedVoiceDesiredSampleRate is necessary to know the number of bytes to return in pcbUncompressed - can be set to 0 if you don't need uncompressed (the usual case)
+	// If you're upgrading from an older Steamworks API, you'll want to pass in 11025 to nUncompressedVoiceDesiredSampleRate
+	virtual EVoiceResult GetAvailableVoice( uint32 *pcbCompressed, uint32 *pcbUncompressed, uint32 nUncompressedVoiceDesiredSampleRate ) = 0;
+
+	// Gets the latest voice data from the microphone. Compressed data is an arbitrary format, and is meant to be handed back to 
+	// DecompressVoice() for playback later as a binary blob. Uncompressed data is 16-bit, signed integer, 11025Hz PCM format.
+	// Please note that the uncompressed data is not the raw feed from the microphone: data may only be available if audible 
+	// levels of speech are detected, and may have passed through denoising filters, etc.
+	// This function should be called as often as possible once recording has started; once per frame at least.
+	// nBytesWritten is set to the number of bytes written to pDestBuffer. 
+	// nUncompressedBytesWritten is set to the number of bytes written to pUncompressedDestBuffer. 
+	// You must grab both compressed and uncompressed here at the same time, if you want both.
+	// Matching data that is not read during this call will be thrown away.
+	// GetAvailableVoice() can be used to determine how much data is actually available.
+	// If you're upgrading from an older Steamworks API, you'll want to pass in 11025 to nUncompressedVoiceDesiredSampleRate
+	virtual EVoiceResult GetVoice( bool bWantCompressed, void *pDestBuffer, uint32 cbDestBufferSize, uint32 *nBytesWritten, bool bWantUncompressed, void *pUncompressedDestBuffer, uint32 cbUncompressedDestBufferSize, uint32 *nUncompressBytesWritten, uint32 nUncompressedVoiceDesiredSampleRate ) = 0;
+
+	// Decompresses a chunk of compressed data produced by GetVoice().
+	// nBytesWritten is set to the number of bytes written to pDestBuffer unless the return value is k_EVoiceResultBufferTooSmall.
+	// In that case, nBytesWritten is set to the size of the buffer required to decompress the given
+	// data. The suggested buffer size for the destination buffer is 22 kilobytes.
+	// The output format of the data is 16-bit signed at the requested samples per second.
+	// If you're upgrading from an older Steamworks API, you'll want to pass in 11025 to nDesiredSampleRate
+	virtual EVoiceResult DecompressVoice( const void *pCompressed, uint32 cbCompressed, void *pDestBuffer, uint32 cbDestBufferSize, uint32 *nBytesWritten, uint32 nDesiredSampleRate ) = 0;
+
+	// This returns the frequency of the voice data as it's stored internally; calling DecompressVoice() with this size will yield the best results
+	virtual uint32 GetVoiceOptimalSampleRate() = 0;
+
+	// Retrieve ticket to be sent to the entity who wishes to authenticate you. 
+	// pcbTicket retrieves the length of the actual ticket.
+	virtual HAuthTicket GetAuthSessionTicket( void *pTicket, int cbMaxTicket, uint32 *pcbTicket ) = 0;
+
+	// Authenticate ticket from entity steamID to be sure it is valid and isnt reused
+	// Registers for callbacks if the entity goes offline or cancels the ticket ( see ValidateAuthTicketResponse_t callback and EAuthSessionResponse )
+	virtual EBeginAuthSessionResult BeginAuthSession( const void *pAuthTicket, int cbAuthTicket, CSteamID steamID ) = 0;
+
+	// Stop tracking started by BeginAuthSession - called when no longer playing game with this entity
+	virtual void EndAuthSession( CSteamID steamID ) = 0;
+
+	// Cancel auth ticket from GetAuthSessionTicket, called when no longer playing game with the entity you gave the ticket to
+	virtual void CancelAuthTicket( HAuthTicket hAuthTicket ) = 0;
+
+	// After receiving a user's authentication data, and passing it to BeginAuthSession, use this function
+	// to determine if the user owns downloadable content specified by the provided AppID.
+	virtual EUserHasLicenseForAppResult UserHasLicenseForApp( CSteamID steamID, AppId_t appID ) = 0;
+	
+	// returns true if this users looks like they are behind a NAT device. Only valid once the user has connected to steam 
+	// (i.e a SteamServersConnected_t has been issued) and may not catch all forms of NAT.
+	virtual bool BIsBehindNAT() = 0;
+
+	// set data to be replicated to friends so that they can join your game
+	// CSteamID steamIDGameServer - the steamID of the game server, received from the game server by the client
+	// uint32 unIPServer, uint16 usPortServer - the IP address of the game server
+	virtual void AdvertiseGame( CSteamID steamIDGameServer, uint32 unIPServer, uint16 usPortServer ) = 0;
+
+	// Requests a ticket encrypted with an app specific shared key
+	// pDataToInclude, cbDataToInclude will be encrypted into the ticket
+	// ( This is asynchronous, you must wait for the ticket to be completed by the server )
+	CALL_RESULT( EncryptedAppTicketResponse_t )
+	virtual SteamAPICall_t RequestEncryptedAppTicket( void *pDataToInclude, int cbDataToInclude ) = 0;
+
+	// retrieve a finished ticket
+	virtual bool GetEncryptedAppTicket( void *pTicket, int cbMaxTicket, uint32 *pcbTicket ) = 0;
+
+	// Trading Card badges data access
+	// if you only have one set of cards, the series will be 1
+	// the user has can have two different badges for a series; the regular (max level 5) and the foil (max level 1)
+	virtual int GetGameBadgeLevel( int nSeries, bool bFoil ) = 0;
+
+	// gets the Steam Level of the user, as shown on their profile
+	virtual int GetPlayerSteamLevel() = 0;
+
+	// Requests a URL which authenticates an in-game browser for store check-out,
+	// and then redirects to the specified URL. As long as the in-game browser
+	// accepts and handles session cookies, Steam microtransaction checkout pages
+	// will automatically recognize the user instead of presenting a login page.
+	// The result of this API call will be a StoreAuthURLResponse_t callback.
+	// NOTE: The URL has a very short lifetime to prevent history-snooping attacks,
+	// so you should only call this API when you are about to launch the browser,
+	// or else immediately navigate to the result URL using a hidden browser window.
+	// NOTE 2: The resulting authorization cookie has an expiration time of one day,
+	// so it would be a good idea to request and visit a new auth URL every 12 hours.
+	CALL_RESULT( StoreAuthURLResponse_t )
+	virtual SteamAPICall_t RequestStoreAuthURL( const char *pchRedirectURL ) = 0;
+
+	// gets whether the users phone number is verified 
+	virtual bool BIsPhoneVerified() = 0;
+
+	// gets whether the user has two factor enabled on their account
+	virtual bool BIsTwoFactorEnabled() = 0;
+
+	// gets whether the users phone number is identifying
+	virtual bool BIsPhoneIdentifying() = 0;
+
+	// gets whether the users phone number is awaiting (re)verification
+	virtual bool BIsPhoneRequiringVerification() = 0;
+
+};
+
+#define STEAMUSER_INTERFACE_VERSION "SteamUser019"
+
+
+// callbacks
+#if defined( VALVE_CALLBACK_PACK_SMALL )
+#pragma pack( push, 4 )
+#elif defined( VALVE_CALLBACK_PACK_LARGE )
+#pragma pack( push, 8 )
+#else
+#error isteamclient.h must be included
+#endif 
+
+//-----------------------------------------------------------------------------
+// Purpose: called when a connections to the Steam back-end has been established
+//			this means the Steam client now has a working connection to the Steam servers
+//			usually this will have occurred before the game has launched, and should
+//			only be seen if the user has dropped connection due to a networking issue
+//			or a Steam server update
+//-----------------------------------------------------------------------------
+struct SteamServersConnected_t
+{
+	enum { k_iCallback = k_iSteamUserCallbacks + 1 };
+};
+
+//-----------------------------------------------------------------------------
+// Purpose: called when a connection attempt has failed
+//			this will occur periodically if the Steam client is not connected, 
+//			and has failed in it's retry to establish a connection
+//-----------------------------------------------------------------------------
+struct SteamServerConnectFailure_t
+{
+	enum { k_iCallback = k_iSteamUserCallbacks + 2 };
+	EResult m_eResult;
+	bool m_bStillRetrying;
+};
+
+
+//-----------------------------------------------------------------------------
+// Purpose: called if the client has lost connection to the Steam servers
+//			real-time services will be disabled until a matching SteamServersConnected_t has been posted
+//-----------------------------------------------------------------------------
+struct SteamServersDisconnected_t
+{
+	enum { k_iCallback = k_iSteamUserCallbacks + 3 };
+	EResult m_eResult;
+};
+
+
+//-----------------------------------------------------------------------------
+// Purpose: Sent by the Steam server to the client telling it to disconnect from the specified game server,
+//			which it may be in the process of or already connected to.
+//			The game client should immediately disconnect upon receiving this message.
+//			This can usually occur if the user doesn't have rights to play on the game server.
+//-----------------------------------------------------------------------------
+struct ClientGameServerDeny_t
+{
+	enum { k_iCallback = k_iSteamUserCallbacks + 13 };
+
+	uint32 m_uAppID;
+	uint32 m_unGameServerIP;
+	uint16 m_usGameServerPort;
+	uint16 m_bSecure;
+	uint32 m_uReason;
+};
+
+
+//-----------------------------------------------------------------------------
+// Purpose: called when the callback system for this client is in an error state (and has flushed pending callbacks)
+//			When getting this message the client should disconnect from Steam, reset any stored Steam state and reconnect.
+//			This usually occurs in the rare event the Steam client has some kind of fatal error.
+//-----------------------------------------------------------------------------
+struct IPCFailure_t
+{
+	enum { k_iCallback = k_iSteamUserCallbacks + 17 };
+	enum EFailureType 
+	{ 
+		k_EFailureFlushedCallbackQueue, 
+		k_EFailurePipeFail,
+	};
+	uint8 m_eFailureType;
+};
+
+
+//-----------------------------------------------------------------------------
+// Purpose: Signaled whenever licenses change
+//-----------------------------------------------------------------------------
+struct LicensesUpdated_t
+{
+	enum { k_iCallback = k_iSteamUserCallbacks + 25 };
+};
+
+
+//-----------------------------------------------------------------------------
+// callback for BeginAuthSession
+//-----------------------------------------------------------------------------
+struct ValidateAuthTicketResponse_t
+{
+	enum { k_iCallback = k_iSteamUserCallbacks + 43 };
+	CSteamID m_SteamID;
+	EAuthSessionResponse m_eAuthSessionResponse;
+	CSteamID m_OwnerSteamID; // different from m_SteamID if borrowed
+};
+
+
+//-----------------------------------------------------------------------------
+// Purpose: called when a user has responded to a microtransaction authorization request
+//-----------------------------------------------------------------------------
+struct MicroTxnAuthorizationResponse_t
+{
+	enum { k_iCallback = k_iSteamUserCallbacks + 52 };
+	
+	uint32 m_unAppID;			// AppID for this microtransaction
+	uint64 m_ulOrderID;			// OrderID provided for the microtransaction
+	uint8 m_bAuthorized;		// if user authorized transaction
+};
+
+
+//-----------------------------------------------------------------------------
+// Purpose: Result from RequestEncryptedAppTicket
+//-----------------------------------------------------------------------------
+struct EncryptedAppTicketResponse_t
+{
+	enum { k_iCallback = k_iSteamUserCallbacks + 54 };
+
+	EResult m_eResult;
+};
+
+//-----------------------------------------------------------------------------
+// callback for GetAuthSessionTicket
+//-----------------------------------------------------------------------------
+struct GetAuthSessionTicketResponse_t
+{
+	enum { k_iCallback = k_iSteamUserCallbacks + 63 };
+	HAuthTicket m_hAuthTicket;
+	EResult m_eResult;
+};
+
+
+//-----------------------------------------------------------------------------
+// Purpose: sent to your game in response to a steam://gamewebcallback/ command
+//-----------------------------------------------------------------------------
+struct GameWebCallback_t
+{
+	enum { k_iCallback = k_iSteamUserCallbacks + 64 };
+	char m_szURL[256];
+};
+
+//-----------------------------------------------------------------------------
+// Purpose: sent to your game in response to ISteamUser::RequestStoreAuthURL
+//-----------------------------------------------------------------------------
+struct StoreAuthURLResponse_t
+{
+	enum { k_iCallback = k_iSteamUserCallbacks + 65 };
+	char m_szURL[512];
+};
+
+
+
+#pragma pack( pop )
+
+#endif // ISTEAMUSER_H

--- a/Common/Chairloader/SteamAPI/isteamuserstats.h
+++ b/Common/Chairloader/SteamAPI/isteamuserstats.h
@@ -1,0 +1,476 @@
+//====== Copyright � 1996-2009, Valve Corporation, All rights reserved. =======
+//
+// Purpose: interface to stats, achievements, and leaderboards 
+//
+//=============================================================================
+
+#ifndef ISTEAMUSERSTATS_H
+#define ISTEAMUSERSTATS_H
+#ifdef _WIN32
+#pragma once
+#endif
+
+#include "isteamclient.h"
+#include "isteamremotestorage.h"
+
+// size limit on stat or achievement name (UTF-8 encoded)
+enum { k_cchStatNameMax = 128 };
+
+// maximum number of bytes for a leaderboard name (UTF-8 encoded)
+enum { k_cchLeaderboardNameMax = 128 };
+
+// maximum number of details int32's storable for a single leaderboard entry
+enum { k_cLeaderboardDetailsMax = 64 };
+
+// handle to a single leaderboard
+typedef uint64 SteamLeaderboard_t;
+
+// handle to a set of downloaded entries in a leaderboard
+typedef uint64 SteamLeaderboardEntries_t;
+
+// type of data request, when downloading leaderboard entries
+enum ELeaderboardDataRequest
+{
+	k_ELeaderboardDataRequestGlobal = 0,
+	k_ELeaderboardDataRequestGlobalAroundUser = 1,
+	k_ELeaderboardDataRequestFriends = 2,
+	k_ELeaderboardDataRequestUsers = 3
+};
+
+// the sort order of a leaderboard
+enum ELeaderboardSortMethod
+{
+	k_ELeaderboardSortMethodNone = 0,
+	k_ELeaderboardSortMethodAscending = 1,	// top-score is lowest number
+	k_ELeaderboardSortMethodDescending = 2,	// top-score is highest number
+};
+
+// the display type (used by the Steam Community web site) for a leaderboard
+enum ELeaderboardDisplayType
+{
+	k_ELeaderboardDisplayTypeNone = 0, 
+	k_ELeaderboardDisplayTypeNumeric = 1,			// simple numerical score
+	k_ELeaderboardDisplayTypeTimeSeconds = 2,		// the score represents a time, in seconds
+	k_ELeaderboardDisplayTypeTimeMilliSeconds = 3,	// the score represents a time, in milliseconds
+};
+
+enum ELeaderboardUploadScoreMethod
+{
+	k_ELeaderboardUploadScoreMethodNone = 0,
+	k_ELeaderboardUploadScoreMethodKeepBest = 1,	// Leaderboard will keep user's best score
+	k_ELeaderboardUploadScoreMethodForceUpdate = 2,	// Leaderboard will always replace score with specified
+};
+
+// a single entry in a leaderboard, as returned by GetDownloadedLeaderboardEntry()
+#if defined( VALVE_CALLBACK_PACK_SMALL )
+#pragma pack( push, 4 )
+#elif defined( VALVE_CALLBACK_PACK_LARGE )
+#pragma pack( push, 8 )
+#else
+#error isteamclient.h must be included
+#endif 
+
+struct LeaderboardEntry_t
+{
+	CSteamID m_steamIDUser; // user with the entry - use SteamFriends()->GetFriendPersonaName() & SteamFriends()->GetFriendAvatar() to get more info
+	int32 m_nGlobalRank;	// [1..N], where N is the number of users with an entry in the leaderboard
+	int32 m_nScore;			// score as set in the leaderboard
+	int32 m_cDetails;		// number of int32 details available for this entry
+	UGCHandle_t m_hUGC;		// handle for UGC attached to the entry
+};
+
+#pragma pack( pop )
+
+
+//-----------------------------------------------------------------------------
+// Purpose: Functions for accessing stats, achievements, and leaderboard information
+//-----------------------------------------------------------------------------
+class ISteamUserStats
+{
+public:
+	// Ask the server to send down this user's data and achievements for this game
+	CALL_BACK( UserStatsReceived_t )
+	virtual bool RequestCurrentStats() = 0;
+
+	// Data accessors
+	virtual bool GetStat( const char *pchName, int32 *pData ) = 0;
+	virtual bool GetStat( const char *pchName, float *pData ) = 0;
+
+	// Set / update data
+	virtual bool SetStat( const char *pchName, int32 nData ) = 0;
+	virtual bool SetStat( const char *pchName, float fData ) = 0;
+	virtual bool UpdateAvgRateStat( const char *pchName, float flCountThisSession, double dSessionLength ) = 0;
+
+	// Achievement flag accessors
+	virtual bool GetAchievement( const char *pchName, bool *pbAchieved ) = 0;
+	virtual bool SetAchievement( const char *pchName ) = 0;
+	virtual bool ClearAchievement( const char *pchName ) = 0;
+
+	// Get the achievement status, and the time it was unlocked if unlocked.
+	// If the return value is true, but the unlock time is zero, that means it was unlocked before Steam 
+	// began tracking achievement unlock times (December 2009). Time is seconds since January 1, 1970.
+	virtual bool GetAchievementAndUnlockTime( const char *pchName, bool *pbAchieved, uint32 *punUnlockTime ) = 0;
+
+	// Store the current data on the server, will get a callback when set
+	// And one callback for every new achievement
+	//
+	// If the callback has a result of k_EResultInvalidParam, one or more stats 
+	// uploaded has been rejected, either because they broke constraints
+	// or were out of date. In this case the server sends back updated values.
+	// The stats should be re-iterated to keep in sync.
+	virtual bool StoreStats() = 0;
+
+	// Achievement / GroupAchievement metadata
+
+	// Gets the icon of the achievement, which is a handle to be used in ISteamUtils::GetImageRGBA(), or 0 if none set. 
+	// A return value of 0 may indicate we are still fetching data, and you can wait for the UserAchievementIconFetched_t callback
+	// which will notify you when the bits are ready. If the callback still returns zero, then there is no image set for the
+	// specified achievement.
+	virtual int GetAchievementIcon( const char *pchName ) = 0;
+
+	// Get general attributes for an achievement. Accepts the following keys:
+	// - "name" and "desc" for retrieving the localized achievement name and description (returned in UTF8)
+	// - "hidden" for retrieving if an achievement is hidden (returns "0" when not hidden, "1" when hidden)
+	virtual const char *GetAchievementDisplayAttribute( const char *pchName, const char *pchKey ) = 0;
+
+	// Achievement progress - triggers an AchievementProgress callback, that is all.
+	// Calling this w/ N out of N progress will NOT set the achievement, the game must still do that.
+	virtual bool IndicateAchievementProgress( const char *pchName, uint32 nCurProgress, uint32 nMaxProgress ) = 0;
+
+	// Used for iterating achievements. In general games should not need these functions because they should have a
+	// list of existing achievements compiled into them
+	virtual uint32 GetNumAchievements() = 0;
+	// Get achievement name iAchievement in [0,GetNumAchievements)
+	virtual const char *GetAchievementName( uint32 iAchievement ) = 0;
+
+	// Friends stats & achievements
+
+	// downloads stats for the user
+	// returns a UserStatsReceived_t received when completed
+	// if the other user has no stats, UserStatsReceived_t.m_eResult will be set to k_EResultFail
+	// these stats won't be auto-updated; you'll need to call RequestUserStats() again to refresh any data
+	CALL_RESULT( UserStatsReceived_t )
+	virtual SteamAPICall_t RequestUserStats( CSteamID steamIDUser ) = 0;
+
+	// requests stat information for a user, usable after a successful call to RequestUserStats()
+	virtual bool GetUserStat( CSteamID steamIDUser, const char *pchName, int32 *pData ) = 0;
+	virtual bool GetUserStat( CSteamID steamIDUser, const char *pchName, float *pData ) = 0;
+	virtual bool GetUserAchievement( CSteamID steamIDUser, const char *pchName, bool *pbAchieved ) = 0;
+	// See notes for GetAchievementAndUnlockTime above
+	virtual bool GetUserAchievementAndUnlockTime( CSteamID steamIDUser, const char *pchName, bool *pbAchieved, uint32 *punUnlockTime ) = 0;
+
+	// Reset stats 
+	virtual bool ResetAllStats( bool bAchievementsToo ) = 0;
+
+	// Leaderboard functions
+
+	// asks the Steam back-end for a leaderboard by name, and will create it if it's not yet
+	// This call is asynchronous, with the result returned in LeaderboardFindResult_t
+	CALL_RESULT(LeaderboardFindResult_t)
+	virtual SteamAPICall_t FindOrCreateLeaderboard( const char *pchLeaderboardName, ELeaderboardSortMethod eLeaderboardSortMethod, ELeaderboardDisplayType eLeaderboardDisplayType ) = 0;
+
+	// as above, but won't create the leaderboard if it's not found
+	// This call is asynchronous, with the result returned in LeaderboardFindResult_t
+	CALL_RESULT( LeaderboardFindResult_t )
+	virtual SteamAPICall_t FindLeaderboard( const char *pchLeaderboardName ) = 0;
+
+	// returns the name of a leaderboard
+	virtual const char *GetLeaderboardName( SteamLeaderboard_t hSteamLeaderboard ) = 0;
+
+	// returns the total number of entries in a leaderboard, as of the last request
+	virtual int GetLeaderboardEntryCount( SteamLeaderboard_t hSteamLeaderboard ) = 0;
+
+	// returns the sort method of the leaderboard
+	virtual ELeaderboardSortMethod GetLeaderboardSortMethod( SteamLeaderboard_t hSteamLeaderboard ) = 0;
+
+	// returns the display type of the leaderboard
+	virtual ELeaderboardDisplayType GetLeaderboardDisplayType( SteamLeaderboard_t hSteamLeaderboard ) = 0;
+
+	// Asks the Steam back-end for a set of rows in the leaderboard.
+	// This call is asynchronous, with the result returned in LeaderboardScoresDownloaded_t
+	// LeaderboardScoresDownloaded_t will contain a handle to pull the results from GetDownloadedLeaderboardEntries() (below)
+	// You can ask for more entries than exist, and it will return as many as do exist.
+	// k_ELeaderboardDataRequestGlobal requests rows in the leaderboard from the full table, with nRangeStart & nRangeEnd in the range [1, TotalEntries]
+	// k_ELeaderboardDataRequestGlobalAroundUser requests rows around the current user, nRangeStart being negate
+	//   e.g. DownloadLeaderboardEntries( hLeaderboard, k_ELeaderboardDataRequestGlobalAroundUser, -3, 3 ) will return 7 rows, 3 before the user, 3 after
+	// k_ELeaderboardDataRequestFriends requests all the rows for friends of the current user 
+	CALL_RESULT( LeaderboardScoresDownloaded_t )
+	virtual SteamAPICall_t DownloadLeaderboardEntries( SteamLeaderboard_t hSteamLeaderboard, ELeaderboardDataRequest eLeaderboardDataRequest, int nRangeStart, int nRangeEnd ) = 0;
+	// as above, but downloads leaderboard entries for an arbitrary set of users - ELeaderboardDataRequest is k_ELeaderboardDataRequestUsers
+	// if a user doesn't have a leaderboard entry, they won't be included in the result
+	// a max of 100 users can be downloaded at a time, with only one outstanding call at a time
+	METHOD_DESC(Downloads leaderboard entries for an arbitrary set of users - ELeaderboardDataRequest is k_ELeaderboardDataRequestUsers)
+		CALL_RESULT( LeaderboardScoresDownloaded_t )
+	virtual SteamAPICall_t DownloadLeaderboardEntriesForUsers( SteamLeaderboard_t hSteamLeaderboard,
+															   ARRAY_COUNT_D(cUsers, Array of users to retrieve) CSteamID *prgUsers, int cUsers ) = 0;
+
+	// Returns data about a single leaderboard entry
+	// use a for loop from 0 to LeaderboardScoresDownloaded_t::m_cEntryCount to get all the downloaded entries
+	// e.g.
+	//		void OnLeaderboardScoresDownloaded( LeaderboardScoresDownloaded_t *pLeaderboardScoresDownloaded )
+	//		{
+	//			for ( int index = 0; index < pLeaderboardScoresDownloaded->m_cEntryCount; index++ )
+	//			{
+	//				LeaderboardEntry_t leaderboardEntry;
+	//				int32 details[3];		// we know this is how many we've stored previously
+	//				GetDownloadedLeaderboardEntry( pLeaderboardScoresDownloaded->m_hSteamLeaderboardEntries, index, &leaderboardEntry, details, 3 );
+	//				assert( leaderboardEntry.m_cDetails == 3 );
+	//				...
+	//			}
+	// once you've accessed all the entries, the data will be free'd, and the SteamLeaderboardEntries_t handle will become invalid
+	virtual bool GetDownloadedLeaderboardEntry( SteamLeaderboardEntries_t hSteamLeaderboardEntries, int index, LeaderboardEntry_t *pLeaderboardEntry, int32 *pDetails, int cDetailsMax ) = 0;
+
+	// Uploads a user score to the Steam back-end.
+	// This call is asynchronous, with the result returned in LeaderboardScoreUploaded_t
+	// Details are extra game-defined information regarding how the user got that score
+	// pScoreDetails points to an array of int32's, cScoreDetailsCount is the number of int32's in the list
+	CALL_RESULT( LeaderboardScoreUploaded_t )
+	virtual SteamAPICall_t UploadLeaderboardScore( SteamLeaderboard_t hSteamLeaderboard, ELeaderboardUploadScoreMethod eLeaderboardUploadScoreMethod, int32 nScore, const int32 *pScoreDetails, int cScoreDetailsCount ) = 0;
+
+	// Attaches a piece of user generated content the user's entry on a leaderboard.
+	// hContent is a handle to a piece of user generated content that was shared using ISteamUserRemoteStorage::FileShare().
+	// This call is asynchronous, with the result returned in LeaderboardUGCSet_t.
+	CALL_RESULT( LeaderboardUGCSet_t )
+	virtual SteamAPICall_t AttachLeaderboardUGC( SteamLeaderboard_t hSteamLeaderboard, UGCHandle_t hUGC ) = 0;
+
+	// Retrieves the number of players currently playing your game (online + offline)
+	// This call is asynchronous, with the result returned in NumberOfCurrentPlayers_t
+	CALL_RESULT( NumberOfCurrentPlayers_t )
+	virtual SteamAPICall_t GetNumberOfCurrentPlayers() = 0;
+
+	// Requests that Steam fetch data on the percentage of players who have received each achievement
+	// for the game globally.
+	// This call is asynchronous, with the result returned in GlobalAchievementPercentagesReady_t.
+	CALL_RESULT( GlobalAchievementPercentagesReady_t )
+	virtual SteamAPICall_t RequestGlobalAchievementPercentages() = 0;
+
+	// Get the info on the most achieved achievement for the game, returns an iterator index you can use to fetch
+	// the next most achieved afterwards.  Will return -1 if there is no data on achievement 
+	// percentages (ie, you haven't called RequestGlobalAchievementPercentages and waited on the callback).
+	virtual int GetMostAchievedAchievementInfo( char *pchName, uint32 unNameBufLen, float *pflPercent, bool *pbAchieved ) = 0;
+
+	// Get the info on the next most achieved achievement for the game. Call this after GetMostAchievedAchievementInfo or another
+	// GetNextMostAchievedAchievementInfo call passing the iterator from the previous call. Returns -1 after the last
+	// achievement has been iterated.
+	virtual int GetNextMostAchievedAchievementInfo( int iIteratorPrevious, char *pchName, uint32 unNameBufLen, float *pflPercent, bool *pbAchieved ) = 0;
+
+	// Returns the percentage of users who have achieved the specified achievement.
+	virtual bool GetAchievementAchievedPercent( const char *pchName, float *pflPercent ) = 0;
+
+	// Requests global stats data, which is available for stats marked as "aggregated".
+	// This call is asynchronous, with the results returned in GlobalStatsReceived_t.
+	// nHistoryDays specifies how many days of day-by-day history to retrieve in addition
+	// to the overall totals. The limit is 60.
+	CALL_RESULT( GlobalStatsReceived_t )
+	virtual SteamAPICall_t RequestGlobalStats( int nHistoryDays ) = 0;
+
+	// Gets the lifetime totals for an aggregated stat
+	virtual bool GetGlobalStat( const char *pchStatName, int64 *pData ) = 0;
+	virtual bool GetGlobalStat( const char *pchStatName, double *pData ) = 0;
+
+	// Gets history for an aggregated stat. pData will be filled with daily values, starting with today.
+	// So when called, pData[0] will be today, pData[1] will be yesterday, and pData[2] will be two days ago, 
+	// etc. cubData is the size in bytes of the pubData buffer. Returns the number of 
+	// elements actually set.
+	virtual int32 GetGlobalStatHistory( const char *pchStatName, ARRAY_COUNT(cubData) int64 *pData, uint32 cubData ) = 0;
+	virtual int32 GetGlobalStatHistory( const char *pchStatName, ARRAY_COUNT(cubData) double *pData, uint32 cubData ) = 0;
+
+#ifdef _PS3
+	// Call to kick off installation of the PS3 trophies. This call is asynchronous, and the results will be returned in a PS3TrophiesInstalled_t
+	// callback.
+	virtual bool InstallPS3Trophies() = 0;
+
+	// Returns the amount of space required at boot to install trophies. This value can be used when comparing the amount of space needed
+	// by the game to the available space value passed to the game at boot. The value is set during InstallPS3Trophies().
+	virtual uint64 GetTrophySpaceRequiredBeforeInstall() = 0;
+
+	// On PS3, user stats & achievement progress through Steam must be stored with the user's saved game data.
+	// At startup, before calling RequestCurrentStats(), you must pass the user's stats data to Steam via this method.
+	// If you do not have any user data, call this function with pvData = NULL and cubData = 0
+	virtual bool SetUserStatsData( const void *pvData, uint32 cubData ) = 0;
+
+	// Call to get the user's current stats data. You should retrieve this data after receiving successful UserStatsReceived_t & UserStatsStored_t
+	// callbacks, and store the data with the user's save game data. You can call this method with pvData = NULL and cubData = 0 to get the required
+	// buffer size.
+	virtual bool GetUserStatsData( void *pvData, uint32 cubData, uint32 *pcubWritten ) = 0;
+#endif
+};
+
+#define STEAMUSERSTATS_INTERFACE_VERSION "STEAMUSERSTATS_INTERFACE_VERSION011"
+
+// callbacks
+#if defined( VALVE_CALLBACK_PACK_SMALL )
+#pragma pack( push, 4 )
+#elif defined( VALVE_CALLBACK_PACK_LARGE )
+#pragma pack( push, 8 )
+#else
+#error isteamclient.h must be included
+#endif 
+
+//-----------------------------------------------------------------------------
+// Purpose: called when the latests stats and achievements have been received
+//			from the server
+//-----------------------------------------------------------------------------
+struct UserStatsReceived_t
+{
+	enum { k_iCallback = k_iSteamUserStatsCallbacks + 1 };
+	uint64		m_nGameID;		// Game these stats are for
+	EResult		m_eResult;		// Success / error fetching the stats
+	CSteamID	m_steamIDUser;	// The user for whom the stats are retrieved for
+};
+
+
+//-----------------------------------------------------------------------------
+// Purpose: result of a request to store the user stats for a game
+//-----------------------------------------------------------------------------
+struct UserStatsStored_t
+{
+	enum { k_iCallback = k_iSteamUserStatsCallbacks + 2 };
+	uint64		m_nGameID;		// Game these stats are for
+	EResult		m_eResult;		// success / error
+};
+
+
+//-----------------------------------------------------------------------------
+// Purpose: result of a request to store the achievements for a game, or an 
+//			"indicate progress" call. If both m_nCurProgress and m_nMaxProgress
+//			are zero, that means the achievement has been fully unlocked.
+//-----------------------------------------------------------------------------
+struct UserAchievementStored_t
+{
+	enum { k_iCallback = k_iSteamUserStatsCallbacks + 3 };
+
+	uint64		m_nGameID;				// Game this is for
+	bool		m_bGroupAchievement;	// if this is a "group" achievement
+	char		m_rgchAchievementName[k_cchStatNameMax];		// name of the achievement
+	uint32		m_nCurProgress;			// current progress towards the achievement
+	uint32		m_nMaxProgress;			// "out of" this many
+};
+
+
+//-----------------------------------------------------------------------------
+// Purpose: call result for finding a leaderboard, returned as a result of FindOrCreateLeaderboard() or FindLeaderboard()
+//			use CCallResult<> to map this async result to a member function
+//-----------------------------------------------------------------------------
+struct LeaderboardFindResult_t
+{
+	enum { k_iCallback = k_iSteamUserStatsCallbacks + 4 };
+	SteamLeaderboard_t m_hSteamLeaderboard;	// handle to the leaderboard serarched for, 0 if no leaderboard found
+	uint8 m_bLeaderboardFound;				// 0 if no leaderboard found
+};
+
+
+//-----------------------------------------------------------------------------
+// Purpose: call result indicating scores for a leaderboard have been downloaded and are ready to be retrieved, returned as a result of DownloadLeaderboardEntries()
+//			use CCallResult<> to map this async result to a member function
+//-----------------------------------------------------------------------------
+struct LeaderboardScoresDownloaded_t
+{
+	enum { k_iCallback = k_iSteamUserStatsCallbacks + 5 };
+	SteamLeaderboard_t m_hSteamLeaderboard;
+	SteamLeaderboardEntries_t m_hSteamLeaderboardEntries;	// the handle to pass into GetDownloadedLeaderboardEntries()
+	int m_cEntryCount; // the number of entries downloaded
+};
+
+
+//-----------------------------------------------------------------------------
+// Purpose: call result indicating scores has been uploaded, returned as a result of UploadLeaderboardScore()
+//			use CCallResult<> to map this async result to a member function
+//-----------------------------------------------------------------------------
+struct LeaderboardScoreUploaded_t
+{
+	enum { k_iCallback = k_iSteamUserStatsCallbacks + 6 };
+	uint8 m_bSuccess;			// 1 if the call was successful
+	SteamLeaderboard_t m_hSteamLeaderboard;	// the leaderboard handle that was
+	int32 m_nScore;				// the score that was attempted to set
+	uint8 m_bScoreChanged;		// true if the score in the leaderboard change, false if the existing score was better
+	int m_nGlobalRankNew;		// the new global rank of the user in this leaderboard
+	int m_nGlobalRankPrevious;	// the previous global rank of the user in this leaderboard; 0 if the user had no existing entry in the leaderboard
+};
+
+struct NumberOfCurrentPlayers_t
+{
+	enum { k_iCallback = k_iSteamUserStatsCallbacks + 7 };
+	uint8 m_bSuccess;			// 1 if the call was successful
+	int32 m_cPlayers;			// Number of players currently playing
+};
+
+
+
+//-----------------------------------------------------------------------------
+// Purpose: Callback indicating that a user's stats have been unloaded.
+//  Call RequestUserStats again to access stats for this user
+//-----------------------------------------------------------------------------
+struct UserStatsUnloaded_t
+{
+	enum { k_iCallback = k_iSteamUserStatsCallbacks + 8 };
+	CSteamID	m_steamIDUser;	// User whose stats have been unloaded
+};
+
+
+
+//-----------------------------------------------------------------------------
+// Purpose: Callback indicating that an achievement icon has been fetched
+//-----------------------------------------------------------------------------
+struct UserAchievementIconFetched_t
+{
+	enum { k_iCallback = k_iSteamUserStatsCallbacks + 9 };
+
+	CGameID		m_nGameID;				// Game this is for
+	char		m_rgchAchievementName[k_cchStatNameMax];		// name of the achievement
+	bool		m_bAchieved;		// Is the icon for the achieved or not achieved version?
+	int			m_nIconHandle;		// Handle to the image, which can be used in SteamUtils()->GetImageRGBA(), 0 means no image is set for the achievement
+};
+
+
+//-----------------------------------------------------------------------------
+// Purpose: Callback indicating that global achievement percentages are fetched
+//-----------------------------------------------------------------------------
+struct GlobalAchievementPercentagesReady_t
+{
+	enum { k_iCallback = k_iSteamUserStatsCallbacks + 10 };
+
+	uint64		m_nGameID;				// Game this is for
+	EResult		m_eResult;				// Result of the operation
+};
+
+
+//-----------------------------------------------------------------------------
+// Purpose: call result indicating UGC has been uploaded, returned as a result of SetLeaderboardUGC()
+//-----------------------------------------------------------------------------
+struct LeaderboardUGCSet_t
+{
+	enum { k_iCallback = k_iSteamUserStatsCallbacks + 11 };
+	EResult m_eResult;				// The result of the operation
+	SteamLeaderboard_t m_hSteamLeaderboard;	// the leaderboard handle that was
+};
+
+
+//-----------------------------------------------------------------------------
+// Purpose: callback indicating that PS3 trophies have been installed
+//-----------------------------------------------------------------------------
+struct PS3TrophiesInstalled_t
+{
+	enum { k_iCallback = k_iSteamUserStatsCallbacks + 12 };
+	uint64	m_nGameID;				// Game these stats are for
+	EResult m_eResult;				// The result of the operation
+	uint64 m_ulRequiredDiskSpace;	// If m_eResult is k_EResultDiskFull, will contain the amount of space needed to install trophies
+
+};
+
+
+//-----------------------------------------------------------------------------
+// Purpose: callback indicating global stats have been received.
+//	Returned as a result of RequestGlobalStats()
+//-----------------------------------------------------------------------------
+struct GlobalStatsReceived_t
+{
+	enum { k_iCallback = k_iSteamUserStatsCallbacks + 12 };
+	uint64	m_nGameID;				// Game global stats were requested for
+	EResult	m_eResult;				// The result of the request
+};
+
+#pragma pack( pop )
+
+
+#endif // ISTEAMUSER_H

--- a/Common/Chairloader/SteamAPI/isteamutils.h
+++ b/Common/Chairloader/SteamAPI/isteamutils.h
@@ -1,0 +1,254 @@
+//====== Copyright � 1996-2008, Valve Corporation, All rights reserved. =======
+//
+// Purpose: interface to utility functions in Steam
+//
+//=============================================================================
+
+#ifndef ISTEAMUTILS_H
+#define ISTEAMUTILS_H
+#ifdef _WIN32
+#pragma once
+#endif
+
+#include "isteamclient.h"
+
+
+// Steam API call failure results
+enum ESteamAPICallFailure
+{
+	k_ESteamAPICallFailureNone = -1,			// no failure
+	k_ESteamAPICallFailureSteamGone = 0,		// the local Steam process has gone away
+	k_ESteamAPICallFailureNetworkFailure = 1,	// the network connection to Steam has been broken, or was already broken
+	// SteamServersDisconnected_t callback will be sent around the same time
+	// SteamServersConnected_t will be sent when the client is able to talk to the Steam servers again
+	k_ESteamAPICallFailureInvalidHandle = 2,	// the SteamAPICall_t handle passed in no longer exists
+	k_ESteamAPICallFailureMismatchedCallback = 3,// GetAPICallResult() was called with the wrong callback type for this API call
+};
+
+
+// Input modes for the Big Picture gamepad text entry
+enum EGamepadTextInputMode
+{
+	k_EGamepadTextInputModeNormal = 0,
+	k_EGamepadTextInputModePassword = 1
+};
+
+
+// Controls number of allowed lines for the Big Picture gamepad text entry
+enum EGamepadTextInputLineMode
+{
+	k_EGamepadTextInputLineModeSingleLine = 0,
+	k_EGamepadTextInputLineModeMultipleLines = 1
+};
+
+
+// function prototype for warning message hook
+#if defined( POSIX )
+#define __cdecl
+#endif
+extern "C" typedef void (__cdecl *SteamAPIWarningMessageHook_t)(int, const char *);
+
+//-----------------------------------------------------------------------------
+// Purpose: interface to user independent utility functions
+//-----------------------------------------------------------------------------
+class ISteamUtils
+{
+public:
+	// return the number of seconds since the user 
+	virtual uint32 GetSecondsSinceAppActive() = 0;
+	virtual uint32 GetSecondsSinceComputerActive() = 0;
+
+	// the universe this client is connecting to
+	virtual EUniverse GetConnectedUniverse() = 0;
+
+	// Steam server time.  Number of seconds since January 1, 1970, GMT (i.e unix time)
+	virtual uint32 GetServerRealTime() = 0;
+
+	// returns the 2 digit ISO 3166-1-alpha-2 format country code this client is running in (as looked up via an IP-to-location database)
+	// e.g "US" or "UK".
+	virtual const char *GetIPCountry() = 0;
+
+	// returns true if the image exists, and valid sizes were filled out
+	virtual bool GetImageSize( int iImage, uint32 *pnWidth, uint32 *pnHeight ) = 0;
+
+	// returns true if the image exists, and the buffer was successfully filled out
+	// results are returned in RGBA format
+	// the destination buffer size should be 4 * height * width * sizeof(char)
+	virtual bool GetImageRGBA( int iImage, uint8 *pubDest, int nDestBufferSize ) = 0;
+
+	// returns the IP of the reporting server for valve - currently only used in Source engine games
+	virtual bool GetCSERIPPort( uint32 *unIP, uint16 *usPort ) = 0;
+
+	// return the amount of battery power left in the current system in % [0..100], 255 for being on AC power
+	virtual uint8 GetCurrentBatteryPower() = 0;
+
+	// returns the appID of the current process
+	virtual uint32 GetAppID() = 0;
+
+	// Sets the position where the overlay instance for the currently calling game should show notifications.
+	// This position is per-game and if this function is called from outside of a game context it will do nothing.
+	virtual void SetOverlayNotificationPosition( ENotificationPosition eNotificationPosition ) = 0;
+
+	// API asynchronous call results
+	// can be used directly, but more commonly used via the callback dispatch API (see steam_api.h)
+	virtual bool IsAPICallCompleted( SteamAPICall_t hSteamAPICall, bool *pbFailed ) = 0;
+	virtual ESteamAPICallFailure GetAPICallFailureReason( SteamAPICall_t hSteamAPICall ) = 0;
+	virtual bool GetAPICallResult( SteamAPICall_t hSteamAPICall, void *pCallback, int cubCallback, int iCallbackExpected, bool *pbFailed ) = 0;
+
+	// Deprecated. Applications should use SteamAPI_RunCallbacks() instead. Game servers do not need to call this function.
+	STEAM_PRIVATE_API( virtual void RunFrame() = 0; )
+
+	// returns the number of IPC calls made since the last time this function was called
+	// Used for perf debugging so you can understand how many IPC calls your game makes per frame
+	// Every IPC call is at minimum a thread context switch if not a process one so you want to rate
+	// control how often you do them.
+	virtual uint32 GetIPCCallCount() = 0;
+
+	// API warning handling
+	// 'int' is the severity; 0 for msg, 1 for warning
+	// 'const char *' is the text of the message
+	// callbacks will occur directly after the API function is called that generated the warning or message
+	virtual void SetWarningMessageHook( SteamAPIWarningMessageHook_t pFunction ) = 0;
+
+	// Returns true if the overlay is running & the user can access it. The overlay process could take a few seconds to
+	// start & hook the game process, so this function will initially return false while the overlay is loading.
+	virtual bool IsOverlayEnabled() = 0;
+
+	// Normally this call is unneeded if your game has a constantly running frame loop that calls the 
+	// D3D Present API, or OGL SwapBuffers API every frame.
+	//
+	// However, if you have a game that only refreshes the screen on an event driven basis then that can break 
+	// the overlay, as it uses your Present/SwapBuffers calls to drive it's internal frame loop and it may also
+	// need to Present() to the screen any time an even needing a notification happens or when the overlay is
+	// brought up over the game by a user.  You can use this API to ask the overlay if it currently need a present
+	// in that case, and then you can check for this periodically (roughly 33hz is desirable) and make sure you
+	// refresh the screen with Present or SwapBuffers to allow the overlay to do it's work.
+	virtual bool BOverlayNeedsPresent() = 0;
+
+	// Asynchronous call to check if an executable file has been signed using the public key set on the signing tab
+	// of the partner site, for example to refuse to load modified executable files.  
+	// The result is returned in CheckFileSignature_t.
+	//   k_ECheckFileSignatureNoSignaturesFoundForThisApp - This app has not been configured on the signing tab of the partner site to enable this function.
+	//   k_ECheckFileSignatureNoSignaturesFoundForThisFile - This file is not listed on the signing tab for the partner site.
+	//   k_ECheckFileSignatureFileNotFound - The file does not exist on disk.
+	//   k_ECheckFileSignatureInvalidSignature - The file exists, and the signing tab has been set for this file, but the file is either not signed or the signature does not match.
+	//   k_ECheckFileSignatureValidSignature - The file is signed and the signature is valid.
+	CALL_RESULT( CheckFileSignature_t )
+	virtual SteamAPICall_t CheckFileSignature( const char *szFileName ) = 0;
+
+	// Activates the Big Picture text input dialog which only supports gamepad input
+	virtual bool ShowGamepadTextInput( EGamepadTextInputMode eInputMode, EGamepadTextInputLineMode eLineInputMode, const char *pchDescription, uint32 unCharMax, const char *pchExistingText ) = 0;
+
+	// Returns previously entered text & length
+	virtual uint32 GetEnteredGamepadTextLength() = 0;
+	virtual bool GetEnteredGamepadTextInput( char *pchText, uint32 cchText ) = 0;
+
+	// returns the language the steam client is running in, you probably want ISteamApps::GetCurrentGameLanguage instead, this is for very special usage cases
+	virtual const char *GetSteamUILanguage() = 0;
+
+	// returns true if Steam itself is running in VR mode
+	virtual bool IsSteamRunningInVR() = 0;
+	
+	// Sets the inset of the overlay notification from the corner specified by SetOverlayNotificationPosition.
+	virtual void SetOverlayNotificationInset( int nHorizontalInset, int nVerticalInset ) = 0;
+
+	// returns true if Steam & the Steam Overlay are running in Big Picture mode
+	// Games much be launched through the Steam client to enable the Big Picture overlay. During development,
+	// a game can be added as a non-steam game to the developers library to test this feature
+	virtual bool IsSteamInBigPictureMode() = 0;
+
+	// ask SteamUI to create and render its OpenVR dashboard
+	virtual void StartVRDashboard() = 0;
+};
+
+#define STEAMUTILS_INTERFACE_VERSION "SteamUtils008"
+
+
+// callbacks
+#if defined( VALVE_CALLBACK_PACK_SMALL )
+#pragma pack( push, 4 )
+#elif defined( VALVE_CALLBACK_PACK_LARGE )
+#pragma pack( push, 8 )
+#else
+#error isteamclient.h must be included
+#endif 
+
+//-----------------------------------------------------------------------------
+// Purpose: The country of the user changed
+//-----------------------------------------------------------------------------
+struct IPCountry_t
+{
+	enum { k_iCallback = k_iSteamUtilsCallbacks + 1 };
+};
+
+
+//-----------------------------------------------------------------------------
+// Purpose: Fired when running on a laptop and less than 10 minutes of battery is left, fires then every minute
+//-----------------------------------------------------------------------------
+struct LowBatteryPower_t
+{
+	enum { k_iCallback = k_iSteamUtilsCallbacks + 2 };
+	uint8 m_nMinutesBatteryLeft;
+};
+
+
+//-----------------------------------------------------------------------------
+// Purpose: called when a SteamAsyncCall_t has completed (or failed)
+//-----------------------------------------------------------------------------
+struct SteamAPICallCompleted_t
+{
+	enum { k_iCallback = k_iSteamUtilsCallbacks + 3 };
+	SteamAPICall_t m_hAsyncCall;
+	int m_iCallback;
+	uint32 m_cubParam;
+};
+
+
+//-----------------------------------------------------------------------------
+// called when Steam wants to shutdown
+//-----------------------------------------------------------------------------
+struct SteamShutdown_t
+{
+	enum { k_iCallback = k_iSteamUtilsCallbacks + 4 };
+};
+
+//-----------------------------------------------------------------------------
+// results for CheckFileSignature
+//-----------------------------------------------------------------------------
+enum ECheckFileSignature
+{
+	k_ECheckFileSignatureInvalidSignature = 0,
+	k_ECheckFileSignatureValidSignature = 1,
+	k_ECheckFileSignatureFileNotFound = 2,
+	k_ECheckFileSignatureNoSignaturesFoundForThisApp = 3,
+	k_ECheckFileSignatureNoSignaturesFoundForThisFile = 4,
+};
+
+//-----------------------------------------------------------------------------
+// callback for CheckFileSignature
+//-----------------------------------------------------------------------------
+struct CheckFileSignature_t
+{
+	enum { k_iCallback = k_iSteamUtilsCallbacks + 5 };
+	ECheckFileSignature m_eCheckFileSignature;
+};
+
+
+// k_iSteamUtilsCallbacks + 13 is taken
+
+
+//-----------------------------------------------------------------------------
+// Big Picture gamepad text input has been closed
+//-----------------------------------------------------------------------------
+struct GamepadTextInputDismissed_t
+{
+	enum { k_iCallback = k_iSteamUtilsCallbacks + 14 };
+	bool m_bSubmitted;										// true if user entered & accepted text (Call ISteamUtils::GetEnteredGamepadTextInput() for text), false if canceled input
+	uint32 m_unSubmittedText;
+};
+
+// k_iSteamUtilsCallbacks + 15 is taken
+
+#pragma pack( pop )
+
+#endif // ISTEAMUTILS_H

--- a/Common/Chairloader/SteamAPI/isteamvideo.h
+++ b/Common/Chairloader/SteamAPI/isteamvideo.h
@@ -1,0 +1,60 @@
+//====== Copyright © 1996-2014 Valve Corporation, All rights reserved. =======
+//
+// Purpose: interface to Steam Video
+//
+//=============================================================================
+
+#ifndef ISTEAMVIDEO_H
+#define ISTEAMVIDEO_H
+#ifdef _WIN32
+#pragma once
+#endif
+
+#include "isteamclient.h"
+
+// callbacks
+#if defined( VALVE_CALLBACK_PACK_SMALL )
+#pragma pack( push, 4 )
+#elif defined( VALVE_CALLBACK_PACK_LARGE )
+#pragma pack( push, 8 )
+#else
+#error isteamclient.h must be included
+#endif
+
+
+
+
+//-----------------------------------------------------------------------------
+// Purpose: Steam Video API
+//-----------------------------------------------------------------------------
+class ISteamVideo
+{
+public:
+
+	// Get a URL suitable for streaming the given Video app ID's video
+	virtual void GetVideoURL( AppId_t unVideoAppID ) = 0;
+
+	// returns true if user is uploading a live broadcast
+	virtual bool IsBroadcasting( int *pnNumViewers ) = 0;
+};
+
+#define STEAMVIDEO_INTERFACE_VERSION "STEAMVIDEO_INTERFACE_V001"
+
+DEFINE_CALLBACK( BroadcastUploadStart_t, k_iClientVideoCallbacks + 4 )
+END_DEFINE_CALLBACK_0()
+
+DEFINE_CALLBACK( BroadcastUploadStop_t, k_iClientVideoCallbacks + 5 )
+	CALLBACK_MEMBER( 0, EBroadcastUploadResult, m_eResult )
+END_DEFINE_CALLBACK_1()
+
+DEFINE_CALLBACK( GetVideoURLResult_t, k_iClientVideoCallbacks + 11 )
+	CALLBACK_MEMBER( 0, EResult, m_eResult )
+	CALLBACK_MEMBER( 1, AppId_t, m_unVideoAppID )
+	CALLBACK_MEMBER( 2, char, m_rgchURL[256] )
+END_DEFINE_CALLBACK_1()
+
+
+#pragma pack( pop )
+
+
+#endif // ISTEAMVIDEO_H

--- a/Common/Chairloader/SteamAPI/matchmakingtypes.h
+++ b/Common/Chairloader/SteamAPI/matchmakingtypes.h
@@ -1,0 +1,251 @@
+//========= Copyright � 1996-2008, Valve LLC, All rights reserved. ============
+//
+// Purpose: 
+//
+// $NoKeywords: $
+//=============================================================================
+
+#ifndef MATCHMAKINGTYPES_H
+#define MATCHMAKINGTYPES_H
+
+#ifdef _WIN32
+#pragma once
+#endif
+
+#ifdef POSIX
+#ifndef _snprintf
+#define _snprintf snprintf
+#endif
+#endif
+
+#include <stdio.h>
+#include <string.h>
+
+//
+// Max size (in bytes of UTF-8 data, not in characters) of server fields, including null terminator.
+// WARNING: These cannot be changed easily, without breaking clients using old interfaces.
+//
+const int k_cbMaxGameServerGameDir = 32;
+const int k_cbMaxGameServerMapName = 32;
+const int k_cbMaxGameServerGameDescription = 64;
+const int k_cbMaxGameServerName = 64;
+const int k_cbMaxGameServerTags = 128;
+const int k_cbMaxGameServerGameData = 2048;
+
+/// Store key/value pair used in matchmaking queries.
+///
+/// Actually, the name Key/Value is a bit misleading.  The "key" is better
+/// understood as "filter operation code" and the "value" is the operand to this
+/// filter operation.  The meaning of the operand depends upon the filter.
+struct MatchMakingKeyValuePair_t
+{
+	MatchMakingKeyValuePair_t() { m_szKey[0] = m_szValue[0] = 0; }
+	MatchMakingKeyValuePair_t( const char *pchKey, const char *pchValue )
+	{
+		strncpy( m_szKey, pchKey, sizeof(m_szKey) ); // this is a public header, use basic c library string funcs only!
+		m_szKey[ sizeof( m_szKey ) - 1 ] = '\0';
+		strncpy( m_szValue, pchValue, sizeof(m_szValue) );
+		m_szValue[ sizeof( m_szValue ) - 1 ] = '\0';
+	}
+	char m_szKey[ 256 ];
+	char m_szValue[ 256 ];
+};
+
+
+enum EMatchMakingServerResponse
+{
+	eServerResponded = 0,
+	eServerFailedToRespond,
+	eNoServersListedOnMasterServer // for the Internet query type, returned in response callback if no servers of this type match
+};
+
+// servernetadr_t is all the addressing info the serverbrowser needs to know about a game server,
+// namely: its IP, its connection port, and its query port.
+class servernetadr_t 
+{
+public:
+
+	servernetadr_t() : m_usConnectionPort( 0 ), m_usQueryPort( 0 ), m_unIP( 0 ) {}
+	
+	void	Init( unsigned int ip, uint16 usQueryPort, uint16 usConnectionPort );
+#ifdef NETADR_H
+	netadr_t	GetIPAndQueryPort();
+#endif
+	
+	// Access the query port.
+	uint16	GetQueryPort() const;
+	void	SetQueryPort( uint16 usPort );
+
+	// Access the connection port.
+	uint16	GetConnectionPort() const;
+	void	SetConnectionPort( uint16 usPort );
+
+	// Access the IP
+	uint32 GetIP() const;
+	void SetIP( uint32 );
+
+	// This gets the 'a.b.c.d:port' string with the connection port (instead of the query port).
+	const char *GetConnectionAddressString() const;
+	const char *GetQueryAddressString() const;
+
+	// Comparison operators and functions.
+	bool	operator<(const servernetadr_t &netadr) const;
+	void operator=( const servernetadr_t &that )
+	{
+		m_usConnectionPort = that.m_usConnectionPort;
+		m_usQueryPort = that.m_usQueryPort;
+		m_unIP = that.m_unIP;
+	}
+
+	
+private:
+	const char *ToString( uint32 unIP, uint16 usPort ) const;
+	uint16	m_usConnectionPort;	// (in HOST byte order)
+	uint16	m_usQueryPort;
+	uint32  m_unIP;
+};
+
+
+inline void	servernetadr_t::Init( unsigned int ip, uint16 usQueryPort, uint16 usConnectionPort )
+{
+	m_unIP = ip;
+	m_usQueryPort = usQueryPort;
+	m_usConnectionPort = usConnectionPort;
+}
+
+#ifdef NETADR_H
+inline netadr_t servernetadr_t::GetIPAndQueryPort()
+{
+	return netadr_t( m_unIP, m_usQueryPort );
+}
+#endif
+
+inline uint16 servernetadr_t::GetQueryPort() const
+{
+	return m_usQueryPort;
+}
+
+inline void	servernetadr_t::SetQueryPort( uint16 usPort )
+{
+	m_usQueryPort = usPort;
+}
+
+inline uint16 servernetadr_t::GetConnectionPort() const
+{
+	return m_usConnectionPort;
+}
+
+inline void	servernetadr_t::SetConnectionPort( uint16 usPort )
+{
+	m_usConnectionPort = usPort;
+}
+
+inline uint32 servernetadr_t::GetIP() const
+{
+	return m_unIP;
+}
+
+inline void	servernetadr_t::SetIP( uint32 unIP )
+{
+	m_unIP = unIP;
+}
+
+inline const char *servernetadr_t::ToString( uint32 unIP, uint16 usPort ) const
+{
+	static char s[4][64];
+	static int nBuf = 0;
+	unsigned char *ipByte = (unsigned char *)&unIP;
+#ifdef VALVE_BIG_ENDIAN
+	_snprintf (s[nBuf], sizeof( s[nBuf] ), "%u.%u.%u.%u:%i", (int)(ipByte[0]), (int)(ipByte[1]), (int)(ipByte[2]), (int)(ipByte[3]), usPort );
+#else
+	_snprintf (s[nBuf], sizeof( s[nBuf] ), "%u.%u.%u.%u:%i", (int)(ipByte[3]), (int)(ipByte[2]), (int)(ipByte[1]), (int)(ipByte[0]), usPort );
+#endif
+	const char *pchRet = s[nBuf];
+	++nBuf;
+	nBuf %= ( (sizeof(s)/sizeof(s[0])) );
+	return pchRet;
+}
+
+inline const char* servernetadr_t::GetConnectionAddressString() const
+{
+	return ToString( m_unIP, m_usConnectionPort );
+}
+
+inline const char* servernetadr_t::GetQueryAddressString() const
+{
+	return ToString( m_unIP, m_usQueryPort );	
+}
+
+inline bool servernetadr_t::operator<(const servernetadr_t &netadr) const
+{
+	return ( m_unIP < netadr.m_unIP ) || ( m_unIP == netadr.m_unIP && m_usQueryPort < netadr.m_usQueryPort );
+}
+
+//-----------------------------------------------------------------------------
+// Purpose: Data describing a single server
+//-----------------------------------------------------------------------------
+class gameserveritem_t
+{
+public:
+	gameserveritem_t();
+
+	const char* GetName() const;
+	void SetName( const char *pName );
+
+public:
+	servernetadr_t m_NetAdr;									///< IP/Query Port/Connection Port for this server
+	int m_nPing;												///< current ping time in milliseconds
+	bool m_bHadSuccessfulResponse;								///< server has responded successfully in the past
+	bool m_bDoNotRefresh;										///< server is marked as not responding and should no longer be refreshed
+	char m_szGameDir[k_cbMaxGameServerGameDir];					///< current game directory
+	char m_szMap[k_cbMaxGameServerMapName];						///< current map
+	char m_szGameDescription[k_cbMaxGameServerGameDescription];	///< game description
+	uint32 m_nAppID;											///< Steam App ID of this server
+	int m_nPlayers;												///< total number of players currently on the server.  INCLUDES BOTS!!
+	int m_nMaxPlayers;											///< Maximum players that can join this server
+	int m_nBotPlayers;											///< Number of bots (i.e simulated players) on this server
+	bool m_bPassword;											///< true if this server needs a password to join
+	bool m_bSecure;												///< Is this server protected by VAC
+	uint32 m_ulTimeLastPlayed;									///< time (in unix time) when this server was last played on (for favorite/history servers)
+	int	m_nServerVersion;										///< server version as reported to Steam
+
+private:
+
+	/// Game server name
+	char m_szServerName[k_cbMaxGameServerName];
+
+	// For data added after SteamMatchMaking001 add it here
+public:
+	/// the tags this server exposes
+	char m_szGameTags[k_cbMaxGameServerTags];
+
+	/// steamID of the game server - invalid if it's doesn't have one (old server, or not connected to Steam)
+	CSteamID m_steamID;
+};
+
+
+inline gameserveritem_t::gameserveritem_t()
+{
+	m_szGameDir[0] = m_szMap[0] = m_szGameDescription[0] = m_szServerName[0] = 0;
+	m_bHadSuccessfulResponse = m_bDoNotRefresh = m_bPassword = m_bSecure = false;
+	m_nPing = m_nAppID = m_nPlayers = m_nMaxPlayers = m_nBotPlayers = m_ulTimeLastPlayed = m_nServerVersion = 0;
+	m_szGameTags[0] = 0;
+}
+
+inline const char* gameserveritem_t::GetName() const
+{
+	// Use the IP address as the name if nothing is set yet.
+	if ( m_szServerName[0] == 0 )
+		return m_NetAdr.GetConnectionAddressString();
+	else
+		return m_szServerName;
+}
+
+inline void gameserveritem_t::SetName( const char *pName )
+{
+	strncpy( m_szServerName, pName, sizeof( m_szServerName ) );
+	m_szServerName[ sizeof( m_szServerName ) - 1 ] = '\0';
+}
+
+
+#endif // MATCHMAKINGTYPES_H

--- a/Common/Chairloader/SteamAPI/steam_api.h
+++ b/Common/Chairloader/SteamAPI/steam_api.h
@@ -1,0 +1,377 @@
+//====== Copyright 1996-2008, Valve Corporation, All rights reserved. =======
+//
+// Purpose: 
+//
+//=============================================================================
+
+#ifndef STEAM_API_H
+#define STEAM_API_H
+#ifdef _WIN32
+#pragma once
+#endif
+
+#include "isteamclient.h"
+#include "isteamuser.h"
+#include "isteamfriends.h"
+#include "isteamutils.h"
+#include "isteammatchmaking.h"
+#include "isteamuserstats.h"
+#include "isteamapps.h"
+#include "isteamnetworking.h"
+#include "isteamremotestorage.h"
+#include "isteamscreenshots.h"
+#include "isteammusic.h"
+#include "isteammusicremote.h"
+#include "isteamhttp.h"
+#include "isteamunifiedmessages.h"
+#include "isteamcontroller.h"
+#include "isteamugc.h"
+#include "isteamapplist.h"
+#include "isteamhtmlsurface.h"
+#include "isteaminventory.h"
+#include "isteamvideo.h"
+
+
+// Steam API export macro
+#if defined( _WIN32 ) && !defined( _X360 )
+	// Functions are implemented in steam_api_chairloader.cpp.
+	#define S_API extern "C"
+#endif
+
+//----------------------------------------------------------------------------------------------------------------------------------------------------------//
+//	Steam API setup & shutdown
+//
+//	These functions manage loading, initializing and shutdown of the steamclient.dll
+//
+//----------------------------------------------------------------------------------------------------------------------------------------------------------//
+
+
+// SteamAPI_Init must be called before using any other API functions. If it fails, an
+// error message will be output to the debugger (or stderr) with further information.
+S_API bool S_CALLTYPE SteamAPI_Init();
+
+// SteamAPI_Shutdown should be called during process shutdown if possible.
+S_API void S_CALLTYPE SteamAPI_Shutdown();
+
+// SteamAPI_RestartAppIfNecessary ensures that your executable was launched through Steam.
+//
+// Returns true if the current process should terminate. Steam is now re-launching your application.
+//
+// Returns false if no action needs to be taken. This means that your executable was started through
+// the Steam client, or a steam_appid.txt file is present in your game's directory (for development).
+// Your current process should continue if false is returned.
+//
+// NOTE: If you use the Steam DRM wrapper on your primary executable file, this check is unnecessary
+// since the DRM wrapper will ensure that your application was launched properly through Steam.
+S_API bool S_CALLTYPE SteamAPI_RestartAppIfNecessary( uint32 unOwnAppID );
+
+// Many Steam API functions allocate a small amount of thread-local memory for parameter storage.
+// SteamAPI_ReleaseCurrentThreadMemory() will free API memory associated with the calling thread.
+// This function is also called automatically by SteamAPI_RunCallbacks(), so a single-threaded
+// program never needs to explicitly call this function.
+S_API void S_CALLTYPE SteamAPI_ReleaseCurrentThreadMemory();
+
+
+// crash dump recording functions
+S_API void S_CALLTYPE SteamAPI_WriteMiniDump( uint32 uStructuredExceptionCode, void* pvExceptionInfo, uint32 uBuildID );
+S_API void S_CALLTYPE SteamAPI_SetMiniDumpComment( const char *pchMsg );
+
+
+//----------------------------------------------------------------------------------------------------------------------------------------------------------//
+// Global accessors for Steamworks C++ APIs. See individual isteam*.h files for details.
+// You should not cache the results of these accessors or pass the result pointers across
+// modules! Different modules may be compiled against different SDK header versions, and
+// the interface pointers could therefore be different across modules. Every line of code
+// which calls into a Steamworks API should retrieve the interface from a global accessor.
+//----------------------------------------------------------------------------------------------------------------------------------------------------------//
+#if !defined( STEAM_API_EXPORTS )
+inline ISteamClient *SteamClient();
+inline ISteamUser *SteamUser();
+inline ISteamFriends *SteamFriends();
+inline ISteamUtils *SteamUtils();
+inline ISteamMatchmaking *SteamMatchmaking();
+inline ISteamUserStats *SteamUserStats();
+inline ISteamApps *SteamApps();
+inline ISteamNetworking *SteamNetworking();
+inline ISteamMatchmakingServers *SteamMatchmakingServers();
+inline ISteamRemoteStorage *SteamRemoteStorage();
+inline ISteamScreenshots *SteamScreenshots();
+inline ISteamHTTP *SteamHTTP();
+inline ISteamUnifiedMessages *SteamUnifiedMessages();
+inline ISteamController *SteamController();
+inline ISteamUGC *SteamUGC();
+inline ISteamAppList *SteamAppList();
+inline ISteamMusic *SteamMusic();
+inline ISteamMusicRemote *SteamMusicRemote();
+inline ISteamHTMLSurface *SteamHTMLSurface();
+inline ISteamInventory *SteamInventory();
+inline ISteamVideo *SteamVideo();
+#endif // VERSION_SAFE_STEAM_API_INTERFACES
+
+
+// CSteamAPIContext encapsulates the Steamworks API global accessors into
+// a single object. This is DEPRECATED and only remains for compatibility.
+class CSteamAPIContext
+{
+public:
+	// DEPRECATED - there is no benefit to using this over the global accessors
+	CSteamAPIContext() { Clear(); }
+	void Clear();
+	bool Init();
+	ISteamClient*		SteamClient() const					{ return m_pSteamClient; }
+	ISteamUser*			SteamUser() const					{ return m_pSteamUser; }
+	ISteamFriends*		SteamFriends() const				{ return m_pSteamFriends; }
+	ISteamUtils*		SteamUtils() const					{ return m_pSteamUtils; }
+	ISteamMatchmaking*	SteamMatchmaking() const			{ return m_pSteamMatchmaking; }
+	ISteamUserStats*	SteamUserStats() const				{ return m_pSteamUserStats; }
+	ISteamApps*			SteamApps() const					{ return m_pSteamApps; }
+	ISteamMatchmakingServers* SteamMatchmakingServers() const { return m_pSteamMatchmakingServers; }
+	ISteamNetworking*	SteamNetworking() const				{ return m_pSteamNetworking; }
+	ISteamRemoteStorage* SteamRemoteStorage() const			{ return m_pSteamRemoteStorage; }
+	ISteamScreenshots*	SteamScreenshots() const			{ return m_pSteamScreenshots; }
+	ISteamHTTP*			SteamHTTP() const					{ return m_pSteamHTTP; }
+	ISteamUnifiedMessages* SteamUnifiedMessages() const		{ return m_pSteamUnifiedMessages; }
+	ISteamController*	SteamController() const				{ return m_pController; }
+	ISteamUGC*			SteamUGC() const					{ return m_pSteamUGC; }
+	ISteamAppList*		SteamAppList() const				{ return m_pSteamAppList; }
+	ISteamMusic*		SteamMusic() const					{ return m_pSteamMusic; }
+	ISteamMusicRemote*	SteamMusicRemote() const			{ return m_pSteamMusicRemote; }
+	ISteamHTMLSurface*	SteamHTMLSurface() const			{ return m_pSteamHTMLSurface; }
+	ISteamInventory*	SteamInventory() const				{ return m_pSteamInventory; }
+	ISteamVideo*		SteamVideo() const					{ return m_pSteamVideo; }
+	// DEPRECATED - there is no benefit to using this over the global accessors
+private:
+	ISteamClient		*m_pSteamClient;
+	ISteamUser			*m_pSteamUser;
+	ISteamFriends		*m_pSteamFriends;
+	ISteamUtils			*m_pSteamUtils;
+	ISteamMatchmaking	*m_pSteamMatchmaking;
+	ISteamUserStats		*m_pSteamUserStats;
+	ISteamApps			*m_pSteamApps;
+	ISteamMatchmakingServers *m_pSteamMatchmakingServers;
+	ISteamNetworking	*m_pSteamNetworking;
+	ISteamRemoteStorage *m_pSteamRemoteStorage;
+	ISteamScreenshots	*m_pSteamScreenshots;
+	ISteamHTTP			*m_pSteamHTTP;
+	ISteamUnifiedMessages *m_pSteamUnifiedMessages;
+	ISteamController	*m_pController;
+	ISteamUGC			*m_pSteamUGC;
+	ISteamAppList		*m_pSteamAppList;
+	ISteamMusic			*m_pSteamMusic;
+	ISteamMusicRemote	*m_pSteamMusicRemote;
+	ISteamHTMLSurface	*m_pSteamHTMLSurface;
+	ISteamInventory		*m_pSteamInventory;
+	ISteamVideo			*m_pSteamVideo;
+};
+
+
+//----------------------------------------------------------------------------------------------------------------------------------------------------------//
+//	steam callback and call-result helpers
+//
+//	The following macros and classes are used to register your application for
+//	callbacks and call-results, which are delivered in a predictable manner.
+//
+//	STEAM_CALLBACK macros are meant for use inside of a C++ class definition.
+//	They map a Steam notification callback directly to a class member function
+//	which is automatically prototyped as "void func( callback_type *pParam )".
+//
+//	CCallResult is used with specific Steam APIs that return "result handles".
+//	The handle can be passed to a CCallResult object's Set function, along with
+//	an object pointer and member-function pointer. The member function will
+//	be executed once the results of the Steam API call are available.
+//
+//	CCallback and CCallbackManual classes can be used instead of STEAM_CALLBACK
+//	macros if you require finer control over registration and unregistration.
+//
+//	Callbacks and call-results are queued automatically and are only
+//	delivered/executed when your application calls SteamAPI_RunCallbacks().
+//----------------------------------------------------------------------------------------------------------------------------------------------------------//
+
+// SteamAPI_RunCallbacks is safe to call from multiple threads simultaneously,
+// but if you choose to do this, callback code could be executed on any thread.
+// One alternative is to call SteamAPI_RunCallbacks from the main thread only,
+// and call SteamAPI_ReleaseCurrentThreadMemory regularly on other threads.
+S_API void S_CALLTYPE SteamAPI_RunCallbacks();
+
+
+// Declares a callback member function plus a helper member variable which
+// registers the callback on object creation and unregisters on destruction.
+// The optional fourth 'var' param exists only for backwards-compatibility
+// and can be ignored.
+#define STEAM_CALLBACK( thisclass, func, .../*callback_type, [deprecated] var*/ ) \
+	_STEAM_CALLBACK_SELECT( ( __VA_ARGS__, 4, 3 ), ( /**/, thisclass, func, __VA_ARGS__ ) )
+
+// Declares a callback function and a named CCallbackManual variable which
+// has Register and Unregister functions instead of automatic registration.
+#define STEAM_CALLBACK_MANUAL( thisclass, func, callback_type, var )	\
+	CCallbackManual< thisclass, callback_type > var; void func( callback_type *pParam )
+
+
+// Internal functions used by the utility CCallback objects to receive callbacks
+S_API void S_CALLTYPE SteamAPI_RegisterCallback( class CCallbackBase *pCallback, int iCallback );
+S_API void S_CALLTYPE SteamAPI_UnregisterCallback( class CCallbackBase *pCallback );
+// Internal functions used by the utility CCallResult objects to receive async call results
+S_API void S_CALLTYPE SteamAPI_RegisterCallResult( class CCallbackBase *pCallback, SteamAPICall_t hAPICall );
+S_API void S_CALLTYPE SteamAPI_UnregisterCallResult( class CCallbackBase *pCallback, SteamAPICall_t hAPICall );
+
+
+//-----------------------------------------------------------------------------
+// Purpose: base for callbacks and call results - internal implementation detail
+//-----------------------------------------------------------------------------
+class CCallbackBase
+{
+public:
+	CCallbackBase() { m_nCallbackFlags = 0; m_iCallback = 0; }
+	// don't add a virtual destructor because we export this binary interface across dll's
+	virtual void Run( void *pvParam ) = 0;
+	virtual void Run( void *pvParam, bool bIOFailure, SteamAPICall_t hSteamAPICall ) = 0;
+	int GetICallback() { return m_iCallback; }
+	virtual int GetCallbackSizeBytes() = 0;
+
+protected:
+	enum { k_ECallbackFlagsRegistered = 0x01, k_ECallbackFlagsGameServer = 0x02 };
+	uint8 m_nCallbackFlags;
+	int m_iCallback;
+	friend class CCallbackMgr;
+
+private:
+	CCallbackBase( const CCallbackBase& );
+	CCallbackBase& operator=( const CCallbackBase& );
+};
+
+//-----------------------------------------------------------------------------
+// Purpose: templated base for callbacks - internal implementation detail
+//-----------------------------------------------------------------------------
+template< int sizeof_P >
+class CCallbackImpl : protected CCallbackBase
+{
+public:
+	~CCallbackImpl() { if ( m_nCallbackFlags & k_ECallbackFlagsRegistered ) SteamAPI_UnregisterCallback( this ); }
+	void SetGameserverFlag() { m_nCallbackFlags |= k_ECallbackFlagsGameServer; }
+
+protected:
+	virtual void Run( void *pvParam ) = 0;
+	virtual void Run( void *pvParam, bool /*bIOFailure*/, SteamAPICall_t /*hSteamAPICall*/ ) { Run( pvParam ); }
+	virtual int GetCallbackSizeBytes() { return sizeof_P; }
+};
+
+
+//-----------------------------------------------------------------------------
+// Purpose: maps a steam async call result to a class member function
+//			template params: T = local class, P = parameter struct
+//-----------------------------------------------------------------------------
+template< class T, class P >
+class CCallResult : private CCallbackBase
+{
+public:
+	typedef void (T::*func_t)( P*, bool );
+
+	CCallResult();
+	~CCallResult();
+	
+	void Set( SteamAPICall_t hAPICall, T *p, func_t func );
+	bool IsActive() const;
+	void Cancel();
+
+	void SetGameserverFlag() { m_nCallbackFlags |= k_ECallbackFlagsGameServer; }
+private:
+	virtual void Run( void *pvParam );
+	virtual void Run( void *pvParam, bool bIOFailure, SteamAPICall_t hSteamAPICall );
+	virtual int GetCallbackSizeBytes() { return sizeof( P ); }
+
+	SteamAPICall_t m_hAPICall;
+	T *m_pObj;
+	func_t m_Func;
+};
+
+
+
+//-----------------------------------------------------------------------------
+// Purpose: maps a steam callback to a class member function
+//			template params: T = local class, P = parameter struct,
+//			bGameserver = listen for gameserver callbacks instead of client callbacks
+//-----------------------------------------------------------------------------
+template< class T, class P, bool bGameserver = false >
+class CCallback : public CCallbackImpl< sizeof( P ) >
+{
+public:
+	typedef void (T::*func_t)(P*);
+
+	// NOTE: If you can't provide the correct parameters at construction time, you should
+	// use the CCallbackManual callback object (STEAM_CALLBACK_MANUAL macro) instead.
+	CCallback( T *pObj, func_t func );
+
+	void Register( T *pObj, func_t func );
+	void Unregister();
+
+protected:
+	virtual void Run( void *pvParam );
+	
+	T *m_pObj;
+	func_t m_Func;
+};
+
+
+//-----------------------------------------------------------------------------
+// Purpose: subclass of CCallback which allows default-construction in
+//			an unregistered state; you must call Register manually
+//-----------------------------------------------------------------------------
+template< class T, class P, bool bGameServer = false >
+class CCallbackManual : public CCallback< T, P, bGameServer >
+{
+public:
+	CCallbackManual() : CCallback< T, P, bGameServer >( NULL, NULL ) {}
+
+	// Inherits public Register and Unregister functions from base class
+};
+
+
+
+#ifdef _WIN32
+// disable this warning; this pattern need for steam callback registration
+#pragma warning( disable: 4355 )	// 'this' : used in base member initializer list
+#endif
+
+
+//----------------------------------------------------------------------------------------------------------------------------------------------------------//
+//	steamclient.dll private wrapper functions
+//
+//	The following functions are part of abstracting API access to the steamclient.dll, but should only be used in very specific cases
+//----------------------------------------------------------------------------------------------------------------------------------------------------------//
+
+// SteamAPI_IsSteamRunning() returns true if Steam is currently running
+S_API bool S_CALLTYPE SteamAPI_IsSteamRunning();
+
+// Pumps out all the steam messages, calling registered callbacks.
+// NOT THREADSAFE - do not call from multiple threads simultaneously.
+S_API void Steam_RunCallbacks( HSteamPipe hSteamPipe, bool bGameServerCallbacks );
+
+// register the callback funcs to use to interact with the steam dll
+S_API void Steam_RegisterInterfaceFuncs( void *hModule );
+
+// returns the HSteamUser of the last user to dispatch a callback
+S_API HSteamUser Steam_GetHSteamUserCurrent();
+
+// returns the filename path of the current running Steam process, used if you need to load an explicit steam dll by name.
+// DEPRECATED - implementation is Windows only, and the path returned is a UTF-8 string which must be converted to UTF-16 for use with Win32 APIs
+S_API const char *SteamAPI_GetSteamInstallPath();
+
+// returns the pipe we are communicating to Steam with
+S_API HSteamPipe SteamAPI_GetHSteamPipe();
+
+// sets whether or not Steam_RunCallbacks() should do a try {} catch (...) {} around calls to issuing callbacks
+S_API void SteamAPI_SetTryCatchCallbacks( bool bTryCatchCallbacks );
+
+// backwards compat export, passes through to SteamAPI_ variants
+S_API HSteamPipe GetHSteamPipe();
+S_API HSteamUser GetHSteamUser();
+
+
+#if defined( VERSION_SAFE_STEAM_API_INTERFACES )
+// exists only for backwards compat with code written against older SDKs
+S_API bool S_CALLTYPE SteamAPI_InitSafe();
+#endif
+
+#include "steam_api_internal.h"
+
+#endif // STEAM_API_H

--- a/Common/Chairloader/SteamAPI/steam_api_chairloader.cpp
+++ b/Common/Chairloader/SteamAPI/steam_api_chairloader.cpp
@@ -1,0 +1,56 @@
+#include <Chairloader/SteamAPI/IChairSteamAPI.h>
+
+S_API HSteamUser SteamAPI_GetHSteamUser()
+{
+    return gCL->pSteamAPI->GetHSteamUser();
+}
+
+S_API void S_CALLTYPE SteamAPI_RegisterCallback(class CCallbackBase* pCallback, int iCallback)
+{
+    gCL->pSteamAPI->RegisterCallback(pCallback, iCallback);
+}
+
+S_API void S_CALLTYPE SteamAPI_UnregisterCallback(class CCallbackBase* pCallback)
+{
+    gCL->pSteamAPI->UnregisterCallback(pCallback);
+}
+
+S_API void S_CALLTYPE SteamAPI_RegisterCallResult(class CCallbackBase* pCallback, SteamAPICall_t hAPICall)
+{
+    gCL->pSteamAPI->RegisterCallResult(pCallback, hAPICall);
+}
+
+S_API void S_CALLTYPE SteamAPI_UnregisterCallResult(class CCallbackBase* pCallback, SteamAPICall_t hAPICall)
+{
+    gCL->pSteamAPI->UnregisterCallResult(pCallback, hAPICall);
+}
+
+S_API bool S_CALLTYPE SteamAPI_IsSteamRunning()
+{
+    return gCL->pSteamAPI->IsSteamRunning();
+}
+
+S_API HSteamUser Steam_GetHSteamUserCurrent()
+{
+    return gCL->pSteamAPI->GetHSteamUserCurrent();
+}
+
+S_API const char* SteamAPI_GetSteamInstallPath()
+{
+    return gCL->pSteamAPI->GetSteamInstallPath();
+}
+
+S_API HSteamPipe SteamAPI_GetHSteamPipe()
+{
+    return gCL->pSteamAPI->GetHSteamPipe();
+}
+
+S_API void* S_CALLTYPE SteamInternal_CreateInterface(const char* ver)
+{
+    return gCL->pSteamAPI->Internal_CreateInterface(ver);
+}
+
+CSteamAPIContext& SteamInternal_ModuleContext()
+{
+    return gCL->pSteamAPI->GetContext();
+}

--- a/Common/Chairloader/SteamAPI/steam_api_chairloader.cpp
+++ b/Common/Chairloader/SteamAPI/steam_api_chairloader.cpp
@@ -1,56 +1,80 @@
 #include <Chairloader/SteamAPI/IChairSteamAPI.h>
 
+#ifndef CHAIRLOADER_MOD_SDK
+extern IChairSteamAPI* g_pIChairSteamAPI;
+static CSteamAPIContext g_EmptyContext;
+#endif
+
+static inline IChairSteamAPI* GetIChairSteamAPI()
+{
+#ifdef CHAIRLOADER_MOD_SDK
+    // Use the pointer from gCL
+    return gCL->pSteamAPI;
+#else
+    // Use g_pIChairSteamAPI in Chairloader.
+    // GOG integration partially emulates Steam API but not enough to expose it to mods.
+    return g_pIChairSteamAPI;
+#endif
+}
+
 S_API HSteamUser SteamAPI_GetHSteamUser()
 {
-    return gCL->pSteamAPI->GetHSteamUser();
+    return GetIChairSteamAPI()->GetHSteamUser();
 }
 
 S_API void S_CALLTYPE SteamAPI_RegisterCallback(class CCallbackBase* pCallback, int iCallback)
 {
-    gCL->pSteamAPI->RegisterCallback(pCallback, iCallback);
+    GetIChairSteamAPI()->RegisterCallback(pCallback, iCallback);
 }
 
 S_API void S_CALLTYPE SteamAPI_UnregisterCallback(class CCallbackBase* pCallback)
 {
-    gCL->pSteamAPI->UnregisterCallback(pCallback);
+    GetIChairSteamAPI()->UnregisterCallback(pCallback);
 }
 
 S_API void S_CALLTYPE SteamAPI_RegisterCallResult(class CCallbackBase* pCallback, SteamAPICall_t hAPICall)
 {
-    gCL->pSteamAPI->RegisterCallResult(pCallback, hAPICall);
+    GetIChairSteamAPI()->RegisterCallResult(pCallback, hAPICall);
 }
 
 S_API void S_CALLTYPE SteamAPI_UnregisterCallResult(class CCallbackBase* pCallback, SteamAPICall_t hAPICall)
 {
-    gCL->pSteamAPI->UnregisterCallResult(pCallback, hAPICall);
+    GetIChairSteamAPI()->UnregisterCallResult(pCallback, hAPICall);
 }
 
 S_API bool S_CALLTYPE SteamAPI_IsSteamRunning()
 {
-    return gCL->pSteamAPI->IsSteamRunning();
+    return GetIChairSteamAPI()->IsSteamRunning();
 }
 
 S_API HSteamUser Steam_GetHSteamUserCurrent()
 {
-    return gCL->pSteamAPI->GetHSteamUserCurrent();
+    return GetIChairSteamAPI()->GetHSteamUserCurrent();
 }
 
 S_API const char* SteamAPI_GetSteamInstallPath()
 {
-    return gCL->pSteamAPI->GetSteamInstallPath();
+    return GetIChairSteamAPI()->GetSteamInstallPath();
 }
 
 S_API HSteamPipe SteamAPI_GetHSteamPipe()
 {
-    return gCL->pSteamAPI->GetHSteamPipe();
+    return GetIChairSteamAPI()->GetHSteamPipe();
 }
 
 S_API void* S_CALLTYPE SteamInternal_CreateInterface(const char* ver)
 {
-    return gCL->pSteamAPI->Internal_CreateInterface(ver);
+    return GetIChairSteamAPI()->Internal_CreateInterface(ver);
 }
 
 CSteamAPIContext& SteamInternal_ModuleContext()
 {
-    return gCL->pSteamAPI->GetContext();
+#ifdef CHAIRLOADER_MOD_SDK
+    // Use the pointer from gCL
+    return GetIChairSteamAPI()->GetContext();
+#else
+    // Use g_pIChairSteamAPI in Chairloader.
+    // GOG integration partially emulates Steam API but not enough to expose it to mods.
+    return g_pIChairSteamAPI ? g_pIChairSteamAPI->GetContext() : g_EmptyContext;
+#endif
 }

--- a/Common/Chairloader/SteamAPI/steam_api_internal.h
+++ b/Common/Chairloader/SteamAPI/steam_api_internal.h
@@ -1,0 +1,317 @@
+//====== Copyright 1996-2015, Valve Corporation, All rights reserved. =======
+//
+// Purpose: Internal private Steamworks API declarations and definitions
+//
+//=============================================================================
+
+#ifndef STEAM_API_INTERNAL_H
+#define STEAM_API_INTERNAL_H
+
+S_API HSteamUser SteamAPI_GetHSteamUser();
+S_API void * S_CALLTYPE SteamInternal_ContextInit( void *pContextInitData );
+S_API void * S_CALLTYPE SteamInternal_CreateInterface( const char *ver );
+
+#if !defined( STEAM_API_EXPORTS )
+
+inline void S_CALLTYPE SteamInternal_OnContextInit( void* p )
+{
+	((CSteamAPIContext*)p)->Clear();
+	if ( SteamAPI_GetHSteamPipe() )
+		((CSteamAPIContext*)p)->Init();
+}
+
+CSteamAPIContext& SteamInternal_ModuleContext();
+
+inline ISteamClient *SteamClient()							{ return SteamInternal_ModuleContext().SteamClient(); }
+inline ISteamUser *SteamUser()								{ return SteamInternal_ModuleContext().SteamUser(); }
+inline ISteamFriends *SteamFriends()						{ return SteamInternal_ModuleContext().SteamFriends(); }
+inline ISteamUtils *SteamUtils()							{ return SteamInternal_ModuleContext().SteamUtils(); }
+inline ISteamMatchmaking *SteamMatchmaking()				{ return SteamInternal_ModuleContext().SteamMatchmaking(); }
+inline ISteamUserStats *SteamUserStats()					{ return SteamInternal_ModuleContext().SteamUserStats(); }
+inline ISteamApps *SteamApps()								{ return SteamInternal_ModuleContext().SteamApps(); }
+inline ISteamMatchmakingServers *SteamMatchmakingServers()	{ return SteamInternal_ModuleContext().SteamMatchmakingServers(); }
+inline ISteamNetworking *SteamNetworking()					{ return SteamInternal_ModuleContext().SteamNetworking(); }
+inline ISteamRemoteStorage *SteamRemoteStorage()			{ return SteamInternal_ModuleContext().SteamRemoteStorage(); }
+inline ISteamScreenshots *SteamScreenshots()				{ return SteamInternal_ModuleContext().SteamScreenshots(); }
+inline ISteamHTTP *SteamHTTP()								{ return SteamInternal_ModuleContext().SteamHTTP(); }
+inline ISteamUnifiedMessages *SteamUnifiedMessages()		{ return SteamInternal_ModuleContext().SteamUnifiedMessages(); }
+inline ISteamController *SteamController()					{ return SteamInternal_ModuleContext().SteamController(); }
+inline ISteamUGC *SteamUGC()								{ return SteamInternal_ModuleContext().SteamUGC(); }
+inline ISteamAppList *SteamAppList()						{ return SteamInternal_ModuleContext().SteamAppList(); }
+inline ISteamMusic *SteamMusic()							{ return SteamInternal_ModuleContext().SteamMusic(); }
+inline ISteamMusicRemote *SteamMusicRemote()				{ return SteamInternal_ModuleContext().SteamMusicRemote(); }
+inline ISteamHTMLSurface *SteamHTMLSurface()				{ return SteamInternal_ModuleContext().SteamHTMLSurface(); }
+inline ISteamInventory *SteamInventory()					{ return SteamInternal_ModuleContext().SteamInventory(); }
+inline ISteamVideo *SteamVideo()							{ return SteamInternal_ModuleContext().SteamVideo(); }
+
+#endif // !defined( STEAM_API_EXPORTS )
+
+
+inline void CSteamAPIContext::Clear()
+{
+	m_pSteamClient = NULL;
+	m_pSteamUser = NULL;
+	m_pSteamFriends = NULL;
+	m_pSteamUtils = NULL;
+	m_pSteamMatchmaking = NULL;
+	m_pSteamUserStats = NULL;
+	m_pSteamApps = NULL;
+	m_pSteamMatchmakingServers = NULL;
+	m_pSteamNetworking = NULL;
+	m_pSteamRemoteStorage = NULL;
+	m_pSteamHTTP = NULL;
+	m_pSteamScreenshots = NULL;
+	m_pSteamMusic = NULL;
+	m_pSteamUnifiedMessages = NULL;
+	m_pController = NULL;
+	m_pSteamUGC = NULL;
+	m_pSteamAppList = NULL;
+	m_pSteamMusic = NULL;
+	m_pSteamMusicRemote = NULL;
+	m_pSteamHTMLSurface = NULL;
+	m_pSteamInventory = NULL;
+}
+
+
+// This function must be declared inline in the header so the module using steam_api.dll gets the version names they want.
+inline bool CSteamAPIContext::Init()
+{
+	HSteamUser hSteamUser = SteamAPI_GetHSteamUser();
+	HSteamPipe hSteamPipe = SteamAPI_GetHSteamPipe();
+	if ( !hSteamPipe )
+		return false;
+
+	m_pSteamClient = (ISteamClient*) SteamInternal_CreateInterface( STEAMCLIENT_INTERFACE_VERSION );
+	if ( !m_pSteamClient )
+		return false;
+	
+	m_pSteamUser = m_pSteamClient->GetISteamUser( hSteamUser, hSteamPipe, STEAMUSER_INTERFACE_VERSION );
+	if ( !m_pSteamUser )
+		return false;
+
+	m_pSteamFriends = m_pSteamClient->GetISteamFriends( hSteamUser, hSteamPipe, STEAMFRIENDS_INTERFACE_VERSION );
+	if ( !m_pSteamFriends )
+		return false;
+
+	m_pSteamUtils = m_pSteamClient->GetISteamUtils( hSteamPipe, STEAMUTILS_INTERFACE_VERSION );
+	if ( !m_pSteamUtils )
+		return false;
+
+	m_pSteamMatchmaking = m_pSteamClient->GetISteamMatchmaking( hSteamUser, hSteamPipe, STEAMMATCHMAKING_INTERFACE_VERSION );
+	if ( !m_pSteamMatchmaking )
+		return false;
+
+	m_pSteamMatchmakingServers = m_pSteamClient->GetISteamMatchmakingServers( hSteamUser, hSteamPipe, STEAMMATCHMAKINGSERVERS_INTERFACE_VERSION );
+	if ( !m_pSteamMatchmakingServers )
+		return false;
+
+	m_pSteamUserStats = m_pSteamClient->GetISteamUserStats( hSteamUser, hSteamPipe, STEAMUSERSTATS_INTERFACE_VERSION );
+	if ( !m_pSteamUserStats )
+		return false;
+
+	m_pSteamApps = m_pSteamClient->GetISteamApps( hSteamUser, hSteamPipe, STEAMAPPS_INTERFACE_VERSION );
+	if ( !m_pSteamApps )
+		return false;
+
+	m_pSteamNetworking = m_pSteamClient->GetISteamNetworking( hSteamUser, hSteamPipe, STEAMNETWORKING_INTERFACE_VERSION );
+	if ( !m_pSteamNetworking )
+		return false;
+
+	m_pSteamRemoteStorage = m_pSteamClient->GetISteamRemoteStorage( hSteamUser, hSteamPipe, STEAMREMOTESTORAGE_INTERFACE_VERSION );
+	if ( !m_pSteamRemoteStorage )
+		return false;
+
+	m_pSteamScreenshots = m_pSteamClient->GetISteamScreenshots( hSteamUser, hSteamPipe, STEAMSCREENSHOTS_INTERFACE_VERSION );
+	if ( !m_pSteamScreenshots )
+		return false;
+
+	m_pSteamHTTP = m_pSteamClient->GetISteamHTTP( hSteamUser, hSteamPipe, STEAMHTTP_INTERFACE_VERSION );
+	if ( !m_pSteamHTTP )
+		return false;
+
+	m_pSteamUnifiedMessages = m_pSteamClient->GetISteamUnifiedMessages( hSteamUser, hSteamPipe, STEAMUNIFIEDMESSAGES_INTERFACE_VERSION );
+	if ( !m_pSteamUnifiedMessages )
+		return false;
+
+	m_pController = m_pSteamClient->GetISteamController( hSteamUser, hSteamPipe, STEAMCONTROLLER_INTERFACE_VERSION );
+	if ( !m_pController )
+		return false;
+
+	m_pSteamUGC = m_pSteamClient->GetISteamUGC( hSteamUser, hSteamPipe, STEAMUGC_INTERFACE_VERSION );
+	if ( !m_pSteamUGC )
+		return false;
+
+	m_pSteamAppList = m_pSteamClient->GetISteamAppList( hSteamUser, hSteamPipe, STEAMAPPLIST_INTERFACE_VERSION );
+	if ( !m_pSteamAppList )
+		return false;
+
+	m_pSteamMusic = m_pSteamClient->GetISteamMusic( hSteamUser, hSteamPipe, STEAMMUSIC_INTERFACE_VERSION );
+	if ( !m_pSteamMusic )
+		return false;
+
+	m_pSteamMusicRemote = m_pSteamClient->GetISteamMusicRemote( hSteamUser, hSteamPipe, STEAMMUSICREMOTE_INTERFACE_VERSION );
+	if ( !m_pSteamMusicRemote )
+		return false;
+
+	m_pSteamHTMLSurface = m_pSteamClient->GetISteamHTMLSurface( hSteamUser, hSteamPipe, STEAMHTMLSURFACE_INTERFACE_VERSION );
+	if ( !m_pSteamHTMLSurface )
+		return false;
+
+	m_pSteamInventory = m_pSteamClient->GetISteamInventory( hSteamUser, hSteamPipe, STEAMINVENTORY_INTERFACE_VERSION );
+	if ( !m_pSteamInventory )
+		return false;
+
+	m_pSteamVideo = m_pSteamClient->GetISteamVideo( hSteamUser, hSteamPipe, STEAMVIDEO_INTERFACE_VERSION );
+	if ( !m_pSteamVideo )
+		return false;
+
+	return true;
+}
+
+
+//-----------------------------------------------------------------------------
+// The following macros are implementation details, not intended for public use
+//-----------------------------------------------------------------------------
+#define _STEAM_CALLBACK_AUTO_HOOK( thisclass, func, param )
+#define _STEAM_CALLBACK_HELPER( _1, _2, SELECTED, ... )		_STEAM_CALLBACK_##SELECTED
+#define _STEAM_CALLBACK_SELECT( X, Y )						_STEAM_CALLBACK_HELPER X Y
+#define _STEAM_CALLBACK_3( extra_code, thisclass, func, param ) \
+	struct CCallbackInternal_ ## func : private CCallbackImpl< sizeof( param ) > { \
+		CCallbackInternal_ ## func () { extra_code SteamAPI_RegisterCallback( this, param::k_iCallback ); } \
+		CCallbackInternal_ ## func ( const CCallbackInternal_ ## func & ) { extra_code SteamAPI_RegisterCallback( this, param::k_iCallback ); } \
+		CCallbackInternal_ ## func & operator=( const CCallbackInternal_ ## func & ) { return *this; } \
+		private: virtual void Run( void *pvParam ) { _STEAM_CALLBACK_AUTO_HOOK( thisclass, func, param ) \
+			thisclass *pOuter = reinterpret_cast<thisclass*>( reinterpret_cast<char*>(this) - offsetof( thisclass, m_steamcallback_ ## func ) ); \
+			pOuter->func( reinterpret_cast<param*>( pvParam ) ); \
+		} \
+	} m_steamcallback_ ## func ; void func( param *pParam )
+#define _STEAM_CALLBACK_4( _, thisclass, func, param, var ) \
+	CCallback< thisclass, param > var; void func( param *pParam )
+
+
+//-----------------------------------------------------------------------------
+// Purpose: maps a steam async call result to a class member function
+//			template params: T = local class, P = parameter struct
+//-----------------------------------------------------------------------------
+template< class T, class P >
+inline CCallResult<T, P>::CCallResult()
+{
+	m_hAPICall = k_uAPICallInvalid;
+	m_pObj = NULL;
+	m_Func = NULL;
+	m_iCallback = P::k_iCallback;
+}
+
+template< class T, class P >
+inline void CCallResult<T, P>::Set( SteamAPICall_t hAPICall, T *p, func_t func )
+{
+	if ( m_hAPICall )
+		SteamAPI_UnregisterCallResult( this, m_hAPICall );
+
+	m_hAPICall = hAPICall;
+	m_pObj = p;
+	m_Func = func;
+
+	if ( hAPICall )
+		SteamAPI_RegisterCallResult( this, hAPICall );
+}
+
+template< class T, class P >
+inline bool CCallResult<T, P>::IsActive() const
+{
+	return (m_hAPICall != k_uAPICallInvalid);
+}
+
+template< class T, class P >
+inline void CCallResult<T, P>::Cancel()
+{
+	if ( m_hAPICall != k_uAPICallInvalid )
+	{
+		SteamAPI_UnregisterCallResult( this, m_hAPICall );
+		m_hAPICall = k_uAPICallInvalid;
+	}
+
+}
+
+template< class T, class P >
+inline CCallResult<T, P>::~CCallResult()
+{
+	Cancel();
+}
+
+template< class T, class P >
+inline void CCallResult<T, P>::Run( void *pvParam )
+{
+	m_hAPICall = k_uAPICallInvalid; // caller unregisters for us
+	(m_pObj->*m_Func)((P *)pvParam, false);
+}
+
+template< class T, class P >
+inline void CCallResult<T, P>::Run( void *pvParam, bool bIOFailure, SteamAPICall_t hSteamAPICall )
+{
+	if ( hSteamAPICall == m_hAPICall )
+	{
+		m_hAPICall = k_uAPICallInvalid; // caller unregisters for us
+		(m_pObj->*m_Func)((P *)pvParam, bIOFailure);
+	}
+}
+
+
+//-----------------------------------------------------------------------------
+// Purpose: maps a steam callback to a class member function
+//			template params: T = local class, P = parameter struct,
+//			bGameserver = listen for gameserver callbacks instead of client callbacks
+//-----------------------------------------------------------------------------
+template< class T, class P, bool bGameserver >
+inline CCallback< T, P, bGameserver >::CCallback( T *pObj, func_t func )
+	: m_pObj( NULL ), m_Func( NULL )
+{
+	if ( bGameserver )
+	{
+		this->SetGameserverFlag();
+	}
+	Register( pObj, func );
+}
+
+template< class T, class P, bool bGameserver >
+inline void CCallback< T, P, bGameserver >::Register( T *pObj, func_t func )
+{
+	if ( !pObj || !func )
+		return;
+
+	if ( this->m_nCallbackFlags & CCallbackBase::k_ECallbackFlagsRegistered )
+		Unregister();
+
+	m_pObj = pObj;
+	m_Func = func;
+	// SteamAPI_RegisterCallback sets k_ECallbackFlagsRegistered
+	SteamAPI_RegisterCallback( this, P::k_iCallback );
+}
+
+template< class T, class P, bool bGameserver >
+inline void CCallback< T, P, bGameserver >::Unregister()
+{
+	// SteamAPI_UnregisterCallback removes k_ECallbackFlagsRegistered
+	SteamAPI_UnregisterCallback( this );
+}
+
+template< class T, class P, bool bGameserver >
+inline void CCallback< T, P, bGameserver >::Run( void *pvParam )
+{
+	(m_pObj->*m_Func)((P *)pvParam);
+}
+
+
+#if defined(USE_BREAKPAD_HANDLER) || defined(STEAM_API_EXPORTS)
+// this should be called before the game initialized the steam APIs
+// pchDate should be of the format "Mmm dd yyyy" (such as from the __ DATE __ macro )
+// pchTime should be of the format "hh:mm:ss" (such as from the __ TIME __ macro )
+// bFullMemoryDumps (Win32 only) -- writes out a uuid-full.dmp in the client/dumps folder
+// pvContext-- can be NULL, will be the void * context passed into m_pfnPreMinidumpCallback
+// PFNPreMinidumpCallback m_pfnPreMinidumpCallback   -- optional callback which occurs just before a .dmp file is written during a crash.  Applications can hook this to allow adding additional information into the .dmp comment stream.
+S_API void S_CALLTYPE SteamAPI_UseBreakpadCrashHandler( char const *pchVersion, char const *pchDate, char const *pchTime, bool bFullMemoryDumps, void *pvContext, PFNPreMinidumpCallback m_pfnPreMinidumpCallback );
+S_API void S_CALLTYPE SteamAPI_SetBreakpadAppID( uint32 unAppID );
+#endif
+
+
+#endif // STEAM_API_INTERNAL_H

--- a/Common/Chairloader/SteamAPI/steam_gameserver.h
+++ b/Common/Chairloader/SteamAPI/steam_gameserver.h
@@ -1,0 +1,237 @@
+//====== Copyright © 1996-2008, Valve Corporation, All rights reserved. =======
+//
+// Purpose: 
+//
+//=============================================================================
+
+#ifndef STEAM_GAMESERVER_H
+#define STEAM_GAMESERVER_H
+#ifdef _WIN32
+#pragma once
+#endif
+
+#include "steam_api.h"
+#include "isteamgameserver.h"
+#include "isteamgameserverstats.h"
+
+enum EServerMode
+{
+	eServerModeInvalid = 0, // DO NOT USE		
+	eServerModeNoAuthentication = 1, // Don't authenticate user logins and don't list on the server list
+	eServerModeAuthentication = 2, // Authenticate users, list on the server list, don't run VAC on clients that connect
+	eServerModeAuthenticationAndSecure = 3, // Authenticate users, list on the server list and VAC protect clients
+};													
+
+// Initialize ISteamGameServer interface object, and set server properties which may not be changed.
+//
+// After calling this function, you should set any additional server parameters, and then
+// call ISteamGameServer::LogOnAnonymous() or ISteamGameServer::LogOn()
+//
+// - usSteamPort is the local port used to communicate with the steam servers.
+// - usGamePort is the port that clients will connect to for gameplay.
+// - usQueryPort is the port that will manage server browser related duties and info
+//		pings from clients.  If you pass MASTERSERVERUPDATERPORT_USEGAMESOCKETSHARE for usQueryPort, then it
+//		will use "GameSocketShare" mode, which means that the game is responsible for sending and receiving
+//		UDP packets for the master  server updater. See references to GameSocketShare in isteamgameserver.h.
+// - The version string is usually in the form x.x.x.x, and is used by the master server to detect when the
+//		server is out of date.  (Only servers with the latest version will be listed.)
+
+inline bool SteamGameServer_Init( uint32 unIP, uint16 usSteamPort, uint16 usGamePort, uint16 usQueryPort, EServerMode eServerMode, const char *pchVersionString );
+
+S_API void SteamGameServer_Shutdown();
+S_API void SteamGameServer_RunCallbacks();
+
+// Most Steam API functions allocate some amount of thread-local memory for
+// parameter storage. Calling SteamGameServer_ReleaseCurrentThreadMemory()
+// will free all API-related memory associated with the calling thread.
+// This memory is released automatically by SteamGameServer_RunCallbacks(),
+// so single-threaded servers do not need to explicitly call this function.
+inline void SteamGameServer_ReleaseCurrentThreadMemory();
+
+S_API bool SteamGameServer_BSecure();
+S_API uint64 SteamGameServer_GetSteamID();
+
+// If your application contains modules which could be built against different Steamworks SDK
+// versions, then you should define VERSION_SAFE_STEAM_API_INTERFACES to enforce that you cannot
+// use the version-less global accessors. Instead, create and use CSteamGameServerAPIContext
+// objects to retrieve interface pointers which are appropriate for your Steamworks SDK headers.
+#if !defined( VERSION_SAFE_STEAM_API_INTERFACES ) && !defined( STEAM_API_EXPORTS )
+inline ISteamClient *SteamGameServerClient();
+inline ISteamGameServer *SteamGameServer();
+inline ISteamUtils *SteamGameServerUtils();
+inline ISteamNetworking *SteamGameServerNetworking();
+inline ISteamGameServerStats *SteamGameServerStats();
+inline ISteamHTTP *SteamGameServerHTTP();
+inline ISteamInventory *SteamGameServerInventory();
+inline ISteamUGC *SteamGameServerUGC();
+inline ISteamApps *SteamGameServerApps();
+#endif
+
+class CSteamGameServerAPIContext
+{
+public:
+	CSteamGameServerAPIContext() { Clear(); }
+	inline void Clear();
+	inline bool Init();
+
+	ISteamClient *SteamClient() const					{ return m_pSteamClient; }
+	ISteamGameServer *SteamGameServer() const			{ return m_pSteamGameServer; }
+	ISteamUtils *SteamGameServerUtils() const			{ return m_pSteamGameServerUtils; }
+	ISteamNetworking *SteamGameServerNetworking() const	{ return m_pSteamGameServerNetworking; }
+	ISteamGameServerStats *SteamGameServerStats() const	{ return m_pSteamGameServerStats; }
+	ISteamHTTP *SteamHTTP() const						{ return m_pSteamHTTP; }
+	ISteamInventory *SteamInventory() const				{ return m_pSteamInventory; }
+	ISteamUGC *SteamUGC() const							{ return m_pSteamUGC; }
+	ISteamApps *SteamApps() const						{ return m_pSteamApps; }
+
+private:
+	ISteamClient				*m_pSteamClient;
+	ISteamGameServer			*m_pSteamGameServer;
+	ISteamUtils					*m_pSteamGameServerUtils;
+	ISteamNetworking			*m_pSteamGameServerNetworking;
+	ISteamGameServerStats		*m_pSteamGameServerStats;
+	ISteamHTTP					*m_pSteamHTTP;
+	ISteamInventory				*m_pSteamInventory;
+	ISteamUGC					*m_pSteamUGC;
+	ISteamApps					*m_pSteamApps;
+};
+
+
+// Older SDKs exported this global pointer, but it is no longer supported.
+// You should use SteamGameServerClient() or CSteamGameServerAPIContext to
+// safely access the ISteamClient APIs from your game server application.
+//S_API ISteamClient *g_pSteamClientGameServer;
+
+// SteamGameServer_InitSafe has been replaced with SteamGameServer_Init and
+// is no longer supported. Use SteamGameServer_Init instead.
+//S_API void S_CALLTYPE SteamGameServer_InitSafe();
+
+
+//----------------------------------------------------------------------------------------------------------------------------------------------------------//
+// These macros are similar to the STEAM_CALLBACK_* macros in steam_api.h, but only trigger for gameserver callbacks
+//----------------------------------------------------------------------------------------------------------------------------------------------------------//
+#define STEAM_GAMESERVER_CALLBACK( thisclass, func, /*callback_type, [deprecated] var*/... ) \
+	_STEAM_CALLBACK_SELECT( ( __VA_ARGS__, GS, 3 ), ( this->SetGameserverFlag();, thisclass, func, __VA_ARGS__ ) )
+
+#define STEAM_GAMESERVER_CALLBACK_MANUAL( thisclass, func, callback_type, var ) \
+	CCallbackManual< thisclass, callback_type, true > var; void func( callback_type *pParam )
+
+
+#define _STEAM_CALLBACK_GS( _, thisclass, func, param, var ) \
+	CCallback< thisclass, param, true > var; void func( param *pParam )
+
+//----------------------------------------------------------------------------------------------------------------------------------------------------------//
+//	steamclient.dll private wrapper functions
+//
+//	The following functions are part of abstracting API access to the steamclient.dll, but should only be used in very specific cases
+//----------------------------------------------------------------------------------------------------------------------------------------------------------//
+S_API HSteamPipe S_CALLTYPE SteamGameServer_GetHSteamPipe();
+S_API HSteamUser S_CALLTYPE SteamGameServer_GetHSteamUser();
+S_API bool S_CALLTYPE SteamInternal_GameServer_Init( uint32 unIP, uint16 usPort, uint16 usGamePort, uint16 usQueryPort, EServerMode eServerMode, const char *pchVersionString );
+
+
+#if !defined( VERSION_SAFE_STEAM_API_INTERFACES ) && !defined( STEAM_API_EXPORTS )
+inline CSteamGameServerAPIContext& SteamGameServerInternal_ModuleContext()
+{
+	// NOTE: declaring "static CSteamAPIConext" creates a large function
+	// which queries the initialization status of the object. We know that
+	// it is pointer-aligned and fully memset with zeros, so just alias a
+	// static buffer of the appropriate size and call it a CSteamAPIContext.
+	static void* ctx[ sizeof(CSteamGameServerAPIContext)/sizeof(void*) ];
+	return *(CSteamGameServerAPIContext*)ctx;
+}
+#define _STEAMINTERNAL_ACCESSOR_BODY( AccessFunc )									\
+		if ( !SteamGameServer_GetHSteamPipe() ) return 0;							\
+		CSteamGameServerAPIContext &ctx = SteamGameServerInternal_ModuleContext();	\
+		if ( !ctx.AccessFunc() ) ctx.Init();										\
+		return ctx.AccessFunc();
+
+inline ISteamClient *SteamGameServerClient()		 { _STEAMINTERNAL_ACCESSOR_BODY( SteamClient ) }
+inline ISteamGameServer *SteamGameServer()			 { _STEAMINTERNAL_ACCESSOR_BODY( SteamGameServer ) }
+inline ISteamUtils *SteamGameServerUtils()			 { _STEAMINTERNAL_ACCESSOR_BODY( SteamGameServerUtils ) }
+inline ISteamNetworking *SteamGameServerNetworking() { _STEAMINTERNAL_ACCESSOR_BODY( SteamGameServerNetworking ) }
+inline ISteamGameServerStats *SteamGameServerStats() { _STEAMINTERNAL_ACCESSOR_BODY( SteamGameServerStats ) }
+inline ISteamHTTP *SteamGameServerHTTP()			 { _STEAMINTERNAL_ACCESSOR_BODY( SteamHTTP ) }
+inline ISteamInventory *SteamGameServerInventory()	 { _STEAMINTERNAL_ACCESSOR_BODY( SteamInventory ) }
+inline ISteamUGC *SteamGameServerUGC()				 { _STEAMINTERNAL_ACCESSOR_BODY( SteamUGC ) }
+inline ISteamApps *SteamGameServerApps()			 { _STEAMINTERNAL_ACCESSOR_BODY( SteamApps ) }
+#undef _STEAMINTERNAL_ACCESSOR_BODY
+#endif // !defined( VERSION_SAFE_STEAM_API_INTERFACES ) && !defined( STEAM_API_EXPORTS )
+
+
+inline void CSteamGameServerAPIContext::Clear()
+{
+	m_pSteamClient = NULL;
+	m_pSteamGameServer = NULL;
+	m_pSteamGameServerUtils = NULL;
+	m_pSteamGameServerNetworking = NULL;
+	m_pSteamGameServerStats = NULL;
+	m_pSteamHTTP = NULL;
+	m_pSteamInventory = NULL;
+	m_pSteamUGC = NULL;
+	m_pSteamApps = NULL;
+}
+
+// This function must be declared inline in the header so the module using steam_api.dll gets the version names they want.
+inline bool CSteamGameServerAPIContext::Init()
+{
+	HSteamUser hSteamUser = SteamGameServer_GetHSteamUser();
+	HSteamPipe hSteamPipe = SteamGameServer_GetHSteamPipe();
+	if ( !hSteamPipe )
+		return false;
+
+	m_pSteamClient = (ISteamClient*) SteamInternal_CreateInterface( STEAMCLIENT_INTERFACE_VERSION );
+	if ( !m_pSteamClient )
+		return false;
+	
+	m_pSteamGameServer = m_pSteamClient->GetISteamGameServer( hSteamUser, hSteamPipe, STEAMGAMESERVER_INTERFACE_VERSION );
+	if ( !m_pSteamGameServer )
+		return false;
+
+	m_pSteamGameServerUtils = m_pSteamClient->GetISteamUtils( hSteamPipe, STEAMUTILS_INTERFACE_VERSION );
+	if ( !m_pSteamGameServerUtils )
+		return false;
+
+	m_pSteamGameServerNetworking = m_pSteamClient->GetISteamNetworking( hSteamUser, hSteamPipe, STEAMNETWORKING_INTERFACE_VERSION );
+	if ( !m_pSteamGameServerNetworking )
+		return false;
+
+	m_pSteamGameServerStats = m_pSteamClient->GetISteamGameServerStats( hSteamUser, hSteamPipe, STEAMGAMESERVERSTATS_INTERFACE_VERSION );
+	if ( !m_pSteamGameServerStats )
+		return false;
+
+	m_pSteamHTTP = m_pSteamClient->GetISteamHTTP( hSteamUser, hSteamPipe, STEAMHTTP_INTERFACE_VERSION );
+	if ( !m_pSteamHTTP )
+		return false;
+
+	m_pSteamInventory = m_pSteamClient->GetISteamInventory( hSteamUser, hSteamPipe, STEAMINVENTORY_INTERFACE_VERSION );
+	if ( !m_pSteamInventory )
+		return false;
+
+	m_pSteamUGC = m_pSteamClient->GetISteamUGC( hSteamUser, hSteamPipe, STEAMUGC_INTERFACE_VERSION );
+	if ( !m_pSteamUGC )
+		return false;
+
+	m_pSteamApps = m_pSteamClient->GetISteamApps( hSteamUser, hSteamPipe, STEAMAPPS_INTERFACE_VERSION );
+	if ( !m_pSteamApps )
+		return false;
+
+	return true;
+}
+
+
+inline bool SteamGameServer_Init( uint32 unIP, uint16 usSteamPort, uint16 usGamePort, uint16 usQueryPort, EServerMode eServerMode, const char *pchVersionString )
+{
+	if ( !SteamInternal_GameServer_Init( unIP, usSteamPort, usGamePort, usQueryPort, eServerMode, pchVersionString ) )
+		return false;
+
+	return true;
+}
+
+
+inline void SteamGameServer_ReleaseCurrentThreadMemory()
+{
+	SteamAPI_ReleaseCurrentThreadMemory();
+}
+
+#endif // STEAM_GAMESERVER_H

--- a/Common/Chairloader/SteamAPI/steamclientpublic.h
+++ b/Common/Chairloader/SteamAPI/steamclientpublic.h
@@ -1,0 +1,1232 @@
+//========= Copyright � 1996-2008, Valve LLC, All rights reserved. ============
+//
+// Purpose:
+//
+//=============================================================================
+
+#ifndef STEAMCLIENTPUBLIC_H
+#define STEAMCLIENTPUBLIC_H
+#ifdef _WIN32
+#pragma once
+#endif
+//lint -save -e1931 -e1927 -e1924 -e613 -e726
+
+// This header file defines the interface between the calling application and the code that
+// knows how to communicate with the connection manager (CM) from the Steam service 
+
+// This header file is intended to be portable; ideally this 1 header file plus a lib or dll
+// is all you need to integrate the client library into some other tree.  So please avoid
+// including or requiring other header files if possible.  This header should only describe the 
+// interface layer, no need to include anything about the implementation.
+
+#include "steamtypes.h"
+#include "steamuniverse.h"
+
+// General result codes
+enum EResult
+{
+	k_EResultOK	= 1,							// success
+	k_EResultFail = 2,							// generic failure 
+	k_EResultNoConnection = 3,					// no/failed network connection
+//	k_EResultNoConnectionRetry = 4,				// OBSOLETE - removed
+	k_EResultInvalidPassword = 5,				// password/ticket is invalid
+	k_EResultLoggedInElsewhere = 6,				// same user logged in elsewhere
+	k_EResultInvalidProtocolVer = 7,			// protocol version is incorrect
+	k_EResultInvalidParam = 8,					// a parameter is incorrect
+	k_EResultFileNotFound = 9,					// file was not found
+	k_EResultBusy = 10,							// called method busy - action not taken
+	k_EResultInvalidState = 11,					// called object was in an invalid state
+	k_EResultInvalidName = 12,					// name is invalid
+	k_EResultInvalidEmail = 13,					// email is invalid
+	k_EResultDuplicateName = 14,				// name is not unique
+	k_EResultAccessDenied = 15,					// access is denied
+	k_EResultTimeout = 16,						// operation timed out
+	k_EResultBanned = 17,						// VAC2 banned
+	k_EResultAccountNotFound = 18,				// account not found
+	k_EResultInvalidSteamID = 19,				// steamID is invalid
+	k_EResultServiceUnavailable = 20,			// The requested service is currently unavailable
+	k_EResultNotLoggedOn = 21,					// The user is not logged on
+	k_EResultPending = 22,						// Request is pending (may be in process, or waiting on third party)
+	k_EResultEncryptionFailure = 23,			// Encryption or Decryption failed
+	k_EResultInsufficientPrivilege = 24,		// Insufficient privilege
+	k_EResultLimitExceeded = 25,				// Too much of a good thing
+	k_EResultRevoked = 26,						// Access has been revoked (used for revoked guest passes)
+	k_EResultExpired = 27,						// License/Guest pass the user is trying to access is expired
+	k_EResultAlreadyRedeemed = 28,				// Guest pass has already been redeemed by account, cannot be acked again
+	k_EResultDuplicateRequest = 29,				// The request is a duplicate and the action has already occurred in the past, ignored this time
+	k_EResultAlreadyOwned = 30,					// All the games in this guest pass redemption request are already owned by the user
+	k_EResultIPNotFound = 31,					// IP address not found
+	k_EResultPersistFailed = 32,				// failed to write change to the data store
+	k_EResultLockingFailed = 33,				// failed to acquire access lock for this operation
+	k_EResultLogonSessionReplaced = 34,
+	k_EResultConnectFailed = 35,
+	k_EResultHandshakeFailed = 36,
+	k_EResultIOFailure = 37,
+	k_EResultRemoteDisconnect = 38,
+	k_EResultShoppingCartNotFound = 39,			// failed to find the shopping cart requested
+	k_EResultBlocked = 40,						// a user didn't allow it
+	k_EResultIgnored = 41,						// target is ignoring sender
+	k_EResultNoMatch = 42,						// nothing matching the request found
+	k_EResultAccountDisabled = 43,
+	k_EResultServiceReadOnly = 44,				// this service is not accepting content changes right now
+	k_EResultAccountNotFeatured = 45,			// account doesn't have value, so this feature isn't available
+	k_EResultAdministratorOK = 46,				// allowed to take this action, but only because requester is admin
+	k_EResultContentVersion = 47,				// A Version mismatch in content transmitted within the Steam protocol.
+	k_EResultTryAnotherCM = 48,					// The current CM can't service the user making a request, user should try another.
+	k_EResultPasswordRequiredToKickSession = 49,// You are already logged in elsewhere, this cached credential login has failed.
+	k_EResultAlreadyLoggedInElsewhere = 50,		// You are already logged in elsewhere, you must wait
+	k_EResultSuspended = 51,					// Long running operation (content download) suspended/paused
+	k_EResultCancelled = 52,					// Operation canceled (typically by user: content download)
+	k_EResultDataCorruption = 53,				// Operation canceled because data is ill formed or unrecoverable
+	k_EResultDiskFull = 54,						// Operation canceled - not enough disk space.
+	k_EResultRemoteCallFailed = 55,				// an remote call or IPC call failed
+	k_EResultPasswordUnset = 56,				// Password could not be verified as it's unset server side
+	k_EResultExternalAccountUnlinked = 57,		// External account (PSN, Facebook...) is not linked to a Steam account
+	k_EResultPSNTicketInvalid = 58,				// PSN ticket was invalid
+	k_EResultExternalAccountAlreadyLinked = 59,	// External account (PSN, Facebook...) is already linked to some other account, must explicitly request to replace/delete the link first
+	k_EResultRemoteFileConflict = 60,			// The sync cannot resume due to a conflict between the local and remote files
+	k_EResultIllegalPassword = 61,				// The requested new password is not legal
+	k_EResultSameAsPreviousValue = 62,			// new value is the same as the old one ( secret question and answer )
+	k_EResultAccountLogonDenied = 63,			// account login denied due to 2nd factor authentication failure
+	k_EResultCannotUseOldPassword = 64,			// The requested new password is not legal
+	k_EResultInvalidLoginAuthCode = 65,			// account login denied due to auth code invalid
+	k_EResultAccountLogonDeniedNoMail = 66,		// account login denied due to 2nd factor auth failure - and no mail has been sent
+	k_EResultHardwareNotCapableOfIPT = 67,		// 
+	k_EResultIPTInitError = 68,					// 
+	k_EResultParentalControlRestricted = 69,	// operation failed due to parental control restrictions for current user
+	k_EResultFacebookQueryError = 70,			// Facebook query returned an error
+	k_EResultExpiredLoginAuthCode = 71,			// account login denied due to auth code expired
+	k_EResultIPLoginRestrictionFailed = 72,
+	k_EResultAccountLockedDown = 73,
+	k_EResultAccountLogonDeniedVerifiedEmailRequired = 74,
+	k_EResultNoMatchingURL = 75,
+	k_EResultBadResponse = 76,					// parse failure, missing field, etc.
+	k_EResultRequirePasswordReEntry = 77,		// The user cannot complete the action until they re-enter their password
+	k_EResultValueOutOfRange = 78,				// the value entered is outside the acceptable range
+	k_EResultUnexpectedError = 79,				// something happened that we didn't expect to ever happen
+	k_EResultDisabled = 80,						// The requested service has been configured to be unavailable
+	k_EResultInvalidCEGSubmission = 81,			// The set of files submitted to the CEG server are not valid !
+	k_EResultRestrictedDevice = 82,				// The device being used is not allowed to perform this action
+	k_EResultRegionLocked = 83,					// The action could not be complete because it is region restricted
+	k_EResultRateLimitExceeded = 84,			// Temporary rate limit exceeded, try again later, different from k_EResultLimitExceeded which may be permanent
+	k_EResultAccountLoginDeniedNeedTwoFactor = 85,	// Need two-factor code to login
+	k_EResultItemDeleted = 86,					// The thing we're trying to access has been deleted
+	k_EResultAccountLoginDeniedThrottle = 87,	// login attempt failed, try to throttle response to possible attacker
+	k_EResultTwoFactorCodeMismatch = 88,		// two factor code mismatch
+	k_EResultTwoFactorActivationCodeMismatch = 89,	// activation code for two-factor didn't match
+	k_EResultAccountAssociatedToMultiplePartners = 90,	// account has been associated with multiple partners
+	k_EResultNotModified = 91,					// data not modified
+	k_EResultNoMobileDevice = 92,				// the account does not have a mobile device associated with it
+	k_EResultTimeNotSynced = 93,				// the time presented is out of range or tolerance
+	k_EResultSmsCodeFailed = 94,				// SMS code failure (no match, none pending, etc.)
+	k_EResultAccountLimitExceeded = 95,			// Too many accounts access this resource
+	k_EResultAccountActivityLimitExceeded = 96,	// Too many changes to this account
+	k_EResultPhoneActivityLimitExceeded = 97,	// Too many changes to this phone
+	k_EResultRefundToWallet = 98,				// Cannot refund to payment method, must use wallet
+	k_EResultEmailSendFailure = 99,				// Cannot send an email
+	k_EResultNotSettled = 100,					// Can't perform operation till payment has settled
+	k_EResultNeedCaptcha = 101,					// Needs to provide a valid captcha
+	k_EResultGSLTDenied = 102,					// a game server login token owned by this token's owner has been banned
+	k_EResultGSOwnerDenied = 103,				// game server owner is denied for other reason (account lock, community ban, vac ban, missing phone)
+	k_EResultInvalidItemType = 104,				// the type of thing we were requested to act on is invalid
+	k_EResultIPBanned = 105,					// the ip address has been banned from taking this action
+	k_EResultGSLTExpired = 106,					// this token has expired from disuse; can be reset for use
+};
+
+// Error codes for use with the voice functions
+enum EVoiceResult
+{
+	k_EVoiceResultOK = 0,
+	k_EVoiceResultNotInitialized = 1,
+	k_EVoiceResultNotRecording = 2,
+	k_EVoiceResultNoData = 3,
+	k_EVoiceResultBufferTooSmall = 4,
+	k_EVoiceResultDataCorrupted = 5,
+	k_EVoiceResultRestricted = 6,
+	k_EVoiceResultUnsupportedCodec = 7,
+	k_EVoiceResultReceiverOutOfDate = 8,
+	k_EVoiceResultReceiverDidNotAnswer = 9,
+
+};
+
+// Result codes to GSHandleClientDeny/Kick
+enum EDenyReason
+{
+	k_EDenyInvalid = 0,
+	k_EDenyInvalidVersion = 1,
+	k_EDenyGeneric = 2,
+	k_EDenyNotLoggedOn = 3,
+	k_EDenyNoLicense = 4,
+	k_EDenyCheater = 5,
+	k_EDenyLoggedInElseWhere = 6,
+	k_EDenyUnknownText = 7,
+	k_EDenyIncompatibleAnticheat = 8,
+	k_EDenyMemoryCorruption = 9,
+	k_EDenyIncompatibleSoftware = 10,
+	k_EDenySteamConnectionLost = 11,
+	k_EDenySteamConnectionError = 12,
+	k_EDenySteamResponseTimedOut = 13,
+	k_EDenySteamValidationStalled = 14,
+	k_EDenySteamOwnerLeftGuestUser = 15,
+};
+
+// return type of GetAuthSessionTicket
+typedef uint32 HAuthTicket;
+const HAuthTicket k_HAuthTicketInvalid = 0;
+
+// results from BeginAuthSession
+enum EBeginAuthSessionResult
+{
+	k_EBeginAuthSessionResultOK = 0,						// Ticket is valid for this game and this steamID.
+	k_EBeginAuthSessionResultInvalidTicket = 1,				// Ticket is not valid.
+	k_EBeginAuthSessionResultDuplicateRequest = 2,			// A ticket has already been submitted for this steamID
+	k_EBeginAuthSessionResultInvalidVersion = 3,			// Ticket is from an incompatible interface version
+	k_EBeginAuthSessionResultGameMismatch = 4,				// Ticket is not for this game
+	k_EBeginAuthSessionResultExpiredTicket = 5,				// Ticket has expired
+};
+
+// Callback values for callback ValidateAuthTicketResponse_t which is a response to BeginAuthSession
+enum EAuthSessionResponse
+{
+	k_EAuthSessionResponseOK = 0,							// Steam has verified the user is online, the ticket is valid and ticket has not been reused.
+	k_EAuthSessionResponseUserNotConnectedToSteam = 1,		// The user in question is not connected to steam
+	k_EAuthSessionResponseNoLicenseOrExpired = 2,			// The license has expired.
+	k_EAuthSessionResponseVACBanned = 3,					// The user is VAC banned for this game.
+	k_EAuthSessionResponseLoggedInElseWhere = 4,			// The user account has logged in elsewhere and the session containing the game instance has been disconnected.
+	k_EAuthSessionResponseVACCheckTimedOut = 5,				// VAC has been unable to perform anti-cheat checks on this user
+	k_EAuthSessionResponseAuthTicketCanceled = 6,			// The ticket has been canceled by the issuer
+	k_EAuthSessionResponseAuthTicketInvalidAlreadyUsed = 7,	// This ticket has already been used, it is not valid.
+	k_EAuthSessionResponseAuthTicketInvalid = 8,			// This ticket is not from a user instance currently connected to steam.
+	k_EAuthSessionResponsePublisherIssuedBan = 9,			// The user is banned for this game. The ban came via the web api and not VAC
+};
+
+// results from UserHasLicenseForApp
+enum EUserHasLicenseForAppResult
+{
+	k_EUserHasLicenseResultHasLicense = 0,					// User has a license for specified app
+	k_EUserHasLicenseResultDoesNotHaveLicense = 1,			// User does not have a license for the specified app
+	k_EUserHasLicenseResultNoAuth = 2,						// User has not been authenticated
+};
+
+
+// Steam account types
+enum EAccountType
+{
+	k_EAccountTypeInvalid = 0,			
+	k_EAccountTypeIndividual = 1,		// single user account
+	k_EAccountTypeMultiseat = 2,		// multiseat (e.g. cybercafe) account
+	k_EAccountTypeGameServer = 3,		// game server account
+	k_EAccountTypeAnonGameServer = 4,	// anonymous game server account
+	k_EAccountTypePending = 5,			// pending
+	k_EAccountTypeContentServer = 6,	// content server
+	k_EAccountTypeClan = 7,
+	k_EAccountTypeChat = 8,
+	k_EAccountTypeConsoleUser = 9,		// Fake SteamID for local PSN account on PS3 or Live account on 360, etc.
+	k_EAccountTypeAnonUser = 10,
+
+	// Max of 16 items in this field
+	k_EAccountTypeMax
+};
+
+
+
+//-----------------------------------------------------------------------------
+// Purpose: 
+//-----------------------------------------------------------------------------
+enum EAppReleaseState
+{
+	k_EAppReleaseState_Unknown			= 0,	// unknown, required appinfo or license info is missing
+	k_EAppReleaseState_Unavailable		= 1,	// even if user 'just' owns it, can see game at all
+	k_EAppReleaseState_Prerelease		= 2,	// can be purchased and is visible in games list, nothing else. Common appInfo section released
+	k_EAppReleaseState_PreloadOnly		= 3,	// owners can preload app, not play it. AppInfo fully released.
+	k_EAppReleaseState_Released			= 4,	// owners can download and play app.
+};
+
+
+//-----------------------------------------------------------------------------
+// Purpose: 
+//-----------------------------------------------------------------------------
+enum EAppOwnershipFlags
+{
+	k_EAppOwnershipFlags_None				= 0x0000,	// unknown
+	k_EAppOwnershipFlags_OwnsLicense		= 0x0001,	// owns license for this game
+	k_EAppOwnershipFlags_FreeLicense		= 0x0002,	// not paid for game
+	k_EAppOwnershipFlags_RegionRestricted	= 0x0004,	// owns app, but not allowed to play in current region
+	k_EAppOwnershipFlags_LowViolence		= 0x0008,	// only low violence version
+	k_EAppOwnershipFlags_InvalidPlatform	= 0x0010,	// app not supported on current platform
+	k_EAppOwnershipFlags_SharedLicense		= 0x0020,	// license was granted by authorized local device
+	k_EAppOwnershipFlags_FreeWeekend		= 0x0040,	// owned by a free weekend licenses
+	k_EAppOwnershipFlags_RetailLicense		= 0x0080,	// has a retail license for game, (CD-Key etc)
+	k_EAppOwnershipFlags_LicenseLocked		= 0x0100,	// shared license is locked (in use) by other user
+	k_EAppOwnershipFlags_LicensePending		= 0x0200,	// owns app, but transaction is still pending. Can't install or play
+	k_EAppOwnershipFlags_LicenseExpired		= 0x0400,	// doesn't own app anymore since license expired
+	k_EAppOwnershipFlags_LicensePermanent	= 0x0800,	// permanent license, not borrowed, or guest or freeweekend etc
+	k_EAppOwnershipFlags_LicenseRecurring	= 0x1000,	// Recurring license, user is charged periodically
+	k_EAppOwnershipFlags_LicenseCanceled	= 0x2000,	// Mark as canceled, but might be still active if recurring
+	k_EAppOwnershipFlags_AutoGrant			= 0x4000,	// Ownership is based on any kind of autogrant license
+	k_EAppOwnershipFlags_PendingGift		= 0x8000,	// user has pending gift to redeem
+	k_EAppOwnershipFlags_RentalNotActivated	= 0x10000,	// Rental hasn't been activated yet
+	k_EAppOwnershipFlags_Rental				= 0x20000,	// Is a rental
+};
+
+
+//-----------------------------------------------------------------------------
+// Purpose: designed as flags to allow filters masks
+//-----------------------------------------------------------------------------
+enum EAppType
+{
+	k_EAppType_Invalid				= 0x000,	// unknown / invalid
+	k_EAppType_Game					= 0x001,	// playable game, default type
+	k_EAppType_Application			= 0x002,	// software application
+	k_EAppType_Tool					= 0x004,	// SDKs, editors & dedicated servers
+	k_EAppType_Demo					= 0x008,	// game demo
+	k_EAppType_Media_DEPRECATED		= 0x010,	// legacy - was used for game trailers, which are now just videos on the web
+	k_EAppType_DLC					= 0x020,	// down loadable content
+	k_EAppType_Guide				= 0x040,	// game guide, PDF etc
+	k_EAppType_Driver				= 0x080,	// hardware driver updater (ATI, Razor etc)
+	k_EAppType_Config				= 0x100,	// hidden app used to config Steam features (backpack, sales, etc)
+	k_EAppType_Hardware				= 0x200,	// a hardware device (Steam Machine, Steam Controller, Steam Link, etc.)
+	k_EAppType_Franchise			= 0x400,	// A hub for collections of multiple apps, eg films, series, games
+	k_EAppType_Video				= 0x800,	// A video component of either a Film or TVSeries (may be the feature, an episode, preview, making-of, etc)
+	k_EAppType_Plugin				= 0x1000,	// Plug-in types for other Apps
+	k_EAppType_Music				= 0x2000,	// Music files
+	k_EAppType_Series				= 0x4000,	// Container app for video series
+		
+	k_EAppType_Shortcut				= 0x40000000,	// just a shortcut, client side only
+	k_EAppType_DepotOnly			= 0x80000000,	// placeholder since depots and apps share the same namespace
+};
+
+
+
+//-----------------------------------------------------------------------------
+// types of user game stats fields
+// WARNING: DO NOT RENUMBER EXISTING VALUES - STORED IN DATABASE
+//-----------------------------------------------------------------------------
+enum ESteamUserStatType
+{
+	k_ESteamUserStatTypeINVALID = 0,
+	k_ESteamUserStatTypeINT = 1,
+	k_ESteamUserStatTypeFLOAT = 2,
+	// Read as FLOAT, set with count / session length
+	k_ESteamUserStatTypeAVGRATE = 3,
+	k_ESteamUserStatTypeACHIEVEMENTS = 4,
+	k_ESteamUserStatTypeGROUPACHIEVEMENTS = 5,
+
+	// max, for sanity checks
+	k_ESteamUserStatTypeMAX
+};
+
+
+//-----------------------------------------------------------------------------
+// Purpose: Chat Entry Types (previously was only friend-to-friend message types)
+//-----------------------------------------------------------------------------
+enum EChatEntryType
+{
+	k_EChatEntryTypeInvalid = 0, 
+	k_EChatEntryTypeChatMsg = 1,		// Normal text message from another user
+	k_EChatEntryTypeTyping = 2,			// Another user is typing (not used in multi-user chat)
+	k_EChatEntryTypeInviteGame = 3,		// Invite from other user into that users current game
+	k_EChatEntryTypeEmote = 4,			// text emote message (deprecated, should be treated as ChatMsg)
+	//k_EChatEntryTypeLobbyGameStart = 5,	// lobby game is starting (dead - listen for LobbyGameCreated_t callback instead)
+	k_EChatEntryTypeLeftConversation = 6, // user has left the conversation ( closed chat window )
+	// Above are previous FriendMsgType entries, now merged into more generic chat entry types
+	k_EChatEntryTypeEntered = 7,		// user has entered the conversation (used in multi-user chat and group chat)
+	k_EChatEntryTypeWasKicked = 8,		// user was kicked (data: 64-bit steamid of actor performing the kick)
+	k_EChatEntryTypeWasBanned = 9,		// user was banned (data: 64-bit steamid of actor performing the ban)
+	k_EChatEntryTypeDisconnected = 10,	// user disconnected
+	k_EChatEntryTypeHistoricalChat = 11,	// a chat message from user's chat history or offilne message
+	//k_EChatEntryTypeReserved1 = 12, // No longer used
+	//k_EChatEntryTypeReserved2 = 13, // No longer used
+	k_EChatEntryTypeLinkBlocked = 14, // a link was removed by the chat filter.
+};
+
+
+//-----------------------------------------------------------------------------
+// Purpose: Chat Room Enter Responses
+//-----------------------------------------------------------------------------
+enum EChatRoomEnterResponse
+{
+	k_EChatRoomEnterResponseSuccess = 1,		// Success
+	k_EChatRoomEnterResponseDoesntExist = 2,	// Chat doesn't exist (probably closed)
+	k_EChatRoomEnterResponseNotAllowed = 3,		// General Denied - You don't have the permissions needed to join the chat
+	k_EChatRoomEnterResponseFull = 4,			// Chat room has reached its maximum size
+	k_EChatRoomEnterResponseError = 5,			// Unexpected Error
+	k_EChatRoomEnterResponseBanned = 6,			// You are banned from this chat room and may not join
+	k_EChatRoomEnterResponseLimited = 7,		// Joining this chat is not allowed because you are a limited user (no value on account)
+	k_EChatRoomEnterResponseClanDisabled = 8,	// Attempt to join a clan chat when the clan is locked or disabled
+	k_EChatRoomEnterResponseCommunityBan = 9,	// Attempt to join a chat when the user has a community lock on their account
+	k_EChatRoomEnterResponseMemberBlockedYou = 10, // Join failed - some member in the chat has blocked you from joining
+	k_EChatRoomEnterResponseYouBlockedMember = 11, // Join failed - you have blocked some member already in the chat
+	// k_EChatRoomEnterResponseNoRankingDataLobby = 12,  // No longer used
+	// k_EChatRoomEnterResponseNoRankingDataUser = 13,  //  No longer used
+	// k_EChatRoomEnterResponseRankOutOfRange = 14, //  No longer used
+};
+
+
+typedef void (*PFNLegacyKeyRegistration)( const char *pchCDKey, const char *pchInstallPath );
+typedef bool (*PFNLegacyKeyInstalled)();
+
+const unsigned int k_unSteamAccountIDMask = 0xFFFFFFFF;
+const unsigned int k_unSteamAccountInstanceMask = 0x000FFFFF;
+// we allow 3 simultaneous user account instances right now, 1= desktop, 2 = console, 4 = web, 0 = all
+const unsigned int k_unSteamUserDesktopInstance	= 1;	 
+const unsigned int k_unSteamUserConsoleInstance	= 2;
+const unsigned int k_unSteamUserWebInstance		= 4;
+
+// Special flags for Chat accounts - they go in the top 8 bits
+// of the steam ID's "instance", leaving 12 for the actual instances
+enum EChatSteamIDInstanceFlags
+{
+	k_EChatAccountInstanceMask = 0x00000FFF, // top 8 bits are flags
+
+	k_EChatInstanceFlagClan = ( k_unSteamAccountInstanceMask + 1 ) >> 1,	// top bit
+	k_EChatInstanceFlagLobby = ( k_unSteamAccountInstanceMask + 1 ) >> 2,	// next one down, etc
+	k_EChatInstanceFlagMMSLobby = ( k_unSteamAccountInstanceMask + 1 ) >> 3,	// next one down, etc
+
+	// Max of 8 flags
+};
+
+
+//-----------------------------------------------------------------------------
+// Purpose: Marketing message flags that change how a client should handle them
+//-----------------------------------------------------------------------------
+enum EMarketingMessageFlags
+{
+	k_EMarketingMessageFlagsNone = 0,
+	k_EMarketingMessageFlagsHighPriority = 1 << 0,
+	k_EMarketingMessageFlagsPlatformWindows = 1 << 1,
+	k_EMarketingMessageFlagsPlatformMac = 1 << 2,
+	k_EMarketingMessageFlagsPlatformLinux = 1 << 3,
+
+	//aggregate flags
+	k_EMarketingMessageFlagsPlatformRestrictions = 
+		k_EMarketingMessageFlagsPlatformWindows |
+        k_EMarketingMessageFlagsPlatformMac |
+        k_EMarketingMessageFlagsPlatformLinux,
+};
+
+
+
+//-----------------------------------------------------------------------------
+// Purpose: Possible positions to tell the overlay to show notifications in
+//-----------------------------------------------------------------------------
+enum ENotificationPosition
+{
+	k_EPositionTopLeft = 0,
+	k_EPositionTopRight = 1,
+	k_EPositionBottomLeft = 2,
+	k_EPositionBottomRight = 3,
+};
+
+
+//-----------------------------------------------------------------------------
+// Purpose: Broadcast upload result details
+//-----------------------------------------------------------------------------
+enum EBroadcastUploadResult
+{
+	k_EBroadcastUploadResultNone = 0,	// broadcast state unknown
+	k_EBroadcastUploadResultOK = 1,		// broadcast was good, no problems
+	k_EBroadcastUploadResultInitFailed = 2,	// broadcast init failed
+	k_EBroadcastUploadResultFrameFailed = 3,	// broadcast frame upload failed
+	k_EBroadcastUploadResultTimeout = 4,	// broadcast upload timed out
+	k_EBroadcastUploadResultBandwidthExceeded = 5,	// broadcast send too much data
+	k_EBroadcastUploadResultLowFPS = 6,	// broadcast FPS too low
+	k_EBroadcastUploadResultMissingKeyFrames = 7,	// broadcast sending not enough key frames
+	k_EBroadcastUploadResultNoConnection = 8,	// broadcast client failed to connect to relay
+	k_EBroadcastUploadResultRelayFailed = 9,	// relay dropped the upload
+	k_EBroadcastUploadResultSettingsChanged = 10,	// the client changed broadcast settings 
+	k_EBroadcastUploadResultMissingAudio = 11,	// client failed to send audio data
+	k_EBroadcastUploadResultTooFarBehind = 12,	// clients was too slow uploading
+	k_EBroadcastUploadResultTranscodeBehind = 13,	// server failed to keep up with transcode
+};
+
+
+//-----------------------------------------------------------------------------
+// Purpose: codes for well defined launch options
+//-----------------------------------------------------------------------------
+enum ELaunchOptionType
+{
+	k_ELaunchOptionType_None		= 0,	// unknown what launch option does
+	k_ELaunchOptionType_Default		= 1,	// runs the game, app, whatever in default mode
+	k_ELaunchOptionType_SafeMode	= 2,	// runs the game in safe mode
+	k_ELaunchOptionType_Multiplayer = 3,	// runs the game in multiplayer mode
+	k_ELaunchOptionType_Config		= 4,	// runs config tool for this game
+	k_ELaunchOptionType_OpenVR		= 5,	// runs game in VR mode using OpenVR
+	k_ELaunchOptionType_Server		= 6,	// runs dedicated server for this game
+	k_ELaunchOptionType_Editor		= 7,	// runs game editor
+	k_ELaunchOptionType_Manual		= 8,	// shows game manual
+	k_ELaunchOptionType_Benchmark	= 9,	// runs game benchmark
+	k_ELaunchOptionType_Option1		= 10,	// generic run option, uses description field for game name
+	k_ELaunchOptionType_Option2		= 11,	// generic run option, uses description field for game name
+	k_ELaunchOptionType_Option3     = 12,	// generic run option, uses description field for game name
+	k_ELaunchOptionType_OculusVR	= 13,	// runs game in VR mode using the Oculus SDK 
+	k_ELaunchOptionType_OpenVROverlay = 14,	// runs an OpenVR dashboard overlay
+	k_ELaunchOptionType_OSVR		= 15,	// runs game in VR mode using the OSVR SDK
+
+	
+	k_ELaunchOptionType_Dialog 		= 1000, // show launch options dialog
+};
+
+
+//-----------------------------------------------------------------------------
+// Purpose: true if this launch option is any of the vr launching types
+//-----------------------------------------------------------------------------
+static inline bool BIsVRLaunchOptionType( const ELaunchOptionType  eType )
+{
+	return eType == k_ELaunchOptionType_OpenVR 
+		|| eType == k_ELaunchOptionType_OpenVROverlay 
+		|| eType == k_ELaunchOptionType_OculusVR
+		|| eType == k_ELaunchOptionType_OSVR;
+}
+
+
+//-----------------------------------------------------------------------------
+// Purpose: code points for VR HMD vendors and models 
+// WARNING: DO NOT RENUMBER EXISTING VALUES - STORED IN A DATABASE
+//-----------------------------------------------------------------------------
+enum EVRHMDType
+{
+	k_eEVRHMDType_None = -1, // unknown vendor and model
+
+	k_eEVRHMDType_Unknown = 0, // unknown vendor and model
+
+	k_eEVRHMDType_HTC_Dev = 1,	// original HTC dev kits
+	k_eEVRHMDType_HTC_VivePre = 2,	// htc vive pre
+	k_eEVRHMDType_HTC_Vive = 3,	// htc vive consumer release
+
+	k_eEVRHMDType_HTC_Unknown = 20, // unknown htc hmd
+
+	k_eEVRHMDType_Oculus_DK1 = 21, // Oculus DK1 
+	k_eEVRHMDType_Oculus_DK2 = 22, // Oculus DK2
+	k_eEVRHMDType_Oculus_Rift = 23, // Oculus rift
+
+	k_eEVRHMDType_Oculus_Unknown = 40, // // Oculus unknown HMD
+};
+
+
+//-----------------------------------------------------------------------------
+// Purpose: true if this is from an Oculus HMD
+//-----------------------------------------------------------------------------
+static inline bool BIsOculusHMD( EVRHMDType eType )
+{
+	return eType == k_eEVRHMDType_Oculus_DK1 || eType == k_eEVRHMDType_Oculus_DK2 || eType == k_eEVRHMDType_Oculus_Rift || eType == k_eEVRHMDType_Oculus_Unknown;
+}
+
+
+//-----------------------------------------------------------------------------
+// Purpose: true if this is from an Vive HMD
+//-----------------------------------------------------------------------------
+static inline bool BIsViveHMD( EVRHMDType eType )
+{
+	return eType == k_eEVRHMDType_HTC_Dev || eType == k_eEVRHMDType_HTC_VivePre || eType == k_eEVRHMDType_HTC_Vive || eType == k_eEVRHMDType_HTC_Unknown;
+}
+
+
+#pragma pack( push, 1 )
+
+#define CSTEAMID_DEFINED
+
+// Steam ID structure (64 bits total)
+class CSteamID
+{
+public:
+
+	//-----------------------------------------------------------------------------
+	// Purpose: Constructor
+	//-----------------------------------------------------------------------------
+	CSteamID()
+	{
+		m_steamid.m_comp.m_unAccountID = 0;
+		m_steamid.m_comp.m_EAccountType = k_EAccountTypeInvalid;
+		m_steamid.m_comp.m_EUniverse = k_EUniverseInvalid;
+		m_steamid.m_comp.m_unAccountInstance = 0;
+	}
+
+
+	//-----------------------------------------------------------------------------
+	// Purpose: Constructor
+	// Input  : unAccountID -	32-bit account ID
+	//			eUniverse -		Universe this account belongs to
+	//			eAccountType -	Type of account
+	//-----------------------------------------------------------------------------
+	CSteamID( uint32 unAccountID, EUniverse eUniverse, EAccountType eAccountType )
+	{
+		Set( unAccountID, eUniverse, eAccountType );
+	}
+
+
+	//-----------------------------------------------------------------------------
+	// Purpose: Constructor
+	// Input  : unAccountID -	32-bit account ID
+	//			unAccountInstance - instance 
+	//			eUniverse -		Universe this account belongs to
+	//			eAccountType -	Type of account
+	//-----------------------------------------------------------------------------
+	CSteamID( uint32 unAccountID, unsigned int unAccountInstance, EUniverse eUniverse, EAccountType eAccountType )
+	{
+#if defined(_SERVER) && defined(Assert)
+		Assert( ! ( ( k_EAccountTypeIndividual == eAccountType ) && ( unAccountInstance > k_unSteamUserWebInstance ) ) );	// enforce that for individual accounts, instance is always 1
+#endif // _SERVER
+		InstancedSet( unAccountID, unAccountInstance, eUniverse, eAccountType );
+	}
+
+
+	//-----------------------------------------------------------------------------
+	// Purpose: Constructor
+	// Input  : ulSteamID -		64-bit representation of a Steam ID
+	// Note:	Will not accept a uint32 or int32 as input, as that is a probable mistake.
+	//			See the stubbed out overloads in the private: section for more info.
+	//-----------------------------------------------------------------------------
+	CSteamID( uint64 ulSteamID )
+	{
+		SetFromUint64( ulSteamID );
+	}
+#ifdef INT64_DIFFERENT_FROM_INT64_T
+	CSteamID( uint64_t ulSteamID )
+	{
+		SetFromUint64( (uint64)ulSteamID );
+	}
+#endif
+
+
+	//-----------------------------------------------------------------------------
+	// Purpose: Sets parameters for steam ID
+	// Input  : unAccountID -	32-bit account ID
+	//			eUniverse -		Universe this account belongs to
+	//			eAccountType -	Type of account
+	//-----------------------------------------------------------------------------
+	void Set( uint32 unAccountID, EUniverse eUniverse, EAccountType eAccountType )
+	{
+		m_steamid.m_comp.m_unAccountID = unAccountID;
+		m_steamid.m_comp.m_EUniverse = eUniverse;
+		m_steamid.m_comp.m_EAccountType = eAccountType;
+
+		if ( eAccountType == k_EAccountTypeClan || eAccountType == k_EAccountTypeGameServer )
+		{
+			m_steamid.m_comp.m_unAccountInstance = 0;
+		}
+		else
+		{
+			// by default we pick the desktop instance
+			m_steamid.m_comp.m_unAccountInstance = k_unSteamUserDesktopInstance;
+		}
+	}
+
+
+	//-----------------------------------------------------------------------------
+	// Purpose: Sets parameters for steam ID
+	// Input  : unAccountID -	32-bit account ID
+	//			eUniverse -		Universe this account belongs to
+	//			eAccountType -	Type of account
+	//-----------------------------------------------------------------------------
+	void InstancedSet( uint32 unAccountID, uint32 unInstance, EUniverse eUniverse, EAccountType eAccountType )
+	{
+		m_steamid.m_comp.m_unAccountID = unAccountID;
+		m_steamid.m_comp.m_EUniverse = eUniverse;
+		m_steamid.m_comp.m_EAccountType = eAccountType;
+		m_steamid.m_comp.m_unAccountInstance = unInstance;
+	}
+
+
+	//-----------------------------------------------------------------------------
+	// Purpose: Initializes a steam ID from its 52 bit parts and universe/type
+	// Input  : ulIdentifier - 52 bits of goodness
+	//-----------------------------------------------------------------------------
+	void FullSet( uint64 ulIdentifier, EUniverse eUniverse, EAccountType eAccountType )
+	{
+		m_steamid.m_comp.m_unAccountID = ( ulIdentifier & k_unSteamAccountIDMask );						// account ID is low 32 bits
+		m_steamid.m_comp.m_unAccountInstance = ( ( ulIdentifier >> 32 ) & k_unSteamAccountInstanceMask );			// account instance is next 20 bits
+		m_steamid.m_comp.m_EUniverse = eUniverse;
+		m_steamid.m_comp.m_EAccountType = eAccountType;
+	}
+
+
+	//-----------------------------------------------------------------------------
+	// Purpose: Initializes a steam ID from its 64-bit representation
+	// Input  : ulSteamID -		64-bit representation of a Steam ID
+	//-----------------------------------------------------------------------------
+	void SetFromUint64( uint64 ulSteamID )
+	{
+		m_steamid.m_unAll64Bits = ulSteamID;
+	}
+
+
+	//-----------------------------------------------------------------------------
+	// Purpose: Clear all fields, leaving an invalid ID.
+	//-----------------------------------------------------------------------------
+    void Clear()
+	{
+		m_steamid.m_comp.m_unAccountID = 0;
+		m_steamid.m_comp.m_EAccountType = k_EAccountTypeInvalid;
+		m_steamid.m_comp.m_EUniverse = k_EUniverseInvalid;
+		m_steamid.m_comp.m_unAccountInstance = 0;
+	}
+
+
+#if defined( INCLUDED_STEAM2_USERID_STRUCTS ) 
+	//-----------------------------------------------------------------------------
+	// Purpose: Initializes a steam ID from a Steam2 ID structure
+	// Input:	pTSteamGlobalUserID -	Steam2 ID to convert
+	//			eUniverse -				universe this ID belongs to
+	//-----------------------------------------------------------------------------
+	void SetFromSteam2( TSteamGlobalUserID *pTSteamGlobalUserID, EUniverse eUniverse )
+	{
+		m_steamid.m_comp.m_unAccountID = pTSteamGlobalUserID->m_SteamLocalUserID.Split.Low32bits * 2 + 
+			pTSteamGlobalUserID->m_SteamLocalUserID.Split.High32bits;
+		m_steamid.m_comp.m_EUniverse = eUniverse;		// set the universe
+		m_steamid.m_comp.m_EAccountType = k_EAccountTypeIndividual; // Steam 2 accounts always map to account type of individual
+		m_steamid.m_comp.m_unAccountInstance = k_unSteamUserDesktopInstance; // Steam2 only knew desktop instances
+	}
+
+	//-----------------------------------------------------------------------------
+	// Purpose: Fills out a Steam2 ID structure
+	// Input:	pTSteamGlobalUserID -	Steam2 ID to write to
+	//-----------------------------------------------------------------------------
+	void ConvertToSteam2( TSteamGlobalUserID *pTSteamGlobalUserID ) const
+	{
+		// only individual accounts have any meaning in Steam 2, only they can be mapped
+		// Assert( m_steamid.m_comp.m_EAccountType == k_EAccountTypeIndividual );
+
+		pTSteamGlobalUserID->m_SteamInstanceID = 0;
+		pTSteamGlobalUserID->m_SteamLocalUserID.Split.High32bits = m_steamid.m_comp.m_unAccountID % 2;
+		pTSteamGlobalUserID->m_SteamLocalUserID.Split.Low32bits = m_steamid.m_comp.m_unAccountID / 2;
+	}
+#endif // defined( INCLUDED_STEAM_COMMON_STEAMCOMMON_H )
+
+	//-----------------------------------------------------------------------------
+	// Purpose: Converts steam ID to its 64-bit representation
+	// Output : 64-bit representation of a Steam ID
+	//-----------------------------------------------------------------------------
+	uint64 ConvertToUint64() const
+	{
+		return m_steamid.m_unAll64Bits;
+	}
+
+
+	//-----------------------------------------------------------------------------
+	// Purpose: Converts the static parts of a steam ID to a 64-bit representation.
+	//			For multiseat accounts, all instances of that account will have the
+	//			same static account key, so they can be grouped together by the static
+	//			account key.
+	// Output : 64-bit static account key
+	//-----------------------------------------------------------------------------
+	uint64 GetStaticAccountKey() const
+	{
+		// note we do NOT include the account instance (which is a dynamic property) in the static account key
+		return (uint64) ( ( ( (uint64) m_steamid.m_comp.m_EUniverse ) << 56 ) + ((uint64) m_steamid.m_comp.m_EAccountType << 52 ) + m_steamid.m_comp.m_unAccountID );
+	}
+
+
+	//-----------------------------------------------------------------------------
+	// Purpose: create an anonymous game server login to be filled in by the AM
+	//-----------------------------------------------------------------------------
+	void CreateBlankAnonLogon( EUniverse eUniverse )
+	{
+		m_steamid.m_comp.m_unAccountID = 0;
+		m_steamid.m_comp.m_EAccountType = k_EAccountTypeAnonGameServer;
+		m_steamid.m_comp.m_EUniverse = eUniverse;
+		m_steamid.m_comp.m_unAccountInstance = 0;
+	}
+
+
+	//-----------------------------------------------------------------------------
+	// Purpose: create an anonymous game server login to be filled in by the AM
+	//-----------------------------------------------------------------------------
+	void CreateBlankAnonUserLogon( EUniverse eUniverse )
+	{
+		m_steamid.m_comp.m_unAccountID = 0;
+		m_steamid.m_comp.m_EAccountType = k_EAccountTypeAnonUser;
+		m_steamid.m_comp.m_EUniverse = eUniverse;
+		m_steamid.m_comp.m_unAccountInstance = 0;
+	}
+
+	//-----------------------------------------------------------------------------
+	// Purpose: Is this an anonymous game server login that will be filled in?
+	//-----------------------------------------------------------------------------
+	bool BBlankAnonAccount() const
+	{
+		return m_steamid.m_comp.m_unAccountID == 0 && BAnonAccount() && m_steamid.m_comp.m_unAccountInstance == 0;
+	}
+
+	//-----------------------------------------------------------------------------
+	// Purpose: Is this a game server account id?  (Either persistent or anonymous)
+	//-----------------------------------------------------------------------------
+	bool BGameServerAccount() const
+	{
+		return m_steamid.m_comp.m_EAccountType == k_EAccountTypeGameServer || m_steamid.m_comp.m_EAccountType == k_EAccountTypeAnonGameServer;
+	}
+
+	//-----------------------------------------------------------------------------
+	// Purpose: Is this a persistent (not anonymous) game server account id?
+	//-----------------------------------------------------------------------------
+	bool BPersistentGameServerAccount() const
+	{
+		return m_steamid.m_comp.m_EAccountType == k_EAccountTypeGameServer;
+	}
+
+	//-----------------------------------------------------------------------------
+	// Purpose: Is this an anonymous game server account id?
+	//-----------------------------------------------------------------------------
+	bool BAnonGameServerAccount() const
+	{
+		return m_steamid.m_comp.m_EAccountType == k_EAccountTypeAnonGameServer;
+	}
+
+	//-----------------------------------------------------------------------------
+	// Purpose: Is this a content server account id?
+	//-----------------------------------------------------------------------------
+	bool BContentServerAccount() const
+	{
+		return m_steamid.m_comp.m_EAccountType == k_EAccountTypeContentServer;
+	}
+
+
+	//-----------------------------------------------------------------------------
+	// Purpose: Is this a clan account id?
+	//-----------------------------------------------------------------------------
+	bool BClanAccount() const
+	{
+		return m_steamid.m_comp.m_EAccountType == k_EAccountTypeClan;
+	}
+
+
+	//-----------------------------------------------------------------------------
+	// Purpose: Is this a chat account id?
+	//-----------------------------------------------------------------------------
+	bool BChatAccount() const
+	{
+		return m_steamid.m_comp.m_EAccountType == k_EAccountTypeChat;
+	}
+
+	//-----------------------------------------------------------------------------
+	// Purpose: Is this a chat account id?
+	//-----------------------------------------------------------------------------
+	bool IsLobby() const
+	{
+		return ( m_steamid.m_comp.m_EAccountType == k_EAccountTypeChat )
+			&& ( m_steamid.m_comp.m_unAccountInstance & k_EChatInstanceFlagLobby );
+	}
+
+
+	//-----------------------------------------------------------------------------
+	// Purpose: Is this an individual user account id?
+	//-----------------------------------------------------------------------------
+	bool BIndividualAccount() const
+	{
+		return m_steamid.m_comp.m_EAccountType == k_EAccountTypeIndividual || m_steamid.m_comp.m_EAccountType == k_EAccountTypeConsoleUser;
+	}
+
+
+	//-----------------------------------------------------------------------------
+	// Purpose: Is this an anonymous account?
+	//-----------------------------------------------------------------------------
+	bool BAnonAccount() const
+	{
+		return m_steamid.m_comp.m_EAccountType == k_EAccountTypeAnonUser || m_steamid.m_comp.m_EAccountType == k_EAccountTypeAnonGameServer;
+	}
+
+	//-----------------------------------------------------------------------------
+	// Purpose: Is this an anonymous user account? ( used to create an account or reset a password )
+	//-----------------------------------------------------------------------------
+	bool BAnonUserAccount() const
+	{
+		return m_steamid.m_comp.m_EAccountType == k_EAccountTypeAnonUser;
+	}
+
+	//-----------------------------------------------------------------------------
+	// Purpose: Is this a faked up Steam ID for a PSN friend account?
+	//-----------------------------------------------------------------------------
+	bool BConsoleUserAccount() const
+	{
+		return m_steamid.m_comp.m_EAccountType == k_EAccountTypeConsoleUser;
+	}
+
+	// simple accessors
+	void SetAccountID( uint32 unAccountID )		{ m_steamid.m_comp.m_unAccountID = unAccountID; }
+	void SetAccountInstance( uint32 unInstance ){ m_steamid.m_comp.m_unAccountInstance = unInstance; }
+	void ClearIndividualInstance()				{ if ( BIndividualAccount() ) m_steamid.m_comp.m_unAccountInstance = 0; }
+	bool HasNoIndividualInstance() const		{ return BIndividualAccount() && (m_steamid.m_comp.m_unAccountInstance==0); }
+	AccountID_t GetAccountID() const			{ return m_steamid.m_comp.m_unAccountID; }
+	uint32 GetUnAccountInstance() const			{ return m_steamid.m_comp.m_unAccountInstance; }
+	EAccountType GetEAccountType() const		{ return ( EAccountType ) m_steamid.m_comp.m_EAccountType; }
+	EUniverse GetEUniverse() const				{ return m_steamid.m_comp.m_EUniverse; }
+	void SetEUniverse( EUniverse eUniverse )	{ m_steamid.m_comp.m_EUniverse = eUniverse; }
+	bool IsValid() const;
+
+	// this set of functions is hidden, will be moved out of class
+	explicit CSteamID( const char *pchSteamID, EUniverse eDefaultUniverse = k_EUniverseInvalid );
+	const char * Render() const;				// renders this steam ID to string
+	static const char * Render( uint64 ulSteamID );	// static method to render a uint64 representation of a steam ID to a string
+
+	void SetFromString( const char *pchSteamID, EUniverse eDefaultUniverse );
+    // SetFromString allows many partially-correct strings, constraining how
+    // we might be able to change things in the future.
+    // SetFromStringStrict requires the exact string forms that we support
+    // and is preferred when the caller knows it's safe to be strict.
+    // Returns whether the string parsed correctly.
+	bool SetFromStringStrict( const char *pchSteamID, EUniverse eDefaultUniverse );
+	bool SetFromSteam2String( const char *pchSteam2ID, EUniverse eUniverse );
+
+	inline bool operator==( const CSteamID &val ) const { return m_steamid.m_unAll64Bits == val.m_steamid.m_unAll64Bits; } 
+	inline bool operator!=( const CSteamID &val ) const { return !operator==( val ); }
+	inline bool operator<( const CSteamID &val ) const { return m_steamid.m_unAll64Bits < val.m_steamid.m_unAll64Bits; }
+	inline bool operator>( const CSteamID &val ) const { return m_steamid.m_unAll64Bits > val.m_steamid.m_unAll64Bits; }
+
+	// DEBUG function
+	bool BValidExternalSteamID() const;
+
+private:
+	// These are defined here to prevent accidental implicit conversion of a u32AccountID to a CSteamID.
+	// If you get a compiler error about an ambiguous constructor/function then it may be because you're
+	// passing a 32-bit int to a function that takes a CSteamID. You should explicitly create the SteamID
+	// using the correct Universe and account Type/Instance values.
+	CSteamID( uint32 );
+	CSteamID( int32 );
+
+	// 64 bits total
+	union SteamID_t
+	{
+		struct SteamIDComponent_t
+		{
+#ifdef VALVE_BIG_ENDIAN
+			EUniverse			m_EUniverse : 8;	// universe this account belongs to
+			unsigned int		m_EAccountType : 4;			// type of account - can't show as EAccountType, due to signed / unsigned difference
+			unsigned int		m_unAccountInstance : 20;	// dynamic instance ID
+			uint32				m_unAccountID : 32;			// unique account identifier
+#else
+			uint32				m_unAccountID : 32;			// unique account identifier
+			unsigned int		m_unAccountInstance : 20;	// dynamic instance ID
+			unsigned int		m_EAccountType : 4;			// type of account - can't show as EAccountType, due to signed / unsigned difference
+			EUniverse			m_EUniverse : 8;	// universe this account belongs to
+#endif
+		} m_comp;
+
+		uint64 m_unAll64Bits;
+	} m_steamid;
+};
+
+inline bool CSteamID::IsValid() const
+{
+	if ( m_steamid.m_comp.m_EAccountType <= k_EAccountTypeInvalid || m_steamid.m_comp.m_EAccountType >= k_EAccountTypeMax )
+		return false;
+	
+	if ( m_steamid.m_comp.m_EUniverse <= k_EUniverseInvalid || m_steamid.m_comp.m_EUniverse >= k_EUniverseMax )
+		return false;
+
+	if ( m_steamid.m_comp.m_EAccountType == k_EAccountTypeIndividual )
+	{
+		if ( m_steamid.m_comp.m_unAccountID == 0 || m_steamid.m_comp.m_unAccountInstance > k_unSteamUserWebInstance )
+			return false;
+	}
+
+	if ( m_steamid.m_comp.m_EAccountType == k_EAccountTypeClan )
+	{
+		if ( m_steamid.m_comp.m_unAccountID == 0 || m_steamid.m_comp.m_unAccountInstance != 0 )
+			return false;
+	}
+
+	if ( m_steamid.m_comp.m_EAccountType == k_EAccountTypeGameServer )
+	{
+		if ( m_steamid.m_comp.m_unAccountID == 0 )
+			return false;
+		// Any limit on instances?  We use them for local users and bots
+	}
+	return true;
+}
+
+// generic invalid CSteamID
+#define k_steamIDNil CSteamID()
+
+// This steamID comes from a user game connection to an out of date GS that hasnt implemented the protocol
+// to provide its steamID
+#define k_steamIDOutofDateGS CSteamID( 0, 0, k_EUniverseInvalid, k_EAccountTypeInvalid )
+// This steamID comes from a user game connection to an sv_lan GS
+#define k_steamIDLanModeGS CSteamID( 0, 0, k_EUniversePublic, k_EAccountTypeInvalid )
+// This steamID can come from a user game connection to a GS that has just booted but hasnt yet even initialized
+// its steam3 component and started logging on.
+#define k_steamIDNotInitYetGS CSteamID( 1, 0, k_EUniverseInvalid, k_EAccountTypeInvalid )
+// This steamID can come from a user game connection to a GS that isn't using the steam authentication system but still
+// wants to support the "Join Game" option in the friends list
+#define k_steamIDNonSteamGS CSteamID( 2, 0, k_EUniverseInvalid, k_EAccountTypeInvalid )
+
+
+#ifdef STEAM
+// Returns the matching chat steamID, with the default instance of 0
+// If the steamID passed in is already of type k_EAccountTypeChat it will be returned with the same instance
+CSteamID ChatIDFromSteamID( const CSteamID &steamID );
+// Returns the matching clan steamID, with the default instance of 0
+// If the steamID passed in is already of type k_EAccountTypeClan it will be returned with the same instance
+CSteamID ClanIDFromSteamID( const CSteamID &steamID );
+// Asserts steamID type before conversion
+CSteamID ChatIDFromClanID( const CSteamID &steamIDClan );
+// Asserts steamID type before conversion
+CSteamID ClanIDFromChatID( const CSteamID &steamIDChat );
+
+#endif // _STEAM
+
+
+//-----------------------------------------------------------------------------
+// Purpose: encapsulates an appID/modID pair
+//-----------------------------------------------------------------------------
+class CGameID
+{
+public:
+
+	CGameID()
+	{
+		m_gameID.m_nType = k_EGameIDTypeApp;
+		m_gameID.m_nAppID = k_uAppIdInvalid;
+		m_gameID.m_nModID = 0;
+	}
+
+	explicit CGameID( uint64 ulGameID )
+	{
+		m_ulGameID = ulGameID;
+	}
+#ifdef INT64_DIFFERENT_FROM_INT64_T
+	CGameID( uint64_t ulGameID )
+	{
+		m_ulGameID = (uint64)ulGameID;
+	}
+#endif
+
+	explicit CGameID( int32 nAppID )
+	{
+		m_ulGameID = 0;
+		m_gameID.m_nAppID = nAppID;
+	}
+
+	explicit CGameID( uint32 nAppID )
+	{
+		m_ulGameID = 0;
+		m_gameID.m_nAppID = nAppID;
+	}
+
+	CGameID( uint32 nAppID, uint32 nModID )
+	{
+		m_ulGameID = 0;
+		m_gameID.m_nAppID = nAppID;
+		m_gameID.m_nModID = nModID;
+		m_gameID.m_nType = k_EGameIDTypeGameMod;
+	}
+
+	// Hidden functions used only by Steam
+	explicit CGameID( const char *pchGameID );
+	const char *Render() const;					// render this Game ID to string
+	static const char *Render( uint64 ulGameID );		// static method to render a uint64 representation of a Game ID to a string
+
+	// must include checksum_crc.h first to get this functionality
+#if defined( CHECKSUM_CRC_H )
+	CGameID( uint32 nAppID, const char *pchModPath )
+	{
+		m_ulGameID = 0;
+		m_gameID.m_nAppID = nAppID;
+		m_gameID.m_nType = k_EGameIDTypeGameMod;
+
+		char rgchModDir[MAX_PATH];
+		V_FileBase( pchModPath, rgchModDir, sizeof( rgchModDir ) );
+		CRC32_t crc32;
+		CRC32_Init( &crc32 );
+		CRC32_ProcessBuffer( &crc32, rgchModDir, V_strlen( rgchModDir ) );
+		CRC32_Final( &crc32 );
+
+		// set the high-bit on the mod-id 
+		// reduces crc32 to 31bits, but lets us use the modID as a guaranteed unique
+		// replacement for appID's
+		m_gameID.m_nModID = crc32 | (0x80000000);
+	}
+
+	CGameID( const char *pchExePath, const char *pchAppName )
+	{
+		m_ulGameID = 0;
+		m_gameID.m_nAppID = k_uAppIdInvalid;
+		m_gameID.m_nType = k_EGameIDTypeShortcut;
+
+		CRC32_t crc32;
+		CRC32_Init( &crc32 );
+		if ( pchExePath )
+			CRC32_ProcessBuffer( &crc32, pchExePath, V_strlen( pchExePath ) );
+		if ( pchAppName )
+			CRC32_ProcessBuffer( &crc32, pchAppName, V_strlen( pchAppName ) );
+		CRC32_Final( &crc32 );
+
+		// set the high-bit on the mod-id 
+		// reduces crc32 to 31bits, but lets us use the modID as a guaranteed unique
+		// replacement for appID's
+		m_gameID.m_nModID = crc32 | (0x80000000);
+	}
+
+#if defined( VSTFILEID_H )
+
+	CGameID( VstFileID vstFileID )
+	{
+		m_ulGameID = 0;
+		m_gameID.m_nAppID = k_uAppIdInvalid;
+		m_gameID.m_nType = k_EGameIDTypeP2P;
+
+		CRC32_t crc32;
+		CRC32_Init( &crc32 );
+		const char *pchFileId = vstFileID.Render();
+		CRC32_ProcessBuffer( &crc32, pchFileId, V_strlen( pchFileId ) );
+		CRC32_Final( &crc32 );
+
+		// set the high-bit on the mod-id 
+		// reduces crc32 to 31bits, but lets us use the modID as a guaranteed unique
+		// replacement for appID's
+		m_gameID.m_nModID = crc32 | (0x80000000);		
+	}
+
+#endif /* VSTFILEID_H */
+
+#endif /* CHECKSUM_CRC_H */
+
+
+	uint64 ToUint64() const
+	{
+		return m_ulGameID;
+	}
+
+	uint64 *GetUint64Ptr()
+	{
+		return &m_ulGameID;
+	}
+
+	void Set( uint64 ulGameID )
+	{
+		m_ulGameID = ulGameID;
+	}
+
+	bool IsMod() const
+	{
+		return ( m_gameID.m_nType == k_EGameIDTypeGameMod );
+	}
+
+	bool IsShortcut() const
+	{
+		return ( m_gameID.m_nType == k_EGameIDTypeShortcut );
+	}
+
+	bool IsP2PFile() const
+	{
+		return ( m_gameID.m_nType == k_EGameIDTypeP2P );
+	}
+
+	bool IsSteamApp() const
+	{
+		return ( m_gameID.m_nType == k_EGameIDTypeApp );
+	}
+		
+	uint32 ModID() const
+	{
+		return m_gameID.m_nModID;
+	}
+
+	uint32 AppID() const
+	{
+		return m_gameID.m_nAppID;
+	}
+
+	bool operator == ( const CGameID &rhs ) const
+	{
+		return m_ulGameID == rhs.m_ulGameID;
+	}
+
+	bool operator != ( const CGameID &rhs ) const
+	{
+		return !(*this == rhs);
+	}
+
+	bool operator < ( const CGameID &rhs ) const
+	{
+		return ( m_ulGameID < rhs.m_ulGameID );
+	}
+
+	bool IsValid() const
+	{
+		// each type has it's own invalid fixed point:
+		switch( m_gameID.m_nType )
+		{
+		case k_EGameIDTypeApp:
+			return m_gameID.m_nAppID != k_uAppIdInvalid;
+
+		case k_EGameIDTypeGameMod:
+			return m_gameID.m_nAppID != k_uAppIdInvalid && m_gameID.m_nModID & 0x80000000;
+
+		case k_EGameIDTypeShortcut:
+			return (m_gameID.m_nModID & 0x80000000) != 0;
+
+		case k_EGameIDTypeP2P:
+			return m_gameID.m_nAppID == k_uAppIdInvalid && m_gameID.m_nModID & 0x80000000;
+
+		default:
+#if defined(Assert)
+			Assert(false);
+#endif
+			return false;
+		}
+
+	}
+
+	void Reset() 
+	{
+		m_ulGameID = 0;
+	}
+
+
+
+private:
+
+	enum EGameIDType
+	{
+		k_EGameIDTypeApp		= 0,
+		k_EGameIDTypeGameMod	= 1,
+		k_EGameIDTypeShortcut	= 2,
+		k_EGameIDTypeP2P		= 3,
+	};
+
+	struct GameID_t
+	{
+#ifdef VALVE_BIG_ENDIAN
+		unsigned int m_nModID : 32;
+		unsigned int m_nType : 8;
+		unsigned int m_nAppID : 24;
+#else
+		unsigned int m_nAppID : 24;
+		unsigned int m_nType : 8;
+		unsigned int m_nModID : 32;
+#endif
+	};
+
+	union
+	{
+		uint64 m_ulGameID;
+		GameID_t m_gameID;
+	};
+};
+
+#pragma pack( pop )
+
+const int k_cchGameExtraInfoMax = 64;
+
+
+//-----------------------------------------------------------------------------
+// Constants used for query ports.
+//-----------------------------------------------------------------------------
+
+#define QUERY_PORT_NOT_INITIALIZED		0xFFFF	// We haven't asked the GS for this query port's actual value yet.
+#define QUERY_PORT_ERROR				0xFFFE	// We were unable to get the query port for this server.
+
+
+//-----------------------------------------------------------------------------
+// Purpose: Passed as argument to SteamAPI_UseBreakpadCrashHandler to enable optional callback
+//  just before minidump file is captured after a crash has occurred.  (Allows app to append additional comment data to the dump, etc.)
+//-----------------------------------------------------------------------------
+typedef void (*PFNPreMinidumpCallback)(void *context);
+
+//-----------------------------------------------------------------------------
+// Purpose: Used by ICrashHandler interfaces to reference particular installed crash handlers
+//-----------------------------------------------------------------------------
+typedef void *BREAKPAD_HANDLE;
+#define BREAKPAD_INVALID_HANDLE (BREAKPAD_HANDLE)0 
+
+#endif // STEAMCLIENTPUBLIC_H

--- a/Common/Chairloader/SteamAPI/steamencryptedappticket.h
+++ b/Common/Chairloader/SteamAPI/steamencryptedappticket.h
@@ -1,0 +1,32 @@
+//========= Copyright © 1996-2010, Valve LLC, All rights reserved. ============
+//
+// Purpose: utilities to decode/decrypt a ticket from the
+// ISteamUser::RequestEncryptedAppTicket, ISteamUser::GetEncryptedAppTicket API
+// 
+// To use: declare CSteamEncryptedAppTicket, then call BDecryptTicket
+// if BDecryptTicket returns true, other accessors are valid
+// 
+//=============================================================================
+
+#include "steam_api.h"
+
+static const int k_nSteamEncryptedAppTicketSymmetricKeyLen = 32;				
+
+
+S_API bool SteamEncryptedAppTicket_BDecryptTicket( const uint8 *rgubTicketEncrypted, uint32 cubTicketEncrypted,
+						  uint8 *rgubTicketDecrypted, uint32 *pcubTicketDecrypted,
+						  const uint8 rgubKey[k_nSteamEncryptedAppTicketSymmetricKeyLen], int cubKey );
+
+S_API bool SteamEncryptedAppTicket_BIsTicketForApp( uint8 *rgubTicketDecrypted, uint32 cubTicketDecrypted, AppId_t nAppID );
+
+S_API RTime32 SteamEncryptedAppTicket_GetTicketIssueTime( uint8 *rgubTicketDecrypted, uint32 cubTicketDecrypted );
+
+S_API void SteamEncryptedAppTicket_GetTicketSteamID( uint8 *rgubTicketDecrypted, uint32 cubTicketDecrypted, CSteamID *psteamID );
+
+S_API AppId_t SteamEncryptedAppTicket_GetTicketAppID( uint8 *rgubTicketDecrypted, uint32 cubTicketDecrypted );
+
+S_API bool SteamEncryptedAppTicket_BUserOwnsAppInTicket( uint8 *rgubTicketDecrypted, uint32 cubTicketDecrypted, AppId_t nAppID );
+
+S_API bool SteamEncryptedAppTicket_BUserIsVacBanned( uint8 *rgubTicketDecrypted, uint32 cubTicketDecrypted );
+
+S_API const uint8 *SteamEncryptedAppTicket_GetUserVariableData( uint8 *rgubTicketDecrypted, uint32 cubTicketDecrypted, uint32 *pcubUserData );

--- a/Common/Chairloader/SteamAPI/steamhttpenums.h
+++ b/Common/Chairloader/SteamAPI/steamhttpenums.h
@@ -1,0 +1,98 @@
+//====== Copyright © 1996-2010, Valve Corporation, All rights reserved. =======
+//
+// Purpose: HTTP related enums, stuff that is shared by both clients and servers, and our
+// UI projects goes here.
+//
+//=============================================================================
+
+#ifndef STEAMHTTPENUMS_H
+#define STEAMHTTPENUMS_H
+#ifdef _WIN32
+#pragma once
+#endif
+
+// HTTP related types
+
+// This enum is used in client API methods, do not re-number existing values.
+enum EHTTPMethod
+{
+	k_EHTTPMethodInvalid = 0,
+	k_EHTTPMethodGET,
+	k_EHTTPMethodHEAD,
+	k_EHTTPMethodPOST,
+	k_EHTTPMethodPUT,
+	k_EHTTPMethodDELETE,
+	k_EHTTPMethodOPTIONS,
+	k_EHTTPMethodPATCH,
+
+	// The remaining HTTP methods are not yet supported, per rfc2616 section 5.1.1 only GET and HEAD are required for 
+	// a compliant general purpose server.  We'll likely add more as we find uses for them.
+
+	// k_EHTTPMethodTRACE,
+	// k_EHTTPMethodCONNECT
+};
+
+
+// HTTP Status codes that the server can send in response to a request, see rfc2616 section 10.3 for descriptions
+// of each of these.
+enum EHTTPStatusCode
+{
+	// Invalid status code (this isn't defined in HTTP, used to indicate unset in our code)
+	k_EHTTPStatusCodeInvalid =					0,
+
+	// Informational codes
+	k_EHTTPStatusCode100Continue =				100,
+	k_EHTTPStatusCode101SwitchingProtocols =	101,
+
+	// Success codes
+	k_EHTTPStatusCode200OK =					200,
+	k_EHTTPStatusCode201Created =				201,
+	k_EHTTPStatusCode202Accepted =				202,
+	k_EHTTPStatusCode203NonAuthoritative =		203,
+	k_EHTTPStatusCode204NoContent =				204,
+	k_EHTTPStatusCode205ResetContent =			205,
+	k_EHTTPStatusCode206PartialContent =		206,
+
+	// Redirection codes
+	k_EHTTPStatusCode300MultipleChoices =		300,
+	k_EHTTPStatusCode301MovedPermanently =		301,
+	k_EHTTPStatusCode302Found =					302,
+	k_EHTTPStatusCode303SeeOther =				303,
+	k_EHTTPStatusCode304NotModified =			304,
+	k_EHTTPStatusCode305UseProxy =				305,
+	//k_EHTTPStatusCode306Unused =				306, (used in old HTTP spec, now unused in 1.1)
+	k_EHTTPStatusCode307TemporaryRedirect =		307,
+
+	// Error codes
+	k_EHTTPStatusCode400BadRequest =			400,
+	k_EHTTPStatusCode401Unauthorized =			401, // You probably want 403 or something else. 401 implies you're sending a WWW-Authenticate header and the client can sent an Authorization header in response.
+	k_EHTTPStatusCode402PaymentRequired =		402, // This is reserved for future HTTP specs, not really supported by clients
+	k_EHTTPStatusCode403Forbidden =				403,
+	k_EHTTPStatusCode404NotFound =				404,
+	k_EHTTPStatusCode405MethodNotAllowed =		405,
+	k_EHTTPStatusCode406NotAcceptable =			406,
+	k_EHTTPStatusCode407ProxyAuthRequired =		407,
+	k_EHTTPStatusCode408RequestTimeout =		408,
+	k_EHTTPStatusCode409Conflict =				409,
+	k_EHTTPStatusCode410Gone =					410,
+	k_EHTTPStatusCode411LengthRequired =		411,
+	k_EHTTPStatusCode412PreconditionFailed =	412,
+	k_EHTTPStatusCode413RequestEntityTooLarge =	413,
+	k_EHTTPStatusCode414RequestURITooLong =		414,
+	k_EHTTPStatusCode415UnsupportedMediaType =	415,
+	k_EHTTPStatusCode416RequestedRangeNotSatisfiable = 416,
+	k_EHTTPStatusCode417ExpectationFailed =		417,
+	k_EHTTPStatusCode4xxUnknown = 				418, // 418 is reserved, so we'll use it to mean unknown
+	k_EHTTPStatusCode429TooManyRequests	=		429,
+
+	// Server error codes
+	k_EHTTPStatusCode500InternalServerError =	500,
+	k_EHTTPStatusCode501NotImplemented =		501,
+	k_EHTTPStatusCode502BadGateway =			502,
+	k_EHTTPStatusCode503ServiceUnavailable =	503,
+	k_EHTTPStatusCode504GatewayTimeout =		504,
+	k_EHTTPStatusCode505HTTPVersionNotSupported = 505,
+	k_EHTTPStatusCode5xxUnknown =				599,
+};
+
+#endif // STEAMHTTPENUMS_H

--- a/Common/Chairloader/SteamAPI/steamps3params.h
+++ b/Common/Chairloader/SteamAPI/steamps3params.h
@@ -1,0 +1,112 @@
+//====== Copyright 1996-2008, Valve Corporation, All rights reserved. =======
+//
+// Purpose: 
+//
+//=============================================================================
+
+#ifndef STEAMPS3PARAMS_H
+#define STEAMPS3PARAMS_H
+#ifdef _WIN32
+#pragma once
+#endif
+
+//----------------------------------------------------------------------------------------------------------------------------------------------------------//
+//	PlayStation 3 initialization parameters
+//
+//	The following structure must be passed to when loading steam_api_ps3.prx
+//----------------------------------------------------------------------------------------------------------------------------------------------------------//
+#define STEAM_PS3_PATH_MAX 1055
+#define STEAM_PS3_SERVICE_ID_MAX 32
+#define STEAM_PS3_COMMUNICATION_ID_MAX 10
+#define STEAM_PS3_COMMUNICATION_SIG_MAX 160
+#define STEAM_PS3_LANGUAGE_MAX 64
+#define STEAM_PS3_REGION_CODE_MAX 16
+#define STEAM_PS3_CURRENT_PARAMS_VER 2
+struct SteamPS3Params_t
+{
+	uint32 m_unVersion;										// set to STEAM_PS3_CURRENT_PARAMS_VER
+	
+	void *pReserved;
+	uint32 m_nAppId;										// set to your game's appid
+
+	char m_rgchInstallationPath[ STEAM_PS3_PATH_MAX ];		// directory containing latest steam prx's and sdata. Can be read only (BDVD)
+	char m_rgchSystemCache[ STEAM_PS3_PATH_MAX ];			// temp working cache, not persistent 
+	char m_rgchGameData[ STEAM_PS3_PATH_MAX ];				// persistent game data path for storing user data
+	char m_rgchNpServiceID[ STEAM_PS3_SERVICE_ID_MAX ];
+	char m_rgchNpCommunicationID[ STEAM_PS3_COMMUNICATION_ID_MAX ];
+	char m_rgchNpCommunicationSig[ STEAM_PS3_COMMUNICATION_SIG_MAX ];
+
+	// Language should be one of the following. must be zero terminated
+	// danish
+	// dutch
+	// english
+	// finnish
+	// french
+	// german
+	// italian
+	// korean
+	// norwegian
+	// polish
+	// portuguese
+	// russian
+	// schinese
+	// spanish
+	// swedish
+	// tchinese
+	char m_rgchSteamLanguage[ STEAM_PS3_LANGUAGE_MAX ];
+
+	// region codes are "SCEA", "SCEE", "SCEJ". must be zero terminated
+	char m_rgchRegionCode[ STEAM_PS3_REGION_CODE_MAX ];
+
+	// Should be SYS_TTYP3 through SYS_TTYP10, if it's 0 then Steam won't spawn a 
+	// thread to read console input at all.  Using this let's you use Steam console commands
+	// like: profile_on, profile_off, profile_dump, mem_stats, mem_validate.
+	unsigned int m_cSteamInputTTY;
+
+	struct Ps3netInit_t
+	{
+		bool m_bNeedInit;
+		void *m_pMemory;
+		int m_nMemorySize;
+		int m_flags;
+	} m_sysNetInitInfo;
+
+	struct Ps3jpgInit_t
+	{
+		bool m_bNeedInit;
+	} m_sysJpgInitInfo;
+
+	struct Ps3pngInit_t
+	{
+		bool m_bNeedInit;
+	} m_sysPngInitInfo;
+	
+	struct Ps3sysutilUserInfo_t
+	{
+		bool m_bNeedInit;
+	} m_sysSysUtilUserInfo;
+
+	bool m_bIncludeNewsPage;
+};
+
+
+//----------------------------------------------------------------------------------------------------------------------------------------------------------//
+// PlayStation 3 memory structure
+//----------------------------------------------------------------------------------------------------------------------------------------------------------//
+#define STEAMPS3_MALLOC_INUSE 0x53D04A51
+#define STEAMPS3_MALLOC_SYSTEM 0x0D102C48
+#define STEAMPS3_MALLOC_OK 0xFFD04A51
+struct SteamPS3Memory_t
+{
+	bool m_bSingleAllocation;		// If true, Steam will request one 6MB allocation and use the returned memory for all future allocations
+									// If false, Steam will make call malloc for each allocation
+
+	// required function pointers
+	void* (*m_pfMalloc)(size_t);
+	void* (*m_pfRealloc)(void *, size_t);
+	void (*m_pfFree)(void *);
+	size_t (*m_pUsable_size)(void*);
+};
+
+
+#endif // STEAMPS3PARAMS_H

--- a/Common/Chairloader/SteamAPI/steamtypes.h
+++ b/Common/Chairloader/SteamAPI/steamtypes.h
@@ -1,0 +1,181 @@
+//========= Copyright © 1996-2008, Valve LLC, All rights reserved. ============
+//
+// Purpose:
+//
+//=============================================================================
+
+#ifndef STEAMTYPES_H
+#define STEAMTYPES_H
+#ifdef _WIN32
+#pragma once
+#endif
+
+#define S_CALLTYPE __cdecl
+
+// Steam-specific types. Defined here so this header file can be included in other code bases.
+#ifndef WCHARTYPES_H
+typedef unsigned char uint8;
+#endif
+
+#if defined( __GNUC__ ) && !defined(POSIX)
+	#if __GNUC__ < 4
+		#error "Steamworks requires GCC 4.X (4.2 or 4.4 have been tested)"
+	#endif
+	#define POSIX 1
+#endif
+
+#if defined(__x86_64__) || defined(_WIN64)
+#define X64BITS
+#endif
+
+// Make sure VALVE_BIG_ENDIAN gets set on PS3, may already be set previously in Valve internal code.
+#if !defined(VALVE_BIG_ENDIAN) && defined(_PS3)
+#define VALVE_BIG_ENDIAN
+#endif
+
+typedef unsigned char uint8;
+typedef signed char int8;
+
+#if defined( _WIN32 )
+
+typedef __int16 int16;
+typedef unsigned __int16 uint16;
+typedef __int32 int32;
+typedef unsigned __int32 uint32;
+typedef __int64 int64;
+typedef unsigned __int64 uint64;
+
+typedef int64 lint64;
+typedef uint64 ulint64;
+
+#ifdef X64BITS
+typedef __int64 intp;				// intp is an integer that can accomodate a pointer
+typedef unsigned __int64 uintp;		// (ie, sizeof(intp) >= sizeof(int) && sizeof(intp) >= sizeof(void *)
+#else
+typedef __int32 intp;
+typedef unsigned __int32 uintp;
+#endif
+
+#else // _WIN32
+
+typedef short int16;
+typedef unsigned short uint16;
+typedef int int32;
+typedef unsigned int uint32;
+typedef long long int64;
+typedef unsigned long long uint64;
+
+// [u]int64 are actually defined as 'long long' and gcc 64-bit
+// doesn't automatically consider them the same as 'long int'.
+// Changing the types for [u]int64 is complicated by
+// there being many definitions, so we just
+// define a 'long int' here and use it in places that would
+// otherwise confuse the compiler.
+typedef long int lint64;
+typedef unsigned long int ulint64;
+
+#ifdef X64BITS
+typedef long long intp;
+typedef unsigned long long uintp;
+#else
+typedef int intp;
+typedef unsigned int uintp;
+#endif
+
+#endif // else _WIN32
+
+#ifdef API_GEN
+# define CLANG_ATTR(ATTR) __attribute__((annotate( ATTR )))
+#else
+# define CLANG_ATTR(ATTR)
+#endif
+
+#define METHOD_DESC(DESC) CLANG_ATTR( "desc:" #DESC ";" )
+#define IGNOREATTR() CLANG_ATTR( "ignore" )
+#define OUT_STRUCT() CLANG_ATTR( "out_struct: ;" )
+#define OUT_STRING() CLANG_ATTR( "out_string: ;" )
+#define OUT_ARRAY_CALL(COUNTER,FUNCTION,PARAMS) CLANG_ATTR( "out_array_call:" #COUNTER "," #FUNCTION "," #PARAMS ";" )
+#define OUT_ARRAY_COUNT(COUNTER, DESC) CLANG_ATTR( "out_array_count:" #COUNTER  ";desc:" #DESC )
+#define ARRAY_COUNT(COUNTER) CLANG_ATTR( "array_count:" #COUNTER ";" )
+#define ARRAY_COUNT_D(COUNTER, DESC) CLANG_ATTR( "array_count:" #COUNTER ";desc:" #DESC )
+#define BUFFER_COUNT(COUNTER) CLANG_ATTR( "buffer_count:" #COUNTER ";" )
+#define OUT_BUFFER_COUNT(COUNTER) CLANG_ATTR( "out_buffer_count:" #COUNTER ";" )
+#define OUT_STRING_COUNT(COUNTER) CLANG_ATTR( "out_string_count:" #COUNTER ";" )
+#define DESC(DESC) CLANG_ATTR("desc:" #DESC ";")
+#define CALL_RESULT(RESULT_TYPE) CLANG_ATTR("callresult:" #RESULT_TYPE ";")
+#define CALL_BACK(RESULT_TYPE) CLANG_ATTR("callback:" #RESULT_TYPE ";")
+
+const int k_cubSaltSize   = 8;
+typedef	uint8 Salt_t[ k_cubSaltSize ];
+
+//-----------------------------------------------------------------------------
+// GID (GlobalID) stuff
+// This is a globally unique identifier.  It's guaranteed to be unique across all
+// racks and servers for as long as a given universe persists.
+//-----------------------------------------------------------------------------
+// NOTE: for GID parsing/rendering and other utils, see gid.h
+typedef uint64 GID_t;
+
+const GID_t k_GIDNil = 0xffffffffffffffffull;
+
+// For convenience, we define a number of types that are just new names for GIDs
+typedef uint64 JobID_t;			// Each Job has a unique ID
+typedef GID_t TxnID_t;			// Each financial transaction has a unique ID
+
+const GID_t k_TxnIDNil = k_GIDNil;
+const GID_t k_TxnIDUnknown = 0;
+
+const JobID_t k_JobIDNil = 0xffffffffffffffffull;
+
+// this is baked into client messages and interfaces as an int, 
+// make sure we never break this.
+typedef uint32 PackageId_t;
+const PackageId_t k_uPackageIdFreeSub = 0x0;
+const PackageId_t k_uPackageIdInvalid = 0xFFFFFFFF;
+
+typedef uint32 BundleId_t;
+const BundleId_t k_uBundleIdInvalid = 0;
+
+// this is baked into client messages and interfaces as an int, 
+// make sure we never break this.
+typedef uint32 AppId_t;
+const AppId_t k_uAppIdInvalid = 0x0;
+
+typedef uint64 AssetClassId_t;
+const AssetClassId_t k_ulAssetClassIdInvalid = 0x0;
+
+typedef uint32 PhysicalItemId_t;
+const PhysicalItemId_t k_uPhysicalItemIdInvalid = 0x0;
+
+
+// this is baked into client messages and interfaces as an int, 
+// make sure we never break this.  AppIds and DepotIDs also presently
+// share the same namespace, but since we'd like to change that in the future
+// I've defined it seperately here.
+typedef uint32 DepotId_t;
+const DepotId_t k_uDepotIdInvalid = 0x0;
+
+// RTime32
+// We use this 32 bit time representing real world time.
+// It offers 1 second resolution beginning on January 1, 1970 (Unix time)
+typedef uint32 RTime32;
+
+typedef uint32 CellID_t;
+const CellID_t k_uCellIDInvalid = 0xFFFFFFFF;
+
+// handle to a Steam API call
+typedef uint64 SteamAPICall_t;
+const SteamAPICall_t k_uAPICallInvalid = 0x0;
+
+typedef uint32 AccountID_t;
+
+typedef uint32 PartnerId_t;
+const PartnerId_t k_uPartnerIdInvalid = 0;
+
+// ID for a depot content manifest
+typedef uint64 ManifestId_t; 
+const ManifestId_t k_uManifestIdInvalid = 0;
+
+
+
+#endif // STEAMTYPES_H

--- a/Common/Chairloader/SteamAPI/steamuniverse.h
+++ b/Common/Chairloader/SteamAPI/steamuniverse.h
@@ -1,0 +1,27 @@
+//========= Copyright � 1996-2008, Valve LLC, All rights reserved. ============
+//
+// Purpose:
+//
+//=============================================================================
+
+#ifndef STEAMUNIVERSE_H
+#define STEAMUNIVERSE_H
+#ifdef _WIN32
+#pragma once
+#endif
+
+
+// Steam universes.  Each universe is a self-contained Steam instance.
+enum EUniverse
+{
+	k_EUniverseInvalid = 0,
+	k_EUniversePublic = 1,
+	k_EUniverseBeta = 2,
+	k_EUniverseInternal = 3,
+	k_EUniverseDev = 4,
+	// k_EUniverseRC = 5,				// no such universe anymore
+	k_EUniverseMax
+};
+
+
+#endif // STEAMUNIVERSE_H

--- a/Common/Prey/CrySystem/Ark/ArkDlcSystem.h
+++ b/Common/Prey/CrySystem/Ark/ArkDlcSystem.h
@@ -1,0 +1,99 @@
+// Header file automatically created from a PDB.
+#pragma once
+#include <Prey/CrySystem/Ark/IArkDlcSystem.h>
+
+struct IArkDlcListener;
+struct SSystemGlobalEnvironment;
+
+// CArkDlcSystem
+// Header:  d:/_perforce/danielle/preybnet/code/preydll/ArkDlcSystem.h
+class CArkDlcSystem : public IArkDlcSystem
+{ // Size=168 (0xA8)
+public:
+	// CArkDlcSystem::ArkDlcInfo
+	// Header:  d:/_perforce/danielle/preybnet/code/preydll/ArkDlcSystem.h
+	struct ArkDlcInfo
+	{ // Size=72 (0x48)
+		unsigned dlcId;
+		string Name;
+		bool bUnlocked;
+		bool bMounted;
+		string mountPoint;
+		string folderPath;
+		string SteamId;
+		string PS4ContentLabel;
+		string XB1ProductId;
+		unsigned NpServiceLabel;
+		
+	#if 0
+		const char* GetPlatformId() const;
+		bool IsValidForPlatform() const;
+	#endif
+	};
+
+	struct HashHack
+	{
+		size_t operator()(const string& s) { CryFatalError("HashHack: Not supported"); return 0; }
+	};
+	
+	bool m_bRequestRefresh;
+	std::vector<IArkDlcListener*> m_listeners;
+	std::unordered_map<unsigned int, string> m_dlcIdMap;
+	std::unordered_map<string, CArkDlcSystem::ArkDlcInfo, HashHack> m_dlcPlatformIdMap;
+	
+	virtual ~CArkDlcSystem() {}
+	virtual bool Init() { return FInit(this); }
+	virtual void InitEnv(SSystemGlobalEnvironment* _gEnv) { FInitEnv(this, _gEnv); }
+	virtual bool LoadDlcMetadata(const string& _strDlcMetadataFile) { return FLoadDlcMetadata(this, _strDlcMetadataFile); }
+	virtual void Update() { FUpdate(this); }
+	virtual void RequestRefresh() { FRequestRefresh(this); }
+	virtual const char* GetDlcPlatformId(unsigned _dlcId) const { return FGetDlcPlatformId(this, _dlcId); }
+	virtual const char* GetFolderPath(unsigned _dlcId) const { return FGetFolderPath(this, _dlcId); }
+	virtual bool IsUnlocked(unsigned _dlcId) const { return FIsUnlocked(this, _dlcId); }
+	virtual bool IsDlcUnlockedForFolder(const char* _folderName) const { return FIsDlcUnlockedForFolder(this, _folderName); }
+	virtual const char* MountDlc(const char* _platformId) { return FMountDlcOv2(this, _platformId); }
+	virtual const char* MountDlc(unsigned _dlcId) { return FMountDlcOv1(this, _dlcId); }
+	virtual const char* MountDlc(CArkDlcSystem::ArkDlcInfo* pDlcInfo) { return FMountDlcOv0(this, pDlcInfo); }
+	virtual void UnMountDlc(const char* _platformId) { FUnMountDlcOv2(this, _platformId); }
+	virtual void UnMountDlc(unsigned _dlcId) { FUnMountDlcOv1(this, _dlcId); }
+	virtual void UnMountDlc(CArkDlcSystem::ArkDlcInfo* pDlcInfo) { FUnMountDlcOv0(this, pDlcInfo); }
+	virtual void UnMountAllDlc() { FUnMountAllDlc(this); }
+	virtual void RegisterListener(IArkDlcListener* _pHandler) { FRegisterListener(this, _pHandler); }
+	virtual void UnregisterListener(IArkDlcListener* _pHandler) { FUnregisterListener(this, _pHandler); }
+	virtual void Refresh() { FRefresh(this); }
+	void UpdateDlcUnlocked(CArkDlcSystem::ArkDlcInfo* pDlcInfo, bool _bUnlocked) { FUpdateDlcUnlocked(this, pDlcInfo, _bUnlocked); }
+	const CArkDlcSystem::ArkDlcInfo* FindDlcInfoByPlatformId(const char* _platformId) const { return FFindDlcInfoByPlatformIdOv1(this, _platformId); }
+	CArkDlcSystem::ArkDlcInfo* FindDlcInfoByPlatformId(const char* _platformId) { return FFindDlcInfoByPlatformIdOv0(this, _platformId); }
+	const CArkDlcSystem::ArkDlcInfo* FindDlcInfoByDlcId(unsigned _dlcId) const { return FFindDlcInfoByDlcIdOv1(this, _dlcId); }
+	CArkDlcSystem::ArkDlcInfo* FindDlcInfoByDlcId(unsigned _dlcId) { return FFindDlcInfoByDlcIdOv0(this, _dlcId); }
+	
+#if 0
+	CArkDlcSystem();
+	CArkDlcSystem(const CArkDlcSystem& _arg0_);
+#endif
+	
+	static inline auto FInit = PreyFunction<bool(CArkDlcSystem* const _this)>(0x1B933B0);
+	static inline auto FInitEnv = PreyFunction<void(CArkDlcSystem* const _this, SSystemGlobalEnvironment* _gEnv)>(0xA13080);
+	static inline auto FLoadDlcMetadata = PreyFunction<bool(CArkDlcSystem* const _this, const string& _strDlcMetadataFile)>(0x94FA0);
+	static inline auto FUpdate = PreyFunction<void(CArkDlcSystem* const _this)>(0x95790);
+	static inline auto FRequestRefresh = PreyFunction<void(CArkDlcSystem* const _this)>(0x9D070);
+	static inline auto FGetDlcPlatformId = PreyFunction<const char* (const CArkDlcSystem* const _this, unsigned _dlcId)>(0x94EF0);
+	static inline auto FGetFolderPath = PreyFunction<const char* (const CArkDlcSystem* const _this, unsigned _dlcId)>(0x94F10);
+	static inline auto FIsUnlocked = PreyFunction<bool(const CArkDlcSystem* const _this, unsigned _dlcId)>(0x94F80);
+	static inline auto FIsDlcUnlockedForFolder = PreyFunction<bool(const CArkDlcSystem* const _this, const char* _folderName)>(0x94F30);
+	static inline auto FMountDlcOv2 = PreyFunction<const char* (CArkDlcSystem* const _this, const char* _platformId)>(0x95620);
+	static inline auto FMountDlcOv1 = PreyFunction<const char* (CArkDlcSystem* const _this, unsigned _dlcId)>(0x955F0);
+	static inline auto FMountDlcOv0 = PreyFunction<const char* (CArkDlcSystem* const _this, CArkDlcSystem::ArkDlcInfo* pDlcInfo)>(0x158AEF0);
+	static inline auto FUnMountDlcOv2 = PreyFunction<void(CArkDlcSystem* const _this, const char* _platformId)>(0x95720);
+	static inline auto FUnMountDlcOv1 = PreyFunction<void(CArkDlcSystem* const _this, unsigned _dlcId)>(0x956F0);
+	static inline auto FUnMountDlcOv0 = PreyFunction<void(CArkDlcSystem* const _this, CArkDlcSystem::ArkDlcInfo* pDlcInfo)>(0xA13080);
+	static inline auto FUnMountAllDlc = PreyFunction<void(CArkDlcSystem* const _this)>(0x956A0);
+	static inline auto FRegisterListener = PreyFunction<void(CArkDlcSystem* const _this, IArkDlcListener* _pHandler)>(0x95650);
+	static inline auto FUnregisterListener = PreyFunction<void(CArkDlcSystem* const _this, IArkDlcListener* _pHandler)>(0x95750);
+	static inline auto FRefresh = PreyFunction<void(CArkDlcSystem* const _this)>(0x96320);
+	static inline auto FUpdateDlcUnlocked = PreyFunction<void(CArkDlcSystem* const _this, CArkDlcSystem::ArkDlcInfo* pDlcInfo, bool _bUnlocked)>(0x957B0);
+	static inline auto FFindDlcInfoByPlatformIdOv1 = PreyFunction<const CArkDlcSystem::ArkDlcInfo* (const CArkDlcSystem* const _this, const char* _platformId)>(0x94C50);
+	static inline auto FFindDlcInfoByPlatformIdOv0 = PreyFunction<CArkDlcSystem::ArkDlcInfo* (CArkDlcSystem* const _this, const char* _platformId)>(0x94A60);
+	static inline auto FFindDlcInfoByDlcIdOv1 = PreyFunction<const CArkDlcSystem::ArkDlcInfo* (const CArkDlcSystem* const _this, unsigned _dlcId)>(0x949A0);
+	static inline auto FFindDlcInfoByDlcIdOv0 = PreyFunction<CArkDlcSystem::ArkDlcInfo* (CArkDlcSystem* const _this, unsigned _dlcId)>(0x948E0);
+};

--- a/Common/Prey/CrySystem/Ark/ArkRewardSystem.h
+++ b/Common/Prey/CrySystem/Ark/ArkRewardSystem.h
@@ -1,0 +1,142 @@
+// Header file automatically created from a PDB.
+#pragma once
+#include <Prey/CrySystem/Ark/IArkRewardSystem.h>
+#include <Prey/CryThreading/CryThread_win32.h>
+
+class CryEvent;
+struct IArkRewardSystemCallbackHandler;
+
+// CArkRewardSystem
+// Header:  CryEngine/CrySystem/Ark/ArkRewardSystem.h
+class CArkRewardSystem : public IArkRewardSystem
+{ // Size=144 (0x90)
+public:
+	struct ArkRewardTrackable
+	{ // Size=16 (0x10)
+		uint64_t associatedMetric;
+		unsigned value;
+		unsigned id;
+	};
+
+	struct ArkRewardTrackableCriteria
+	{ // Size=16 (0x10)
+		CArkRewardSystem::ArkRewardTrackable* trackable;
+		unsigned value;
+		bool bCriteriaMet;
+	};
+
+	struct ArkReward
+	{ // Size=40 (0x28)
+		unsigned unlockId;
+		std::vector<CArkRewardSystem::ArkRewardTrackableCriteria> criteria;
+		bool bCriteriaMet;
+	};
+
+	struct IArkRewardsJobInfo
+	{ // Size=8 (0x8)
+		enum class ArkRewardsJobInfoType : unsigned
+		{
+			Flush = 0,
+			Unlock = 1,
+		};
+
+		virtual ~IArkRewardsJobInfo();
+		virtual CArkRewardSystem::IArkRewardsJobInfo::ArkRewardsJobInfoType JobType() const = 0;
+	};
+
+	struct CArkRewardSystemFlushJobInfo : public CArkRewardSystem::IArkRewardsJobInfo
+	{ // Size=16 (0x10)
+		CryEvent& event;
+
+		virtual CArkRewardSystem::IArkRewardsJobInfo::ArkRewardsJobInfoType JobType() const;
+
+	#if 0
+		CArkRewardSystemFlushJobInfo(CryEvent& _arg0_);
+	#endif
+
+		static inline auto FJobType = PreyFunction<CArkRewardSystem::IArkRewardsJobInfo::ArkRewardsJobInfoType(const CArkRewardSystem::CArkRewardSystemFlushJobInfo* const _this)>(0x158AEF0);
+	};
+
+	struct CArkRewardSystemUnlockJobInfo : public CArkRewardSystem::IArkRewardsJobInfo
+	{ // Size=16 (0x10)
+		unsigned userId;
+		unsigned rewardId;
+
+		virtual CArkRewardSystem::IArkRewardsJobInfo::ArkRewardsJobInfoType JobType() const;
+
+	#if 0
+		CArkRewardSystemUnlockJobInfo(const unsigned _arg0_, const unsigned _arg1_);
+	#endif
+	};
+
+	class ArkRewardsThread : public CrySimpleThread<CryRunnable>
+	{ // Size=312 (0x138)
+	public:
+		CArkRewardSystem* m_pRewardSystem;
+		CryConditionVariable::LockType m_cvLock;
+		CryConditionVariable m_cond;
+		std::deque<CArkRewardSystem::IArkRewardsJobInfo *,std::allocator<CArkRewardSystem::IArkRewardsJobInfo *> > m_jobQueue;
+		static constexpr const unsigned MAXIMUM_PENDING_REWARDS = 8;
+		unsigned m_pendingRewards[8];
+		unsigned m_pendingRewardsCount;
+		bool m_bAlive;
+
+		virtual void Run();
+		virtual void Cancel();
+
+	#if 0
+		ArkRewardsThread(CArkRewardSystem* _arg0_);
+		void PushUnlockRequest(unsigned _arg0_, unsigned _arg1_);
+		void Flush();
+	#endif
+
+		static inline auto FRun = PreyFunction<void(CArkRewardSystem::ArkRewardsThread* const _this)>(0xD5CDB0);
+		static inline auto FCancel = PreyFunction<void(CArkRewardSystem::ArkRewardsThread* const _this)>(0xD5C580);
+	};
+
+	static constexpr const uint64_t kNoAssociatedMetric = 0;
+	CArkRewardSystem::ArkRewardsThread* m_pRewardsThread = nullptr;
+	IArkRewardSystemCallbackHandler* m_pHandler = nullptr;
+	std::vector<CArkRewardSystem::ArkRewardTrackable> m_trackables;
+	std::unordered_map<uint64_t, CArkRewardSystem::ArkRewardTrackable*> m_trackablesByMetric;
+	unsigned m_userId = -1;
+	std::vector<CArkRewardSystem::ArkReward> m_rewards;
+
+	CArkRewardSystem() = default;
+	virtual ~CArkRewardSystem() {}
+	virtual bool Init() { return FInit(this); }
+	virtual void SetActiveUserId(unsigned _userId) { FSetActiveUserId(this, _userId); }
+	virtual bool LoadRewardData(const string& _strRewardFile) { return FLoadRewardData(this, _strRewardFile); }
+	virtual void SetInitialTrackableValue(unsigned _trackable, unsigned _value) { return FSetInitialTrackableValueOv1(this, _trackable, _value); }
+	virtual void SetInitialTrackableValue(uint64_t _associatedMetric, unsigned _value) { return FSetInitialTrackableValueOv0(this, _associatedMetric, _value); }
+	virtual unsigned IncrementTrackableValue(unsigned _trackable) { return FIncrementTrackableValueOv1(this, _trackable); }
+	virtual unsigned IncrementTrackableValue(uint64_t _associatedMetric) { return FIncrementTrackableValueOv0(this, _associatedMetric); }
+	virtual unsigned UpdateTrackableValueMax(uint64_t _associatedMetric, unsigned _value) { return FUpdateTrackableValueMax(this, _associatedMetric, _value); }
+	virtual void UnlockReward(unsigned _reward) { FUnlockReward(this, _reward); }
+	virtual void ResetTrackableData() { FResetTrackableData(this); }
+	virtual void SetCallbackHandler(IArkRewardSystemCallbackHandler* _pHandler) { FSetCallbackHandler(this, _pHandler); }
+	virtual void InternalTrackableUpdated(unsigned _trackableId, unsigned _oldVal, unsigned _newVal) { FInternalTrackableUpdated(this, _trackableId, _oldVal, _newVal); }
+	virtual void InternalRewardUnlocked(unsigned _rewardId) { FInternalRewardUnlocked(this, _rewardId); }
+
+#if 0
+	CArkRewardSystem(const CArkRewardSystem& _arg0_);
+	void TrackableChanged(unsigned _arg0_, unsigned _arg1_, unsigned _arg2_);
+	bool SuppressRewards() const;
+#endif
+
+	static inline auto FCArkRewardSystemOv1 = PreyFunction<void(CArkRewardSystem* const _this)>(0xD5C0F0);
+	static inline auto FInit = PreyFunction<bool(CArkRewardSystem* const _this)>(0xD5C710);
+	static inline auto FSetActiveUserId = PreyFunction<void(CArkRewardSystem* const _this, unsigned _userId)>(0xD5D0B0);
+	static inline auto FLoadRewardData = PreyFunction<bool(CArkRewardSystem* const _this, const string& _strRewardFile)>(0xD5C8F0);
+	static inline auto FSetInitialTrackableValueOv1 = PreyFunction<void(CArkRewardSystem* const _this, unsigned _trackable, unsigned _value)>(0xD5D130);
+	static inline auto FSetInitialTrackableValueOv0 = PreyFunction<void(CArkRewardSystem* const _this, uint64_t _associatedMetric, unsigned _value)>(0xD5D140);
+	static inline auto FIncrementTrackableValueOv1 = PreyFunction<unsigned(CArkRewardSystem* const _this, unsigned _trackable)>(0xD5C660);
+	static inline auto FIncrementTrackableValueOv0 = PreyFunction<unsigned(CArkRewardSystem* const _this, uint64_t _associatedMetric)>(0xD5C6A0);
+	static inline auto FUpdateTrackableValueMax = PreyFunction<unsigned(CArkRewardSystem* const _this, uint64_t _associatedMetric, unsigned _value)>(0xD5D190);
+	static inline auto FUnlockReward = PreyFunction<void(CArkRewardSystem* const _this, unsigned _reward)>(0xD5D180);
+	static inline auto FResetTrackableData = PreyFunction<void(CArkRewardSystem* const _this)>(0xD5CD50);
+	static inline auto FSetCallbackHandler = PreyFunction<void(CArkRewardSystem* const _this, IArkRewardSystemCallbackHandler* _pHandler)>(0x9FBCE0);
+	static inline auto FInternalTrackableUpdated = PreyFunction<void(CArkRewardSystem* const _this, unsigned _trackableId, unsigned _oldVal, unsigned _newVal)>(0xA13080);
+	static inline auto FInternalRewardUnlocked = PreyFunction<void(CArkRewardSystem* const _this, unsigned _rewardId)>(0xA13080);
+};
+

--- a/Common/Prey/CrySystem/Ark/IArkDlcSystem.h
+++ b/Common/Prey/CrySystem/Ark/IArkDlcSystem.h
@@ -1,0 +1,34 @@
+// Header file automatically created from a PDB.
+#pragma once
+
+struct SSystemGlobalEnvironment;
+
+// IArkDlcListener
+// Header:  _unknown/IArkDlcListener.h
+struct IArkDlcListener
+{ // Size=8 (0x8)
+	virtual void OnDlcStatusChanged(unsigned _dlcId, bool _bUnlocked) = 0;
+};
+
+// IArkDlcSystem
+// Header:  _unknown/IArkDlcSystem.h
+struct IArkDlcSystem
+{ // Size=8 (0x8)
+	virtual ~IArkDlcSystem() {}
+	virtual bool Init() = 0;
+	virtual void InitEnv(SSystemGlobalEnvironment* _gEnv) = 0;
+	virtual void Update() = 0;
+	virtual void RequestRefresh() = 0;
+	virtual bool LoadDlcMetadata(const string& _strDlcMetadataFile) = 0;
+	virtual const char* GetDlcPlatformId(unsigned _dlcId) const = 0;
+	virtual const char* GetFolderPath(unsigned _dlcId) const = 0;
+	virtual bool IsUnlocked(unsigned _dlcId) const = 0;
+	virtual bool IsDlcUnlockedForFolder(const char* _folderName) const = 0;
+	virtual const char* MountDlc(const char* _platformId) = 0;
+	virtual const char* MountDlc(unsigned _dlcId) = 0;
+	virtual void UnMountDlc(const char* _platformId) = 0;
+	virtual void UnMountDlc(unsigned _dlcId) = 0;
+	virtual void UnMountAllDlc() = 0;
+	virtual void RegisterListener(IArkDlcListener* _pHandler) = 0;
+	virtual void UnregisterListener(IArkDlcListener* _pHandler) = 0;
+};

--- a/Common/Prey/CrySystem/Ark/IArkRewardSystem.h
+++ b/Common/Prey/CrySystem/Ark/IArkRewardSystem.h
@@ -1,0 +1,32 @@
+// Header file automatically created from a PDB.
+#pragma once
+
+// IArkRewardSystemCallbackHandler
+// Header:  Prey/CrySystem/Ark/IArkRewardSystem.h
+struct IArkRewardSystemCallbackHandler
+{ // Size=8 (0x8)
+	virtual void OnChangedTrackable(unsigned _arg0_, unsigned _arg1_, unsigned _arg2_, unsigned _arg3_) = 0;
+	virtual void OnRewardUnlocked(unsigned _arg0_, unsigned _arg1_) = 0;
+};
+
+// IArkRewardSystem
+// Header:  CryEngine/CrySystem/Ark/IArkRewardSystem.h
+// Include: Prey/CrySystem/Ark/IArkRewardSystem.h
+struct IArkRewardSystem
+{ // Size=8 (0x8)
+	virtual ~IArkRewardSystem() {}
+	virtual bool Init() = 0;
+	virtual void SetActiveUserId(unsigned _userId) = 0;
+	virtual bool LoadRewardData(const string& _strRewardFile) = 0;
+	virtual void SetInitialTrackableValue(unsigned _trackable, unsigned _value) = 0;
+	virtual void SetInitialTrackableValue(uint64_t _associatedMetric, unsigned _value) = 0;
+	virtual unsigned IncrementTrackableValue(unsigned _trackable) = 0;
+	virtual unsigned IncrementTrackableValue(uint64_t _associatedMetric) = 0;
+	virtual unsigned UpdateTrackableValueMax(uint64_t _associatedMetric, unsigned _value) = 0;
+	virtual void UnlockReward(unsigned _reward) = 0;
+	virtual void ResetTrackableData() = 0;
+	virtual void SetCallbackHandler(IArkRewardSystemCallbackHandler* _arg0_) = 0;
+	virtual void InternalTrackableUpdated(unsigned _arg0_, unsigned _arg1_, unsigned _arg2_) = 0;
+	virtual void InternalRewardUnlocked(unsigned _arg0_) = 0;
+};
+

--- a/Common/Prey/CrySystem/System.h
+++ b/Common/Prey/CrySystem/System.h
@@ -149,6 +149,7 @@ public:
 	static inline auto FShutdown = PreyFunction<void(CSystem* _this)>(0xDC79F0);
 	static inline auto FUpdate = PreyFunction<bool(CSystem* const _this, int updateFlags, int nPauseMode)>(0xDC8A50);
 	static inline auto FRenderEnd = PreyFunction<void(CSystem* const _this, bool bRenderStats)>(0xDDF450);
+	static inline auto FInitSoundSystem = PreyFunction<bool(CSystem* const _this, const SSystemInitParams & _initParams)>(0xDD7730);
 
 	//! Sets whether dev mode is enabled.
 	inline void SetDevMode(bool bEnable) { FSetDevMode(this, bEnable); }


### PR DESCRIPTION
1) Adds a new module called Patches with optional hooks and patches. It can be disabled with `-nopatches` for troubleshooting.
2) Adds Steam API headers. steam_api64.dll is loaded only by Chairloader. Mods can access it via `gCL->pSteamAPI`. If the library is successfully loaded, the game will exit if Steam is not running/API fails to initialize instead of silently disabling Steam API. This was done so players don't suddenly stop getting achievements and know that there is a problem.
3) Implements `IArkRewardSystem` for achievements and `IArkDlcSystem` for the pre-order DLC using Steam API.
4) Fixes an important crash in the important listener for the important class when exiting the game.