### PR TITLE
Add ch:copy_sibling attribute support

### DIFF
--- a/ChairManager/Merging/XMLMerger2.h
+++ b/ChairManager/Merging/XMLMerger2.h
@@ -10,13 +10,17 @@
 class XMLMerger2 {
 public:
     //! Merge two XML documents together, using the specified merging policy.
+    //! @param  baseDoc     Currently merged document.
+    //! @param  modDoc      Mod document that needs to be merged into base.
+    //! @param  originalDoc Original document from Prey.
+    //! @param  policy      Merging policy.
     static void MergeXMLDocument(pugi::xml_document &baseDoc, pugi::xml_document &modDoc, pugi::xml_document &originalDoc, MergingPolicy policy);
 
     //! Merge two XML nodes together, using the specified merging policy.
     static void MergeNodeStructure(pugi::xml_node baseNode, pugi::xml_node modNode, pugi::xml_node originalNode, MergingPolicy policy);
 
     //! Merge two xml nodes, including wildcard matching, vanilla checking, and indicator handling
-    static void MergeXmlNode(pugi::xml_node baseNode, pugi::xml_node modNode, pugi::xml_node originalNode);
+    static void MergeXmlNode(pugi::xml_node baseNode, pugi::xml_node modNode, pugi::xml_node originalNode, bool forcePatchMode = false);
 
     //! Different merging policies
     static void MergeByAttribute(pugi::xml_node baseNode, pugi::xml_node modNode, pugi::xml_node originalNode, MergingPolicy policy);
@@ -51,6 +55,19 @@ public:
     /// \brief Serialize the level entity IDs to a file
     /// \param levelPath The path to the contents of level.pak
     static void SerializeLevelEntityIDs(fs::path levelPath);
+
+    //! Parses a sibling query.
+    //! @param  query   The query in the format "key1=val1;key2=val2";
+    //! @returns List of keys and values.
+    static std::vector<std::pair<std::string, std::string>> ParseSiblingQuery(std::string_view query);
+
+private:
+    //! When a node has this attribute, it will be created based on an existing node.
+    static constexpr char COPY_SIBLING[] = "ch:copy_sibling";
+
+    //! Checks that the mod node doesn't have copy_sibling attribute.
+    //! If it does, throws std::runtime_error.
+    static void VerifyNotCopySibling(pugi::xml_node baseNode, pugi::xml_node modNode);
 };
 
 

--- a/ChairManager/Merging/XMLMerger2Test.cpp
+++ b/ChairManager/Merging/XMLMerger2Test.cpp
@@ -765,7 +765,6 @@ TEST(XMLMerger2Test, MergeNodeStructureAttribute){
     expectedDoc.save(expected, "", pugi::format_raw);
 
     ASSERT_EQ(base.str(), expected.str());
-
 }
 
 TEST(XMLMerger2Test, MergeXMLDocument){
@@ -899,4 +898,160 @@ TEST(XMLMerger2Test, MergeXMLDocument){
     expectedDoc.save(expected, "", pugi::format_raw);
 
     ASSERT_EQ(base.str(), expected.str());
+}
+
+TEST(XMLMerger2Test, CopySibling) {
+    pugi::xml_document baseDoc, modDoc, originalDoc, expectedDoc, policyDoc;
+    MergingPolicy policy;
+
+    baseDoc.load_string(R"(
+    <X hippo="false">
+        <Y>
+            <Z id="1">
+                <A val="1"/>
+                <B val="2"/>
+                <C val="3"/>
+            </Z>
+            <Z id="2">
+                <A val="1"/>
+                <B val="2"/>
+                <C val="3"/>
+            </Z>
+            <Z id="3">
+                <A val="10"/>
+                <B val="11"/>
+                <C val="12"/>
+            </Z>
+             <Z id="4">
+                <A val="10"/>
+                <B val="11"/>
+                <C val="12"/>
+            </Z>
+        </Y>
+        <W zebra="27">I'm a zebra</W>
+    </X>
+    )");
+    originalDoc.load_string(R"(
+    <X hippo="false">
+        <Y>
+            <Z id="1">
+                <A val="1"/>
+                <B val="2"/>
+                <C val="3"/>
+            </Z>
+            <Z id="2">
+                <A val="1"/>
+                <B val="2"/>
+                <C val="3"/>
+            </Z>
+            <Z id="3">
+                <A val="1"/>
+                <B val="2"/>
+                <C val="3"/>
+            </Z>
+             <Z id="4">
+                <A val="1"/>
+                <B val="2"/>
+                <C val="3"/>
+            </Z>
+        </Y>
+        <W zebra="27">I'm a zebra</W>
+    </X>
+    )");
+
+    modDoc.load_string(R"(
+    <X hippo="true">
+        <Y>
+            <Z id="1">
+                <A val="4"/>
+                <B val="5"/>
+                <C val="6"/>
+            </Z>
+            <Z id="2">
+                <A val="4"/>
+                <B val="5"/>
+                <C val="6"/>
+            </Z>
+             <Z id="8" ch:copy_sibling="id=2">
+                <A val="420"/>
+            </Z>
+        </Y>
+        <W zebra="42">I'm a special zebra</W>
+    </X>
+    )");
+
+    expectedDoc.load_string(R"(
+    <X hippo="true">
+        <Y>
+            <Z id="1">
+                <A val="4"/>
+                <B val="5"/>
+                <C val="6"/>
+            </Z>
+            <Z id="2">
+                <A val="4"/>
+                <B val="5"/>
+                <C val="6"/>
+            </Z>
+            <Z id="3">
+                <A val="10"/>
+                <B val="11"/>
+                <C val="12"/>
+            </Z>
+             <Z id="4">
+                <A val="10"/>
+                <B val="11"/>
+                <C val="12"/>
+            </Z>
+             <Z id="8" ch:copy_sibling="id=2">
+                <A val="420"/>
+                <B val="5"/>
+                <C val="6"/>
+            </Z>
+        </Y>
+        <W zebra="42">I'm a special zebra</W>
+    </X>
+    )");
+
+    policyDoc.load_string(R"(
+        <mergingPolicy identification_policy="match_attribute">
+            <attribute name="id" priority="0"/>
+            <nodeStructure>
+                <_wildcard_ merge_attributes="true">
+                    <Y merge_children="true"/>
+                    <W merge_node="true"/>
+                </_wildcard_>
+            </nodeStructure>
+        </mergingPolicy>
+    )");
+
+    policy = MergingPolicy(policyDoc.first_child(), "Ark/", "TheChair.ExampleMod");
+
+    XMLMerger2::MergeXMLDocument(baseDoc, modDoc, originalDoc, policy);
+
+    std::stringstream base, expected;
+    baseDoc.save(base, "", pugi::format_raw);
+    expectedDoc.save(expected, "", pugi::format_raw);
+
+    ASSERT_EQ(base.str(), expected.str());
+}
+
+TEST(XMLMerger2Test, ParseSiblingQuery) {
+    struct Item
+    {
+        std::string str;
+        std::vector<std::pair<std::string, std::string>> parsed;
+    };
+
+    Item items[] = {
+        Item{ "" },
+        Item{ "key=value", {{"key", "value"}}},
+        Item{ "key1=value1;key2=value2", {{"key1", "value1"}, {"key2", "value2"}}},
+    };
+
+    for (Item& i : items)
+    {
+        auto parsed = XMLMerger2::ParseSiblingQuery(i.str);
+        ASSERT_EQ(parsed, i.parsed);
+    }
 }


### PR DESCRIPTION
Adds `ch:copy_sibling` attribute that allows modders to create new XML elements based on existing ones.

Example:
```xml
<EntityPrototypeLibrary
    Name="ArkNpcs">
    <EntityPrototype
        Name="Mimics.MyMimic"
        Id="{DEADBEEF-0000-1111-2222-3333-2785CEA43421}"
        ch:copy_sibling="Name=Mimics.Mimic;Id={1BD3AAAA-7619-4181-8751-2785CEA43421}"> <!-- Both Name and Id as an example -->
        <Properties
            MyProperty="Never Gonna Give You Up">
        <!-- The rest of properties will be added automagically -->
    </EntityPrototype>
</EntityPrototypeLibrary>
```