### PR TITLE
Preditor: Transform tools

### DIFF
--- a/ChairManager/Data/Preditor/ActionSets.xml
+++ b/ChairManager/Data/Preditor/ActionSets.xml
@@ -58,6 +58,9 @@
         name="transform_tools"
         description="Transform Tools"
         priority="60">
+        <Action name="toggle_pivot" description="Toggle tool pivot between origin and center">
+            <Bind key="z"/>
+        </Action>
         <Action name="toggle_tool_space" description="Toggle tool space between local and world">
             <Bind key="x"/>
         </Action>

--- a/ChairManager/Data/Preditor/ActionSets.xml
+++ b/ChairManager/Data/Preditor/ActionSets.xml
@@ -58,6 +58,9 @@
         name="transform_tools"
         description="Transform Tools"
         priority="60">
+        <Action name="toggle_tool_space" description="Toggle tool space between local and world">
+            <Bind key="x"/>
+        </Action>
         <Action name="snap" description="Snap To Grid" isModifier="1">
             <Bind key="lctrl"/>
         </Action>

--- a/ChairManager/Data/Preditor/ActionSets.xml
+++ b/ChairManager/Data/Preditor/ActionSets.xml
@@ -53,6 +53,16 @@
         </Action>
     </ActionSet>
 
+    <!-- Transform Tools -->
+    <ActionSet
+        name="transform_tools"
+        description="Transform Tools"
+        priority="60">
+        <Action name="snap" description="Snap To Grid" isModifier="1">
+            <Bind key="lctrl"/>
+        </Action>
+    </ActionSet>
+
     <!-- Tool Selection -->
     <ActionSet
         name="tool_select"

--- a/Preditor/Common/CMakeLists.txt
+++ b/Preditor/Common/CMakeLists.txt
@@ -11,6 +11,10 @@ set(SOURCE_FILES
 	App/AppStage.h
 	App/IAppImGui.h
 	App/SingletonAppStage.h
+
+	ImGuizmo/ImGuizmo.cpp
+	ImGuizmo/ImGuizmo.h
+	ImGuizmo/ImZoomSlider.h
 	
 	Preditor/Assets/Common.h
 	Preditor/Assets/IAssetSystem.h

--- a/Preditor/Common/ImGuizmo/ImGuizmo.cpp
+++ b/Preditor/Common/ImGuizmo/ImGuizmo.cpp
@@ -1,0 +1,2998 @@
+// https://github.com/CedricGuillemet/ImGuizmo
+// v 1.89 WIP
+//
+// The MIT License(MIT)
+//
+// Copyright(c) 2021 Cedric Guillemet
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+//
+
+#ifndef IMGUI_DEFINE_MATH_OPERATORS
+#define IMGUI_DEFINE_MATH_OPERATORS
+#endif
+#include "imgui.h"
+#include "imgui_internal.h"
+#include "ImGuizmo.h"
+
+#if defined(_MSC_VER) || defined(__MINGW32__)
+#include <malloc.h>
+#endif
+#if !defined(_MSC_VER) && !defined(__MINGW64_VERSION_MAJOR)
+#define _malloca(x) alloca(x)
+#define _freea(x)
+#endif
+
+// includes patches for multiview from
+// https://github.com/CedricGuillemet/ImGuizmo/issues/15
+
+namespace IMGUIZMO_NAMESPACE
+{
+   static const float ZPI = 3.14159265358979323846f;
+   static const float RAD2DEG = (180.f / ZPI);
+   static const float DEG2RAD = (ZPI / 180.f);
+   const float screenRotateSize = 0.06f;
+   // scale a bit so translate axis do not touch when in universal
+   const float rotationDisplayFactor = 1.2f;
+
+   static OPERATION operator&(OPERATION lhs, OPERATION rhs)
+   {
+     return static_cast<OPERATION>(static_cast<int>(lhs) & static_cast<int>(rhs));
+   }
+
+   static bool operator!=(OPERATION lhs, int rhs)
+   {
+     return static_cast<int>(lhs) != rhs;
+   }
+
+   static bool Intersects(OPERATION lhs, OPERATION rhs)
+   {
+     return (lhs & rhs) != 0;
+   }
+
+   // True if lhs contains rhs
+   static bool Contains(OPERATION lhs, OPERATION rhs)
+   {
+     return (lhs & rhs) == rhs;
+   }
+
+   ///////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+   // utility and math
+
+   void FPU_MatrixF_x_MatrixF(const float* a, const float* b, float* r)
+   {
+      r[0] = a[0] * b[0] + a[1] * b[4] + a[2] * b[8] + a[3] * b[12];
+      r[1] = a[0] * b[1] + a[1] * b[5] + a[2] * b[9] + a[3] * b[13];
+      r[2] = a[0] * b[2] + a[1] * b[6] + a[2] * b[10] + a[3] * b[14];
+      r[3] = a[0] * b[3] + a[1] * b[7] + a[2] * b[11] + a[3] * b[15];
+
+      r[4] = a[4] * b[0] + a[5] * b[4] + a[6] * b[8] + a[7] * b[12];
+      r[5] = a[4] * b[1] + a[5] * b[5] + a[6] * b[9] + a[7] * b[13];
+      r[6] = a[4] * b[2] + a[5] * b[6] + a[6] * b[10] + a[7] * b[14];
+      r[7] = a[4] * b[3] + a[5] * b[7] + a[6] * b[11] + a[7] * b[15];
+
+      r[8] = a[8] * b[0] + a[9] * b[4] + a[10] * b[8] + a[11] * b[12];
+      r[9] = a[8] * b[1] + a[9] * b[5] + a[10] * b[9] + a[11] * b[13];
+      r[10] = a[8] * b[2] + a[9] * b[6] + a[10] * b[10] + a[11] * b[14];
+      r[11] = a[8] * b[3] + a[9] * b[7] + a[10] * b[11] + a[11] * b[15];
+
+      r[12] = a[12] * b[0] + a[13] * b[4] + a[14] * b[8] + a[15] * b[12];
+      r[13] = a[12] * b[1] + a[13] * b[5] + a[14] * b[9] + a[15] * b[13];
+      r[14] = a[12] * b[2] + a[13] * b[6] + a[14] * b[10] + a[15] * b[14];
+      r[15] = a[12] * b[3] + a[13] * b[7] + a[14] * b[11] + a[15] * b[15];
+   }
+
+   void Frustum(float left, float right, float bottom, float top, float znear, float zfar, float* m16)
+   {
+      float temp, temp2, temp3, temp4;
+      temp = 2.0f * znear;
+      temp2 = right - left;
+      temp3 = top - bottom;
+      temp4 = zfar - znear;
+      m16[0] = temp / temp2;
+      m16[1] = 0.0;
+      m16[2] = 0.0;
+      m16[3] = 0.0;
+      m16[4] = 0.0;
+      m16[5] = temp / temp3;
+      m16[6] = 0.0;
+      m16[7] = 0.0;
+      m16[8] = (right + left) / temp2;
+      m16[9] = (top + bottom) / temp3;
+      m16[10] = (-zfar - znear) / temp4;
+      m16[11] = -1.0f;
+      m16[12] = 0.0;
+      m16[13] = 0.0;
+      m16[14] = (-temp * zfar) / temp4;
+      m16[15] = 0.0;
+   }
+
+   void Perspective(float fovyInDegrees, float aspectRatio, float znear, float zfar, float* m16)
+   {
+      float ymax, xmax;
+      ymax = znear * tanf(fovyInDegrees * DEG2RAD);
+      xmax = ymax * aspectRatio;
+      Frustum(-xmax, xmax, -ymax, ymax, znear, zfar, m16);
+   }
+
+   void Cross(const float* a, const float* b, float* r)
+   {
+      r[0] = a[1] * b[2] - a[2] * b[1];
+      r[1] = a[2] * b[0] - a[0] * b[2];
+      r[2] = a[0] * b[1] - a[1] * b[0];
+   }
+
+   float Dot(const float* a, const float* b)
+   {
+      return a[0] * b[0] + a[1] * b[1] + a[2] * b[2];
+   }
+
+   void Normalize(const float* a, float* r)
+   {
+      float il = 1.f / (sqrtf(Dot(a, a)) + FLT_EPSILON);
+      r[0] = a[0] * il;
+      r[1] = a[1] * il;
+      r[2] = a[2] * il;
+   }
+
+   void LookAt(const float* eye, const float* at, const float* up, float* m16)
+   {
+      float X[3], Y[3], Z[3], tmp[3];
+
+      tmp[0] = eye[0] - at[0];
+      tmp[1] = eye[1] - at[1];
+      tmp[2] = eye[2] - at[2];
+      Normalize(tmp, Z);
+      Normalize(up, Y);
+      Cross(Y, Z, tmp);
+      Normalize(tmp, X);
+      Cross(Z, X, tmp);
+      Normalize(tmp, Y);
+
+      m16[0] = X[0];
+      m16[1] = Y[0];
+      m16[2] = Z[0];
+      m16[3] = 0.0f;
+      m16[4] = X[1];
+      m16[5] = Y[1];
+      m16[6] = Z[1];
+      m16[7] = 0.0f;
+      m16[8] = X[2];
+      m16[9] = Y[2];
+      m16[10] = Z[2];
+      m16[11] = 0.0f;
+      m16[12] = -Dot(X, eye);
+      m16[13] = -Dot(Y, eye);
+      m16[14] = -Dot(Z, eye);
+      m16[15] = 1.0f;
+   }
+
+   template <typename T> T Clamp(T x, T y, T z) { return ((x < y) ? y : ((x > z) ? z : x)); }
+   template <typename T> T max(T x, T y) { return (x > y) ? x : y; }
+   template <typename T> T min(T x, T y) { return (x < y) ? x : y; }
+   template <typename T> bool IsWithin(T x, T y, T z) { return (x >= y) && (x <= z); }
+
+   struct matrix_t;
+   struct vec_t
+   {
+   public:
+      float x, y, z, w;
+
+      void Lerp(const vec_t& v, float t)
+      {
+         x += (v.x - x) * t;
+         y += (v.y - y) * t;
+         z += (v.z - z) * t;
+         w += (v.w - w) * t;
+      }
+
+      void Set(float v) { x = y = z = w = v; }
+      void Set(float _x, float _y, float _z = 0.f, float _w = 0.f) { x = _x; y = _y; z = _z; w = _w; }
+
+      vec_t& operator -= (const vec_t& v) { x -= v.x; y -= v.y; z -= v.z; w -= v.w; return *this; }
+      vec_t& operator += (const vec_t& v) { x += v.x; y += v.y; z += v.z; w += v.w; return *this; }
+      vec_t& operator *= (const vec_t& v) { x *= v.x; y *= v.y; z *= v.z; w *= v.w; return *this; }
+      vec_t& operator *= (float v) { x *= v;    y *= v;    z *= v;    w *= v;    return *this; }
+
+      vec_t operator * (float f) const;
+      vec_t operator - () const;
+      vec_t operator - (const vec_t& v) const;
+      vec_t operator + (const vec_t& v) const;
+      vec_t operator * (const vec_t& v) const;
+
+      const vec_t& operator + () const { return (*this); }
+      float Length() const { return sqrtf(x * x + y * y + z * z); };
+      float LengthSq() const { return (x * x + y * y + z * z); };
+      vec_t Normalize() { (*this) *= (1.f / ( Length() > FLT_EPSILON ? Length() : FLT_EPSILON ) ); return (*this); }
+      vec_t Normalize(const vec_t& v) { this->Set(v.x, v.y, v.z, v.w); this->Normalize(); return (*this); }
+      vec_t Abs() const;
+
+      void Cross(const vec_t& v)
+      {
+         vec_t res;
+         res.x = y * v.z - z * v.y;
+         res.y = z * v.x - x * v.z;
+         res.z = x * v.y - y * v.x;
+
+         x = res.x;
+         y = res.y;
+         z = res.z;
+         w = 0.f;
+      }
+
+      void Cross(const vec_t& v1, const vec_t& v2)
+      {
+         x = v1.y * v2.z - v1.z * v2.y;
+         y = v1.z * v2.x - v1.x * v2.z;
+         z = v1.x * v2.y - v1.y * v2.x;
+         w = 0.f;
+      }
+
+      float Dot(const vec_t& v) const
+      {
+         return (x * v.x) + (y * v.y) + (z * v.z) + (w * v.w);
+      }
+
+      float Dot3(const vec_t& v) const
+      {
+         return (x * v.x) + (y * v.y) + (z * v.z);
+      }
+
+      void Transform(const matrix_t& matrix);
+      void Transform(const vec_t& s, const matrix_t& matrix);
+
+      void TransformVector(const matrix_t& matrix);
+      void TransformPoint(const matrix_t& matrix);
+      void TransformVector(const vec_t& v, const matrix_t& matrix) { (*this) = v; this->TransformVector(matrix); }
+      void TransformPoint(const vec_t& v, const matrix_t& matrix) { (*this) = v; this->TransformPoint(matrix); }
+
+      float& operator [] (size_t index) { return ((float*)&x)[index]; }
+      const float& operator [] (size_t index) const { return ((float*)&x)[index]; }
+      bool operator!=(const vec_t& other) const { return memcmp(this, &other, sizeof(vec_t)) != 0; }
+   };
+
+   vec_t makeVect(float _x, float _y, float _z = 0.f, float _w = 0.f) { vec_t res; res.x = _x; res.y = _y; res.z = _z; res.w = _w; return res; }
+   vec_t makeVect(ImVec2 v) { vec_t res; res.x = v.x; res.y = v.y; res.z = 0.f; res.w = 0.f; return res; }
+   vec_t vec_t::operator * (float f) const { return makeVect(x * f, y * f, z * f, w * f); }
+   vec_t vec_t::operator - () const { return makeVect(-x, -y, -z, -w); }
+   vec_t vec_t::operator - (const vec_t& v) const { return makeVect(x - v.x, y - v.y, z - v.z, w - v.w); }
+   vec_t vec_t::operator + (const vec_t& v) const { return makeVect(x + v.x, y + v.y, z + v.z, w + v.w); }
+   vec_t vec_t::operator * (const vec_t& v) const { return makeVect(x * v.x, y * v.y, z * v.z, w * v.w); }
+   vec_t vec_t::Abs() const { return makeVect(fabsf(x), fabsf(y), fabsf(z)); }
+
+   vec_t Normalized(const vec_t& v) { vec_t res; res = v; res.Normalize(); return res; }
+   vec_t Cross(const vec_t& v1, const vec_t& v2)
+   {
+      vec_t res;
+      res.x = v1.y * v2.z - v1.z * v2.y;
+      res.y = v1.z * v2.x - v1.x * v2.z;
+      res.z = v1.x * v2.y - v1.y * v2.x;
+      res.w = 0.f;
+      return res;
+   }
+
+   float Dot(const vec_t& v1, const vec_t& v2)
+   {
+      return (v1.x * v2.x) + (v1.y * v2.y) + (v1.z * v2.z);
+   }
+
+   vec_t BuildPlan(const vec_t& p_point1, const vec_t& p_normal)
+   {
+      vec_t normal, res;
+      normal.Normalize(p_normal);
+      res.w = normal.Dot(p_point1);
+      res.x = normal.x;
+      res.y = normal.y;
+      res.z = normal.z;
+      return res;
+   }
+
+   struct matrix_t
+   {
+   public:
+
+      union
+      {
+         float m[4][4];
+         float m16[16];
+         struct
+         {
+            vec_t right, up, dir, position;
+         } v;
+         vec_t component[4];
+      };
+
+      operator float* () { return m16; }
+      operator const float* () const { return m16; }
+      void Translation(float _x, float _y, float _z) { this->Translation(makeVect(_x, _y, _z)); }
+
+      void Translation(const vec_t& vt)
+      {
+         v.right.Set(1.f, 0.f, 0.f, 0.f);
+         v.up.Set(0.f, 1.f, 0.f, 0.f);
+         v.dir.Set(0.f, 0.f, 1.f, 0.f);
+         v.position.Set(vt.x, vt.y, vt.z, 1.f);
+      }
+
+      void Scale(float _x, float _y, float _z)
+      {
+         v.right.Set(_x, 0.f, 0.f, 0.f);
+         v.up.Set(0.f, _y, 0.f, 0.f);
+         v.dir.Set(0.f, 0.f, _z, 0.f);
+         v.position.Set(0.f, 0.f, 0.f, 1.f);
+      }
+      void Scale(const vec_t& s) { Scale(s.x, s.y, s.z); }
+
+      matrix_t& operator *= (const matrix_t& mat)
+      {
+         matrix_t tmpMat;
+         tmpMat = *this;
+         tmpMat.Multiply(mat);
+         *this = tmpMat;
+         return *this;
+      }
+      matrix_t operator * (const matrix_t& mat) const
+      {
+         matrix_t matT;
+         matT.Multiply(*this, mat);
+         return matT;
+      }
+
+      void Multiply(const matrix_t& matrix)
+      {
+         matrix_t tmp;
+         tmp = *this;
+
+         FPU_MatrixF_x_MatrixF((float*)&tmp, (float*)&matrix, (float*)this);
+      }
+
+      void Multiply(const matrix_t& m1, const matrix_t& m2)
+      {
+         FPU_MatrixF_x_MatrixF((float*)&m1, (float*)&m2, (float*)this);
+      }
+
+      float GetDeterminant() const
+      {
+         return m[0][0] * m[1][1] * m[2][2] + m[0][1] * m[1][2] * m[2][0] + m[0][2] * m[1][0] * m[2][1] -
+            m[0][2] * m[1][1] * m[2][0] - m[0][1] * m[1][0] * m[2][2] - m[0][0] * m[1][2] * m[2][1];
+      }
+
+      float Inverse(const matrix_t& srcMatrix, bool affine = false);
+      void SetToIdentity()
+      {
+         v.right.Set(1.f, 0.f, 0.f, 0.f);
+         v.up.Set(0.f, 1.f, 0.f, 0.f);
+         v.dir.Set(0.f, 0.f, 1.f, 0.f);
+         v.position.Set(0.f, 0.f, 0.f, 1.f);
+      }
+      void Transpose()
+      {
+         matrix_t tmpm;
+         for (int l = 0; l < 4; l++)
+         {
+            for (int c = 0; c < 4; c++)
+            {
+               tmpm.m[l][c] = m[c][l];
+            }
+         }
+         (*this) = tmpm;
+      }
+
+      void RotationAxis(const vec_t& axis, float angle);
+
+      void OrthoNormalize()
+      {
+         v.right.Normalize();
+         v.up.Normalize();
+         v.dir.Normalize();
+      }
+   };
+
+   void vec_t::Transform(const matrix_t& matrix)
+   {
+      vec_t out;
+
+      out.x = x * matrix.m[0][0] + y * matrix.m[1][0] + z * matrix.m[2][0] + w * matrix.m[3][0];
+      out.y = x * matrix.m[0][1] + y * matrix.m[1][1] + z * matrix.m[2][1] + w * matrix.m[3][1];
+      out.z = x * matrix.m[0][2] + y * matrix.m[1][2] + z * matrix.m[2][2] + w * matrix.m[3][2];
+      out.w = x * matrix.m[0][3] + y * matrix.m[1][3] + z * matrix.m[2][3] + w * matrix.m[3][3];
+
+      x = out.x;
+      y = out.y;
+      z = out.z;
+      w = out.w;
+   }
+
+   void vec_t::Transform(const vec_t& s, const matrix_t& matrix)
+   {
+      *this = s;
+      Transform(matrix);
+   }
+
+   void vec_t::TransformPoint(const matrix_t& matrix)
+   {
+      vec_t out;
+
+      out.x = x * matrix.m[0][0] + y * matrix.m[1][0] + z * matrix.m[2][0] + matrix.m[3][0];
+      out.y = x * matrix.m[0][1] + y * matrix.m[1][1] + z * matrix.m[2][1] + matrix.m[3][1];
+      out.z = x * matrix.m[0][2] + y * matrix.m[1][2] + z * matrix.m[2][2] + matrix.m[3][2];
+      out.w = x * matrix.m[0][3] + y * matrix.m[1][3] + z * matrix.m[2][3] + matrix.m[3][3];
+
+      x = out.x;
+      y = out.y;
+      z = out.z;
+      w = out.w;
+   }
+
+   void vec_t::TransformVector(const matrix_t& matrix)
+   {
+      vec_t out;
+
+      out.x = x * matrix.m[0][0] + y * matrix.m[1][0] + z * matrix.m[2][0];
+      out.y = x * matrix.m[0][1] + y * matrix.m[1][1] + z * matrix.m[2][1];
+      out.z = x * matrix.m[0][2] + y * matrix.m[1][2] + z * matrix.m[2][2];
+      out.w = x * matrix.m[0][3] + y * matrix.m[1][3] + z * matrix.m[2][3];
+
+      x = out.x;
+      y = out.y;
+      z = out.z;
+      w = out.w;
+   }
+
+   float matrix_t::Inverse(const matrix_t& srcMatrix, bool affine)
+   {
+      float det = 0;
+
+      if (affine)
+      {
+         det = GetDeterminant();
+         float s = 1 / det;
+         m[0][0] = (srcMatrix.m[1][1] * srcMatrix.m[2][2] - srcMatrix.m[1][2] * srcMatrix.m[2][1]) * s;
+         m[0][1] = (srcMatrix.m[2][1] * srcMatrix.m[0][2] - srcMatrix.m[2][2] * srcMatrix.m[0][1]) * s;
+         m[0][2] = (srcMatrix.m[0][1] * srcMatrix.m[1][2] - srcMatrix.m[0][2] * srcMatrix.m[1][1]) * s;
+         m[1][0] = (srcMatrix.m[1][2] * srcMatrix.m[2][0] - srcMatrix.m[1][0] * srcMatrix.m[2][2]) * s;
+         m[1][1] = (srcMatrix.m[2][2] * srcMatrix.m[0][0] - srcMatrix.m[2][0] * srcMatrix.m[0][2]) * s;
+         m[1][2] = (srcMatrix.m[0][2] * srcMatrix.m[1][0] - srcMatrix.m[0][0] * srcMatrix.m[1][2]) * s;
+         m[2][0] = (srcMatrix.m[1][0] * srcMatrix.m[2][1] - srcMatrix.m[1][1] * srcMatrix.m[2][0]) * s;
+         m[2][1] = (srcMatrix.m[2][0] * srcMatrix.m[0][1] - srcMatrix.m[2][1] * srcMatrix.m[0][0]) * s;
+         m[2][2] = (srcMatrix.m[0][0] * srcMatrix.m[1][1] - srcMatrix.m[0][1] * srcMatrix.m[1][0]) * s;
+         m[3][0] = -(m[0][0] * srcMatrix.m[3][0] + m[1][0] * srcMatrix.m[3][1] + m[2][0] * srcMatrix.m[3][2]);
+         m[3][1] = -(m[0][1] * srcMatrix.m[3][0] + m[1][1] * srcMatrix.m[3][1] + m[2][1] * srcMatrix.m[3][2]);
+         m[3][2] = -(m[0][2] * srcMatrix.m[3][0] + m[1][2] * srcMatrix.m[3][1] + m[2][2] * srcMatrix.m[3][2]);
+      }
+      else
+      {
+         // transpose matrix
+         float src[16];
+         for (int i = 0; i < 4; ++i)
+         {
+            src[i] = srcMatrix.m16[i * 4];
+            src[i + 4] = srcMatrix.m16[i * 4 + 1];
+            src[i + 8] = srcMatrix.m16[i * 4 + 2];
+            src[i + 12] = srcMatrix.m16[i * 4 + 3];
+         }
+
+         // calculate pairs for first 8 elements (cofactors)
+         float tmp[12]; // temp array for pairs
+         tmp[0] = src[10] * src[15];
+         tmp[1] = src[11] * src[14];
+         tmp[2] = src[9] * src[15];
+         tmp[3] = src[11] * src[13];
+         tmp[4] = src[9] * src[14];
+         tmp[5] = src[10] * src[13];
+         tmp[6] = src[8] * src[15];
+         tmp[7] = src[11] * src[12];
+         tmp[8] = src[8] * src[14];
+         tmp[9] = src[10] * src[12];
+         tmp[10] = src[8] * src[13];
+         tmp[11] = src[9] * src[12];
+
+         // calculate first 8 elements (cofactors)
+         m16[0] = (tmp[0] * src[5] + tmp[3] * src[6] + tmp[4] * src[7]) - (tmp[1] * src[5] + tmp[2] * src[6] + tmp[5] * src[7]);
+         m16[1] = (tmp[1] * src[4] + tmp[6] * src[6] + tmp[9] * src[7]) - (tmp[0] * src[4] + tmp[7] * src[6] + tmp[8] * src[7]);
+         m16[2] = (tmp[2] * src[4] + tmp[7] * src[5] + tmp[10] * src[7]) - (tmp[3] * src[4] + tmp[6] * src[5] + tmp[11] * src[7]);
+         m16[3] = (tmp[5] * src[4] + tmp[8] * src[5] + tmp[11] * src[6]) - (tmp[4] * src[4] + tmp[9] * src[5] + tmp[10] * src[6]);
+         m16[4] = (tmp[1] * src[1] + tmp[2] * src[2] + tmp[5] * src[3]) - (tmp[0] * src[1] + tmp[3] * src[2] + tmp[4] * src[3]);
+         m16[5] = (tmp[0] * src[0] + tmp[7] * src[2] + tmp[8] * src[3]) - (tmp[1] * src[0] + tmp[6] * src[2] + tmp[9] * src[3]);
+         m16[6] = (tmp[3] * src[0] + tmp[6] * src[1] + tmp[11] * src[3]) - (tmp[2] * src[0] + tmp[7] * src[1] + tmp[10] * src[3]);
+         m16[7] = (tmp[4] * src[0] + tmp[9] * src[1] + tmp[10] * src[2]) - (tmp[5] * src[0] + tmp[8] * src[1] + tmp[11] * src[2]);
+
+         // calculate pairs for second 8 elements (cofactors)
+         tmp[0] = src[2] * src[7];
+         tmp[1] = src[3] * src[6];
+         tmp[2] = src[1] * src[7];
+         tmp[3] = src[3] * src[5];
+         tmp[4] = src[1] * src[6];
+         tmp[5] = src[2] * src[5];
+         tmp[6] = src[0] * src[7];
+         tmp[7] = src[3] * src[4];
+         tmp[8] = src[0] * src[6];
+         tmp[9] = src[2] * src[4];
+         tmp[10] = src[0] * src[5];
+         tmp[11] = src[1] * src[4];
+
+         // calculate second 8 elements (cofactors)
+         m16[8] = (tmp[0] * src[13] + tmp[3] * src[14] + tmp[4] * src[15]) - (tmp[1] * src[13] + tmp[2] * src[14] + tmp[5] * src[15]);
+         m16[9] = (tmp[1] * src[12] + tmp[6] * src[14] + tmp[9] * src[15]) - (tmp[0] * src[12] + tmp[7] * src[14] + tmp[8] * src[15]);
+         m16[10] = (tmp[2] * src[12] + tmp[7] * src[13] + tmp[10] * src[15]) - (tmp[3] * src[12] + tmp[6] * src[13] + tmp[11] * src[15]);
+         m16[11] = (tmp[5] * src[12] + tmp[8] * src[13] + tmp[11] * src[14]) - (tmp[4] * src[12] + tmp[9] * src[13] + tmp[10] * src[14]);
+         m16[12] = (tmp[2] * src[10] + tmp[5] * src[11] + tmp[1] * src[9]) - (tmp[4] * src[11] + tmp[0] * src[9] + tmp[3] * src[10]);
+         m16[13] = (tmp[8] * src[11] + tmp[0] * src[8] + tmp[7] * src[10]) - (tmp[6] * src[10] + tmp[9] * src[11] + tmp[1] * src[8]);
+         m16[14] = (tmp[6] * src[9] + tmp[11] * src[11] + tmp[3] * src[8]) - (tmp[10] * src[11] + tmp[2] * src[8] + tmp[7] * src[9]);
+         m16[15] = (tmp[10] * src[10] + tmp[4] * src[8] + tmp[9] * src[9]) - (tmp[8] * src[9] + tmp[11] * src[10] + tmp[5] * src[8]);
+
+         // calculate determinant
+         det = src[0] * m16[0] + src[1] * m16[1] + src[2] * m16[2] + src[3] * m16[3];
+
+         // calculate matrix inverse
+         float invdet = 1 / det;
+         for (int j = 0; j < 16; ++j)
+         {
+            m16[j] *= invdet;
+         }
+      }
+
+      return det;
+   }
+
+   void matrix_t::RotationAxis(const vec_t& axis, float angle)
+   {
+      float length2 = axis.LengthSq();
+      if (length2 < FLT_EPSILON)
+      {
+         SetToIdentity();
+         return;
+      }
+
+      vec_t n = axis * (1.f / sqrtf(length2));
+      float s = sinf(angle);
+      float c = cosf(angle);
+      float k = 1.f - c;
+
+      float xx = n.x * n.x * k + c;
+      float yy = n.y * n.y * k + c;
+      float zz = n.z * n.z * k + c;
+      float xy = n.x * n.y * k;
+      float yz = n.y * n.z * k;
+      float zx = n.z * n.x * k;
+      float xs = n.x * s;
+      float ys = n.y * s;
+      float zs = n.z * s;
+
+      m[0][0] = xx;
+      m[0][1] = xy + zs;
+      m[0][2] = zx - ys;
+      m[0][3] = 0.f;
+      m[1][0] = xy - zs;
+      m[1][1] = yy;
+      m[1][2] = yz + xs;
+      m[1][3] = 0.f;
+      m[2][0] = zx + ys;
+      m[2][1] = yz - xs;
+      m[2][2] = zz;
+      m[2][3] = 0.f;
+      m[3][0] = 0.f;
+      m[3][1] = 0.f;
+      m[3][2] = 0.f;
+      m[3][3] = 1.f;
+   }
+
+   ///////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+   //
+
+   enum MOVETYPE
+   {
+      MT_NONE,
+      MT_MOVE_X,
+      MT_MOVE_Y,
+      MT_MOVE_Z,
+      MT_MOVE_YZ,
+      MT_MOVE_ZX,
+      MT_MOVE_XY,
+      MT_MOVE_SCREEN,
+      MT_ROTATE_X,
+      MT_ROTATE_Y,
+      MT_ROTATE_Z,
+      MT_ROTATE_SCREEN,
+      MT_SCALE_X,
+      MT_SCALE_Y,
+      MT_SCALE_Z,
+      MT_SCALE_XYZ
+   };
+
+   static bool IsTranslateType(int type)
+   {
+     return type >= MT_MOVE_X && type <= MT_MOVE_SCREEN;
+   }
+
+   static bool IsRotateType(int type)
+   {
+     return type >= MT_ROTATE_X && type <= MT_ROTATE_SCREEN;
+   }
+
+   static bool IsScaleType(int type)
+   {
+     return type >= MT_SCALE_X && type <= MT_SCALE_XYZ;
+   }
+
+   // Matches MT_MOVE_AB order
+   static const OPERATION TRANSLATE_PLANS[3] = { TRANSLATE_Y | TRANSLATE_Z, TRANSLATE_X | TRANSLATE_Z, TRANSLATE_X | TRANSLATE_Y };
+
+   Style::Style()
+   {
+      // default values
+      TranslationLineThickness   = 3.0f;
+      TranslationLineArrowSize   = 6.0f;
+      RotationLineThickness      = 2.0f;
+      RotationOuterLineThickness = 3.0f;
+      ScaleLineThickness         = 3.0f;
+      ScaleLineCircleSize        = 6.0f;
+      HatchedAxisLineThickness   = 6.0f;
+      CenterCircleSize           = 6.0f;
+
+      // initialize default colors
+      Colors[DIRECTION_X]           = ImVec4(0.666f, 0.000f, 0.000f, 1.000f);
+      Colors[DIRECTION_Y]           = ImVec4(0.000f, 0.666f, 0.000f, 1.000f);
+      Colors[DIRECTION_Z]           = ImVec4(0.000f, 0.000f, 0.666f, 1.000f);
+      Colors[PLANE_X]               = ImVec4(0.666f, 0.000f, 0.000f, 0.380f);
+      Colors[PLANE_Y]               = ImVec4(0.000f, 0.666f, 0.000f, 0.380f);
+      Colors[PLANE_Z]               = ImVec4(0.000f, 0.000f, 0.666f, 0.380f);
+      Colors[SELECTION]             = ImVec4(1.000f, 0.500f, 0.062f, 0.541f);
+      Colors[INACTIVE]              = ImVec4(0.600f, 0.600f, 0.600f, 0.600f);
+      Colors[TRANSLATION_LINE]      = ImVec4(0.666f, 0.666f, 0.666f, 0.666f);
+      Colors[SCALE_LINE]            = ImVec4(0.250f, 0.250f, 0.250f, 1.000f);
+      Colors[ROTATION_USING_BORDER] = ImVec4(1.000f, 0.500f, 0.062f, 1.000f);
+      Colors[ROTATION_USING_FILL]   = ImVec4(1.000f, 0.500f, 0.062f, 0.500f);
+      Colors[HATCHED_AXIS_LINES]    = ImVec4(0.000f, 0.000f, 0.000f, 0.500f);
+      Colors[TEXT]                  = ImVec4(1.000f, 1.000f, 1.000f, 1.000f);
+      Colors[TEXT_SHADOW]           = ImVec4(0.000f, 0.000f, 0.000f, 1.000f);
+   }
+
+   struct Context
+   {
+      Context() : mbUsing(false), mbEnable(true), mbUsingBounds(false)
+      {
+      }
+
+      ImDrawList* mDrawList;
+      Style mStyle;
+
+      MODE mMode;
+      matrix_t mViewMat;
+      matrix_t mProjectionMat;
+      matrix_t mModel;
+      matrix_t mModelLocal; // orthonormalized model
+      matrix_t mModelInverse;
+      matrix_t mModelSource;
+      matrix_t mModelSourceInverse;
+      matrix_t mMVP;
+      matrix_t mMVPLocal; // MVP with full model matrix whereas mMVP's model matrix might only be translation in case of World space edition
+      matrix_t mViewProjection;
+
+      vec_t mModelScaleOrigin;
+      vec_t mCameraEye;
+      vec_t mCameraRight;
+      vec_t mCameraDir;
+      vec_t mCameraUp;
+      vec_t mRayOrigin;
+      vec_t mRayVector;
+
+      float  mRadiusSquareCenter;
+      ImVec2 mScreenSquareCenter;
+      ImVec2 mScreenSquareMin;
+      ImVec2 mScreenSquareMax;
+
+      float mScreenFactor;
+      vec_t mRelativeOrigin;
+
+      bool mbUsing;
+      bool mbEnable;
+      bool mbMouseOver;
+      bool mReversed; // reversed projection matrix
+
+      // translation
+      vec_t mTranslationPlan;
+      vec_t mTranslationPlanOrigin;
+      vec_t mMatrixOrigin;
+      vec_t mTranslationLastDelta;
+
+      // rotation
+      vec_t mRotationVectorSource;
+      float mRotationAngle;
+      float mRotationAngleOrigin;
+      //vec_t mWorldToLocalAxis;
+
+      // scale
+      vec_t mScale;
+      vec_t mScaleValueOrigin;
+      vec_t mScaleLast;
+      float mSaveMousePosx;
+
+      // save axis factor when using gizmo
+      bool mBelowAxisLimit[3];
+      bool mBelowPlaneLimit[3];
+      float mAxisFactor[3];
+
+      float mAxisLimit=0.0025f;
+      float mPlaneLimit=0.02f;
+
+      // bounds stretching
+      vec_t mBoundsPivot;
+      vec_t mBoundsAnchor;
+      vec_t mBoundsPlan;
+      vec_t mBoundsLocalPivot;
+      int mBoundsBestAxis;
+      int mBoundsAxis[2];
+      bool mbUsingBounds;
+      matrix_t mBoundsMatrix;
+
+      //
+      int mCurrentOperation;
+
+      float mX = 0.f;
+      float mY = 0.f;
+      float mWidth = 0.f;
+      float mHeight = 0.f;
+      float mXMax = 0.f;
+      float mYMax = 0.f;
+      float mDisplayRatio = 1.f;
+
+      bool mIsOrthographic = false;
+
+      int mActualID = -1;
+      int mEditingID = -1;
+      OPERATION mOperation = OPERATION(-1);
+
+      bool mAllowAxisFlip = true;
+      float mGizmoSizeClipSpace = 0.1f;
+   };
+
+   static Context gContext;
+
+   static const vec_t directionUnary[3] = { makeVect(1.f, 0.f, 0.f), makeVect(0.f, 1.f, 0.f), makeVect(0.f, 0.f, 1.f) };
+   static const char* translationInfoMask[] = { "X : %5.3f", "Y : %5.3f", "Z : %5.3f",
+      "Y : %5.3f Z : %5.3f", "X : %5.3f Z : %5.3f", "X : %5.3f Y : %5.3f",
+      "X : %5.3f Y : %5.3f Z : %5.3f" };
+   static const char* scaleInfoMask[] = { "X : %5.2f", "Y : %5.2f", "Z : %5.2f", "XYZ : %5.2f" };
+   static const char* rotationInfoMask[] = { "X : %5.2f deg %5.2f rad", "Y : %5.2f deg %5.2f rad", "Z : %5.2f deg %5.2f rad", "Screen : %5.2f deg %5.2f rad" };
+   static const int translationInfoIndex[] = { 0,0,0, 1,0,0, 2,0,0, 1,2,0, 0,2,0, 0,1,0, 0,1,2 };
+   static const float quadMin = 0.5f;
+   static const float quadMax = 0.8f;
+   static const float quadUV[8] = { quadMin, quadMin, quadMin, quadMax, quadMax, quadMax, quadMax, quadMin };
+   static const int halfCircleSegmentCount = 64;
+   static const float snapTension = 0.5f;
+
+   ///////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+   //
+   static int GetMoveType(OPERATION op, vec_t* gizmoHitProportion);
+   static int GetRotateType(OPERATION op);
+   static int GetScaleType(OPERATION op);
+
+   Style& GetStyle()
+   {
+      return gContext.mStyle;
+   }
+
+   static ImU32 GetColorU32(int idx)
+   {
+      IM_ASSERT(idx < COLOR::COUNT);
+      return ImGui::ColorConvertFloat4ToU32(gContext.mStyle.Colors[idx]);
+   }
+
+   static ImVec2 worldToPos(const vec_t& worldPos, const matrix_t& mat, ImVec2 position = ImVec2(gContext.mX, gContext.mY), ImVec2 size = ImVec2(gContext.mWidth, gContext.mHeight))
+   {
+      vec_t trans;
+      trans.TransformPoint(worldPos, mat);
+      trans *= 0.5f / trans.w;
+      trans += makeVect(0.5f, 0.5f);
+      trans.y = 1.f - trans.y;
+      trans.x *= size.x;
+      trans.y *= size.y;
+      trans.x += position.x;
+      trans.y += position.y;
+      return ImVec2(trans.x, trans.y);
+   }
+
+   static void ComputeCameraRay(vec_t& rayOrigin, vec_t& rayDir, ImVec2 position = ImVec2(gContext.mX, gContext.mY), ImVec2 size = ImVec2(gContext.mWidth, gContext.mHeight))
+   {
+      ImGuiIO& io = ImGui::GetIO();
+
+      matrix_t mViewProjInverse;
+      mViewProjInverse.Inverse(gContext.mViewMat * gContext.mProjectionMat);
+
+      const float mox = ((io.MousePos.x - position.x) / size.x) * 2.f - 1.f;
+      const float moy = (1.f - ((io.MousePos.y - position.y) / size.y)) * 2.f - 1.f;
+
+      const float zNear = gContext.mReversed ? (1.f - FLT_EPSILON) : 0.f;
+      const float zFar = gContext.mReversed ? 0.f : (1.f - FLT_EPSILON);
+
+      rayOrigin.Transform(makeVect(mox, moy, zNear, 1.f), mViewProjInverse);
+      rayOrigin *= 1.f / rayOrigin.w;
+      vec_t rayEnd;
+      rayEnd.Transform(makeVect(mox, moy, zFar, 1.f), mViewProjInverse);
+      rayEnd *= 1.f / rayEnd.w;
+      rayDir = Normalized(rayEnd - rayOrigin);
+   }
+
+   static float GetSegmentLengthClipSpace(const vec_t& start, const vec_t& end, const bool localCoordinates = false)
+   {
+      vec_t startOfSegment = start;
+      const matrix_t& mvp = localCoordinates ? gContext.mMVPLocal : gContext.mMVP;
+      startOfSegment.TransformPoint(mvp);
+      if (fabsf(startOfSegment.w) > FLT_EPSILON) // check for axis aligned with camera direction
+      {
+         startOfSegment *= 1.f / startOfSegment.w;
+      }
+
+      vec_t endOfSegment = end;
+      endOfSegment.TransformPoint(mvp);
+      if (fabsf(endOfSegment.w) > FLT_EPSILON) // check for axis aligned with camera direction
+      {
+         endOfSegment *= 1.f / endOfSegment.w;
+      }
+
+      vec_t clipSpaceAxis = endOfSegment - startOfSegment;
+      if (gContext.mDisplayRatio < 1.0)
+         clipSpaceAxis.x *= gContext.mDisplayRatio;
+      else
+         clipSpaceAxis.y /= gContext.mDisplayRatio;
+      float segmentLengthInClipSpace = sqrtf(clipSpaceAxis.x * clipSpaceAxis.x + clipSpaceAxis.y * clipSpaceAxis.y);
+      return segmentLengthInClipSpace;
+   }
+
+   static float GetParallelogram(const vec_t& ptO, const vec_t& ptA, const vec_t& ptB)
+   {
+      vec_t pts[] = { ptO, ptA, ptB };
+      for (unsigned int i = 0; i < 3; i++)
+      {
+         pts[i].TransformPoint(gContext.mMVP);
+         if (fabsf(pts[i].w) > FLT_EPSILON) // check for axis aligned with camera direction
+         {
+            pts[i] *= 1.f / pts[i].w;
+         }
+      }
+      vec_t segA = pts[1] - pts[0];
+      vec_t segB = pts[2] - pts[0];
+      segA.y /= gContext.mDisplayRatio;
+      segB.y /= gContext.mDisplayRatio;
+      vec_t segAOrtho = makeVect(-segA.y, segA.x);
+      segAOrtho.Normalize();
+      float dt = segAOrtho.Dot3(segB);
+      float surface = sqrtf(segA.x * segA.x + segA.y * segA.y) * fabsf(dt);
+      return surface;
+   }
+
+   inline vec_t PointOnSegment(const vec_t& point, const vec_t& vertPos1, const vec_t& vertPos2)
+   {
+      vec_t c = point - vertPos1;
+      vec_t V;
+
+      V.Normalize(vertPos2 - vertPos1);
+      float d = (vertPos2 - vertPos1).Length();
+      float t = V.Dot3(c);
+
+      if (t < 0.f)
+      {
+         return vertPos1;
+      }
+
+      if (t > d)
+      {
+         return vertPos2;
+      }
+
+      return vertPos1 + V * t;
+   }
+
+   static float IntersectRayPlane(const vec_t& rOrigin, const vec_t& rVector, const vec_t& plan)
+   {
+      const float numer = plan.Dot3(rOrigin) - plan.w;
+      const float denom = plan.Dot3(rVector);
+
+      if (fabsf(denom) < FLT_EPSILON)  // normal is orthogonal to vector, cant intersect
+      {
+         return -1.0f;
+      }
+
+      return -(numer / denom);
+   }
+
+   static float DistanceToPlane(const vec_t& point, const vec_t& plan)
+   {
+      return plan.Dot3(point) + plan.w;
+   }
+
+   static bool IsInContextRect(ImVec2 p)
+   {
+      return IsWithin(p.x, gContext.mX, gContext.mXMax) && IsWithin(p.y, gContext.mY, gContext.mYMax);
+   }
+
+   static bool IsHoveringWindow()
+   {
+      ImGuiContext& g = *ImGui::GetCurrentContext();
+      ImGuiWindow* window = ImGui::FindWindowByName(gContext.mDrawList->_OwnerName);
+      if (g.HoveredWindow == window)   // Mouse hovering drawlist window
+         return true;
+      if (g.HoveredWindow != NULL)     // Any other window is hovered
+         return false;
+      if (ImGui::IsMouseHoveringRect(window->InnerRect.Min, window->InnerRect.Max, false))   // Hovering drawlist window rect, while no other window is hovered (for _NoInputs windows)
+         return true;
+      return false;
+   }
+
+   void SetRect(float x, float y, float width, float height)
+   {
+      gContext.mX = x;
+      gContext.mY = y;
+      gContext.mWidth = width;
+      gContext.mHeight = height;
+      gContext.mXMax = gContext.mX + gContext.mWidth;
+      gContext.mYMax = gContext.mY + gContext.mXMax;
+      gContext.mDisplayRatio = width / height;
+   }
+
+   void SetOrthographic(bool isOrthographic)
+   {
+      gContext.mIsOrthographic = isOrthographic;
+   }
+
+   void SetDrawlist(ImDrawList* drawlist)
+   {
+      gContext.mDrawList = drawlist ? drawlist : ImGui::GetWindowDrawList();
+   }
+
+   void SetImGuiContext(ImGuiContext* ctx)
+   {
+      ImGui::SetCurrentContext(ctx);
+   }
+
+   void BeginFrame()
+   {
+      const ImU32 flags = ImGuiWindowFlags_NoTitleBar | ImGuiWindowFlags_NoResize | ImGuiWindowFlags_NoScrollbar | ImGuiWindowFlags_NoInputs | ImGuiWindowFlags_NoSavedSettings | ImGuiWindowFlags_NoFocusOnAppearing | ImGuiWindowFlags_NoBringToFrontOnFocus;
+
+#ifdef IMGUI_HAS_VIEWPORT
+      ImGui::SetNextWindowSize(ImGui::GetMainViewport()->Size);
+      ImGui::SetNextWindowPos(ImGui::GetMainViewport()->Pos);
+#else
+      ImGuiIO& io = ImGui::GetIO();
+      ImGui::SetNextWindowSize(io.DisplaySize);
+      ImGui::SetNextWindowPos(ImVec2(0, 0));
+#endif
+
+      ImGui::PushStyleColor(ImGuiCol_WindowBg, 0);
+      ImGui::PushStyleColor(ImGuiCol_Border, 0);
+      ImGui::PushStyleVar(ImGuiStyleVar_WindowRounding, 0.0f);
+
+      ImGui::Begin("gizmo", NULL, flags);
+      gContext.mDrawList = ImGui::GetWindowDrawList();
+      ImGui::End();
+      ImGui::PopStyleVar();
+      ImGui::PopStyleColor(2);
+   }
+
+   bool IsUsing()
+   {
+      return (gContext.mbUsing && (gContext.mActualID == -1 || gContext.mActualID == gContext.mEditingID)) || gContext.mbUsingBounds;
+   }
+   
+   bool IsUsingAny()
+   {
+      return gContext.mbUsing || gContext.mbUsingBounds;
+   }
+
+   bool IsOver()
+   {
+      return (Intersects(gContext.mOperation, TRANSLATE) && GetMoveType(gContext.mOperation, NULL) != MT_NONE) ||
+         (Intersects(gContext.mOperation, ROTATE) && GetRotateType(gContext.mOperation) != MT_NONE) ||
+         (Intersects(gContext.mOperation, SCALE) && GetScaleType(gContext.mOperation) != MT_NONE) || IsUsing();
+   }
+
+   bool IsOver(OPERATION op)
+   {
+      if(IsUsing())
+      {
+         return true;
+      }
+      if(Intersects(op, SCALE) && GetScaleType(op) != MT_NONE)
+      {
+         return true;
+      }
+      if(Intersects(op, ROTATE) && GetRotateType(op) != MT_NONE)
+      {
+         return true;
+      }
+      if(Intersects(op, TRANSLATE) && GetMoveType(op, NULL) != MT_NONE)
+      {
+         return true;
+      }
+      return false;
+   }
+
+   void Enable(bool enable)
+   {
+      gContext.mbEnable = enable;
+      if (!enable)
+      {
+         gContext.mbUsing = false;
+         gContext.mbUsingBounds = false;
+      }
+   }
+
+   static void ComputeContext(const float* view, const float* projection, float* matrix, MODE mode)
+   {
+      gContext.mMode = mode;
+      gContext.mViewMat = *(matrix_t*)view;
+      gContext.mProjectionMat = *(matrix_t*)projection;
+      gContext.mbMouseOver = IsHoveringWindow();
+
+      gContext.mModelLocal = *(matrix_t*)matrix;
+      gContext.mModelLocal.OrthoNormalize();
+
+      if (mode == LOCAL)
+      {
+         gContext.mModel = gContext.mModelLocal;
+      }
+      else
+      {
+         gContext.mModel.Translation(((matrix_t*)matrix)->v.position);
+      }
+      gContext.mModelSource = *(matrix_t*)matrix;
+      gContext.mModelScaleOrigin.Set(gContext.mModelSource.v.right.Length(), gContext.mModelSource.v.up.Length(), gContext.mModelSource.v.dir.Length());
+
+      gContext.mModelInverse.Inverse(gContext.mModel);
+      gContext.mModelSourceInverse.Inverse(gContext.mModelSource);
+      gContext.mViewProjection = gContext.mViewMat * gContext.mProjectionMat;
+      gContext.mMVP = gContext.mModel * gContext.mViewProjection;
+      gContext.mMVPLocal = gContext.mModelLocal * gContext.mViewProjection;
+
+      matrix_t viewInverse;
+      viewInverse.Inverse(gContext.mViewMat);
+      gContext.mCameraDir = viewInverse.v.dir;
+      gContext.mCameraEye = viewInverse.v.position;
+      gContext.mCameraRight = viewInverse.v.right;
+      gContext.mCameraUp = viewInverse.v.up;
+
+      // projection reverse
+       vec_t nearPos, farPos;
+       nearPos.Transform(makeVect(0, 0, 1.f, 1.f), gContext.mProjectionMat);
+       farPos.Transform(makeVect(0, 0, 2.f, 1.f), gContext.mProjectionMat);
+
+       gContext.mReversed = (nearPos.z/nearPos.w) > (farPos.z / farPos.w);
+
+      // compute scale from the size of camera right vector projected on screen at the matrix position
+      vec_t pointRight = viewInverse.v.right;
+      pointRight.TransformPoint(gContext.mViewProjection);
+      gContext.mScreenFactor = gContext.mGizmoSizeClipSpace / (pointRight.x / pointRight.w - gContext.mMVP.v.position.x / gContext.mMVP.v.position.w);
+
+      vec_t rightViewInverse = viewInverse.v.right;
+      rightViewInverse.TransformVector(gContext.mModelInverse);
+      float rightLength = GetSegmentLengthClipSpace(makeVect(0.f, 0.f), rightViewInverse);
+      gContext.mScreenFactor = gContext.mGizmoSizeClipSpace / rightLength;
+
+      ImVec2 centerSSpace = worldToPos(makeVect(0.f, 0.f), gContext.mMVP);
+      gContext.mScreenSquareCenter = centerSSpace;
+      gContext.mScreenSquareMin = ImVec2(centerSSpace.x - 10.f, centerSSpace.y - 10.f);
+      gContext.mScreenSquareMax = ImVec2(centerSSpace.x + 10.f, centerSSpace.y + 10.f);
+
+      ComputeCameraRay(gContext.mRayOrigin, gContext.mRayVector);
+   }
+
+   static void ComputeColors(ImU32* colors, int type, OPERATION operation)
+   {
+      if (gContext.mbEnable)
+      {
+         ImU32 selectionColor = GetColorU32(SELECTION);
+
+         switch (operation)
+         {
+         case TRANSLATE:
+            colors[0] = (type == MT_MOVE_SCREEN) ? selectionColor : IM_COL32_WHITE;
+            for (int i = 0; i < 3; i++)
+            {
+               colors[i + 1] = (type == (int)(MT_MOVE_X + i)) ? selectionColor : GetColorU32(DIRECTION_X + i);
+               colors[i + 4] = (type == (int)(MT_MOVE_YZ + i)) ? selectionColor : GetColorU32(PLANE_X + i);
+               colors[i + 4] = (type == MT_MOVE_SCREEN) ? selectionColor : colors[i + 4];
+            }
+            break;
+         case ROTATE:
+            colors[0] = (type == MT_ROTATE_SCREEN) ? selectionColor : IM_COL32_WHITE;
+            for (int i = 0; i < 3; i++)
+            {
+               colors[i + 1] = (type == (int)(MT_ROTATE_X + i)) ? selectionColor : GetColorU32(DIRECTION_X + i);
+            }
+            break;
+         case SCALEU:
+         case SCALE:
+            colors[0] = (type == MT_SCALE_XYZ) ? selectionColor : IM_COL32_WHITE;
+            for (int i = 0; i < 3; i++)
+            {
+               colors[i + 1] = (type == (int)(MT_SCALE_X + i)) ? selectionColor : GetColorU32(DIRECTION_X + i);
+            }
+            break;
+         // note: this internal function is only called with three possible values for operation
+         default:
+            break;
+         }
+      }
+      else
+      {
+         ImU32 inactiveColor = GetColorU32(INACTIVE);
+         for (int i = 0; i < 7; i++)
+         {
+            colors[i] = inactiveColor;
+         }
+      }
+   }
+
+   static void ComputeTripodAxisAndVisibility(const int axisIndex, vec_t& dirAxis, vec_t& dirPlaneX, vec_t& dirPlaneY, bool& belowAxisLimit, bool& belowPlaneLimit, const bool localCoordinates = false)
+   {
+      dirAxis = directionUnary[axisIndex];
+      dirPlaneX = directionUnary[(axisIndex + 1) % 3];
+      dirPlaneY = directionUnary[(axisIndex + 2) % 3];
+
+      if (gContext.mbUsing && (gContext.mActualID == -1 || gContext.mActualID == gContext.mEditingID))
+      {
+         // when using, use stored factors so the gizmo doesn't flip when we translate
+         belowAxisLimit = gContext.mBelowAxisLimit[axisIndex];
+         belowPlaneLimit = gContext.mBelowPlaneLimit[axisIndex];
+
+         dirAxis *= gContext.mAxisFactor[axisIndex];
+         dirPlaneX *= gContext.mAxisFactor[(axisIndex + 1) % 3];
+         dirPlaneY *= gContext.mAxisFactor[(axisIndex + 2) % 3];
+      }
+      else
+      {
+         // new method
+         float lenDir = GetSegmentLengthClipSpace(makeVect(0.f, 0.f, 0.f), dirAxis, localCoordinates);
+         float lenDirMinus = GetSegmentLengthClipSpace(makeVect(0.f, 0.f, 0.f), -dirAxis, localCoordinates);
+
+         float lenDirPlaneX = GetSegmentLengthClipSpace(makeVect(0.f, 0.f, 0.f), dirPlaneX, localCoordinates);
+         float lenDirMinusPlaneX = GetSegmentLengthClipSpace(makeVect(0.f, 0.f, 0.f), -dirPlaneX, localCoordinates);
+
+         float lenDirPlaneY = GetSegmentLengthClipSpace(makeVect(0.f, 0.f, 0.f), dirPlaneY, localCoordinates);
+         float lenDirMinusPlaneY = GetSegmentLengthClipSpace(makeVect(0.f, 0.f, 0.f), -dirPlaneY, localCoordinates);
+
+         // For readability
+         bool & allowFlip = gContext.mAllowAxisFlip;
+         float mulAxis = (allowFlip && lenDir < lenDirMinus&& fabsf(lenDir - lenDirMinus) > FLT_EPSILON) ? -1.f : 1.f;
+         float mulAxisX = (allowFlip && lenDirPlaneX < lenDirMinusPlaneX&& fabsf(lenDirPlaneX - lenDirMinusPlaneX) > FLT_EPSILON) ? -1.f : 1.f;
+         float mulAxisY = (allowFlip && lenDirPlaneY < lenDirMinusPlaneY&& fabsf(lenDirPlaneY - lenDirMinusPlaneY) > FLT_EPSILON) ? -1.f : 1.f;
+         dirAxis *= mulAxis;
+         dirPlaneX *= mulAxisX;
+         dirPlaneY *= mulAxisY;
+
+         // for axis
+         float axisLengthInClipSpace = GetSegmentLengthClipSpace(makeVect(0.f, 0.f, 0.f), dirAxis * gContext.mScreenFactor, localCoordinates);
+
+         float paraSurf = GetParallelogram(makeVect(0.f, 0.f, 0.f), dirPlaneX * gContext.mScreenFactor, dirPlaneY * gContext.mScreenFactor);
+         belowPlaneLimit = (paraSurf > gContext.mAxisLimit);
+         belowAxisLimit = (axisLengthInClipSpace > gContext.mPlaneLimit);
+
+         // and store values
+         gContext.mAxisFactor[axisIndex] = mulAxis;
+         gContext.mAxisFactor[(axisIndex + 1) % 3] = mulAxisX;
+         gContext.mAxisFactor[(axisIndex + 2) % 3] = mulAxisY;
+         gContext.mBelowAxisLimit[axisIndex] = belowAxisLimit;
+         gContext.mBelowPlaneLimit[axisIndex] = belowPlaneLimit;
+      }
+   }
+
+   static void ComputeSnap(float* value, float snap)
+   {
+      if (snap <= FLT_EPSILON)
+      {
+         return;
+      }
+
+      float modulo = fmodf(*value, snap);
+      float moduloRatio = fabsf(modulo) / snap;
+      if (moduloRatio < snapTension)
+      {
+         *value -= modulo;
+      }
+      else if (moduloRatio > (1.f - snapTension))
+      {
+         *value = *value - modulo + snap * ((*value < 0.f) ? -1.f : 1.f);
+      }
+   }
+   static void ComputeSnap(vec_t& value, const float* snap)
+   {
+      for (int i = 0; i < 3; i++)
+      {
+         ComputeSnap(&value[i], snap[i]);
+      }
+   }
+
+   static float ComputeAngleOnPlan()
+   {
+      const float len = IntersectRayPlane(gContext.mRayOrigin, gContext.mRayVector, gContext.mTranslationPlan);
+      vec_t localPos = Normalized(gContext.mRayOrigin + gContext.mRayVector * len - gContext.mModel.v.position);
+
+      vec_t perpendicularVector;
+      perpendicularVector.Cross(gContext.mRotationVectorSource, gContext.mTranslationPlan);
+      perpendicularVector.Normalize();
+      float acosAngle = Clamp(Dot(localPos, gContext.mRotationVectorSource), -1.f, 1.f);
+      float angle = acosf(acosAngle);
+      angle *= (Dot(localPos, perpendicularVector) < 0.f) ? 1.f : -1.f;
+      return angle;
+   }
+
+   static void DrawRotationGizmo(OPERATION op, int type)
+   {
+      if(!Intersects(op, ROTATE))
+      {
+         return;
+      }
+      ImDrawList* drawList = gContext.mDrawList;
+
+      // colors
+      ImU32 colors[7];
+      ComputeColors(colors, type, ROTATE);
+
+      vec_t cameraToModelNormalized;
+      if (gContext.mIsOrthographic)
+      {
+         matrix_t viewInverse;
+         viewInverse.Inverse(*(matrix_t*)&gContext.mViewMat);
+         cameraToModelNormalized = -viewInverse.v.dir;
+      }
+      else
+      {
+         cameraToModelNormalized = Normalized(gContext.mModel.v.position - gContext.mCameraEye);
+      }
+
+      cameraToModelNormalized.TransformVector(gContext.mModelInverse);
+
+      gContext.mRadiusSquareCenter = screenRotateSize * gContext.mHeight;
+
+      bool hasRSC = Intersects(op, ROTATE_SCREEN);
+      for (int axis = 0; axis < 3; axis++)
+      {
+         if(!Intersects(op, static_cast<OPERATION>(ROTATE_Z >> axis)))
+         {
+            continue;
+         }
+         const bool usingAxis = (gContext.mbUsing && type == MT_ROTATE_Z - axis);
+         const int circleMul = (hasRSC && !usingAxis ) ? 1 : 2;
+
+         ImVec2* circlePos = (ImVec2*)alloca(sizeof(ImVec2) * (circleMul * halfCircleSegmentCount + 1));
+
+         float angleStart = atan2f(cameraToModelNormalized[(4 - axis) % 3], cameraToModelNormalized[(3 - axis) % 3]) + ZPI * 0.5f;
+
+         for (int i = 0; i < circleMul * halfCircleSegmentCount + 1; i++)
+         {
+            float ng = angleStart + (float)circleMul * ZPI * ((float)i / (float)(circleMul * halfCircleSegmentCount));
+            vec_t axisPos = makeVect(cosf(ng), sinf(ng), 0.f);
+            vec_t pos = makeVect(axisPos[axis], axisPos[(axis + 1) % 3], axisPos[(axis + 2) % 3]) * gContext.mScreenFactor * rotationDisplayFactor;
+            circlePos[i] = worldToPos(pos, gContext.mMVP);
+         }
+         if (!gContext.mbUsing || usingAxis)
+         {
+            drawList->AddPolyline(circlePos, circleMul* halfCircleSegmentCount + 1, colors[3 - axis], false, gContext.mStyle.RotationLineThickness);
+         }
+
+         float radiusAxis = sqrtf((ImLengthSqr(worldToPos(gContext.mModel.v.position, gContext.mViewProjection) - circlePos[0])));
+         if (radiusAxis > gContext.mRadiusSquareCenter)
+         {
+            gContext.mRadiusSquareCenter = radiusAxis;
+         }
+      }
+      if(hasRSC && (!gContext.mbUsing || type == MT_ROTATE_SCREEN))
+      {
+         drawList->AddCircle(worldToPos(gContext.mModel.v.position, gContext.mViewProjection), gContext.mRadiusSquareCenter, colors[0], 64, gContext.mStyle.RotationOuterLineThickness);
+      }
+
+      if (gContext.mbUsing && (gContext.mActualID == -1 || gContext.mActualID == gContext.mEditingID) && IsRotateType(type))
+      {
+         ImVec2 circlePos[halfCircleSegmentCount + 1];
+
+         circlePos[0] = worldToPos(gContext.mModel.v.position, gContext.mViewProjection);
+         for (unsigned int i = 1; i < halfCircleSegmentCount + 1; i++)
+         {
+            float ng = gContext.mRotationAngle * ((float)(i - 1) / (float)(halfCircleSegmentCount - 1));
+            matrix_t rotateVectorMatrix;
+            rotateVectorMatrix.RotationAxis(gContext.mTranslationPlan, ng);
+            vec_t pos;
+            pos.TransformPoint(gContext.mRotationVectorSource, rotateVectorMatrix);
+            pos *= gContext.mScreenFactor * rotationDisplayFactor;
+            circlePos[i] = worldToPos(pos + gContext.mModel.v.position, gContext.mViewProjection);
+         }
+         drawList->AddConvexPolyFilled(circlePos, halfCircleSegmentCount + 1, GetColorU32(ROTATION_USING_FILL));
+         drawList->AddPolyline(circlePos, halfCircleSegmentCount + 1, GetColorU32(ROTATION_USING_BORDER), true, gContext.mStyle.RotationLineThickness);
+
+         ImVec2 destinationPosOnScreen = circlePos[1];
+         char tmps[512];
+         ImFormatString(tmps, sizeof(tmps), rotationInfoMask[type - MT_ROTATE_X], (gContext.mRotationAngle / ZPI) * 180.f, gContext.mRotationAngle);
+         drawList->AddText(ImVec2(destinationPosOnScreen.x + 15, destinationPosOnScreen.y + 15), GetColorU32(TEXT_SHADOW), tmps);
+         drawList->AddText(ImVec2(destinationPosOnScreen.x + 14, destinationPosOnScreen.y + 14), GetColorU32(TEXT), tmps);
+      }
+   }
+
+   static void DrawHatchedAxis(const vec_t& axis)
+   {
+      if (gContext.mStyle.HatchedAxisLineThickness <= 0.0f)
+      {
+         return;
+      }
+
+      for (int j = 1; j < 10; j++)
+      {
+         ImVec2 baseSSpace2 = worldToPos(axis * 0.05f * (float)(j * 2) * gContext.mScreenFactor, gContext.mMVP);
+         ImVec2 worldDirSSpace2 = worldToPos(axis * 0.05f * (float)(j * 2 + 1) * gContext.mScreenFactor, gContext.mMVP);
+         gContext.mDrawList->AddLine(baseSSpace2, worldDirSSpace2, GetColorU32(HATCHED_AXIS_LINES), gContext.mStyle.HatchedAxisLineThickness);
+      }
+   }
+
+   static void DrawScaleGizmo(OPERATION op, int type)
+   {
+      ImDrawList* drawList = gContext.mDrawList;
+
+      if(!Intersects(op, SCALE))
+      {
+        return;
+      }
+
+      // colors
+      ImU32 colors[7];
+      ComputeColors(colors, type, SCALE);
+
+      // draw
+      vec_t scaleDisplay = { 1.f, 1.f, 1.f, 1.f };
+
+      if (gContext.mbUsing && (gContext.mActualID == -1 || gContext.mActualID == gContext.mEditingID))
+      {
+         scaleDisplay = gContext.mScale;
+      }
+
+      for (int i = 0; i < 3; i++)
+      {
+         if(!Intersects(op, static_cast<OPERATION>(SCALE_X << i)))
+         {
+            continue;
+         }
+         const bool usingAxis = (gContext.mbUsing && type == MT_SCALE_X + i);
+         if (!gContext.mbUsing || usingAxis)
+         {
+            vec_t dirPlaneX, dirPlaneY, dirAxis;
+            bool belowAxisLimit, belowPlaneLimit;
+            ComputeTripodAxisAndVisibility(i, dirAxis, dirPlaneX, dirPlaneY, belowAxisLimit, belowPlaneLimit, true);
+
+            // draw axis
+            if (belowAxisLimit)
+            {
+               bool hasTranslateOnAxis = Contains(op, static_cast<OPERATION>(TRANSLATE_X << i));
+               float markerScale = hasTranslateOnAxis ? 1.4f : 1.0f;
+               ImVec2 baseSSpace = worldToPos(dirAxis * 0.1f * gContext.mScreenFactor, gContext.mMVP);
+               ImVec2 worldDirSSpaceNoScale = worldToPos(dirAxis * markerScale * gContext.mScreenFactor, gContext.mMVP);
+               ImVec2 worldDirSSpace = worldToPos((dirAxis * markerScale * scaleDisplay[i]) * gContext.mScreenFactor, gContext.mMVP);
+
+               if (gContext.mbUsing && (gContext.mActualID == -1 || gContext.mActualID == gContext.mEditingID))
+               {
+                  ImU32 scaleLineColor = GetColorU32(SCALE_LINE);
+                  drawList->AddLine(baseSSpace, worldDirSSpaceNoScale, scaleLineColor, gContext.mStyle.ScaleLineThickness);
+                  drawList->AddCircleFilled(worldDirSSpaceNoScale, gContext.mStyle.ScaleLineCircleSize, scaleLineColor);
+               }
+
+               if (!hasTranslateOnAxis || gContext.mbUsing)
+               {
+                  drawList->AddLine(baseSSpace, worldDirSSpace, colors[i + 1], gContext.mStyle.ScaleLineThickness);
+               }
+               drawList->AddCircleFilled(worldDirSSpace, gContext.mStyle.ScaleLineCircleSize, colors[i + 1]);
+
+               if (gContext.mAxisFactor[i] < 0.f)
+               {
+                  DrawHatchedAxis(dirAxis * scaleDisplay[i]);
+               }
+            }
+         }
+      }
+
+      // draw screen cirle
+      drawList->AddCircleFilled(gContext.mScreenSquareCenter, gContext.mStyle.CenterCircleSize, colors[0], 32);
+
+      if (gContext.mbUsing && (gContext.mActualID == -1 || gContext.mActualID == gContext.mEditingID) && IsScaleType(type))
+      {
+         //ImVec2 sourcePosOnScreen = worldToPos(gContext.mMatrixOrigin, gContext.mViewProjection);
+         ImVec2 destinationPosOnScreen = worldToPos(gContext.mModel.v.position, gContext.mViewProjection);
+         /*vec_t dif(destinationPosOnScreen.x - sourcePosOnScreen.x, destinationPosOnScreen.y - sourcePosOnScreen.y);
+         dif.Normalize();
+         dif *= 5.f;
+         drawList->AddCircle(sourcePosOnScreen, 6.f, translationLineColor);
+         drawList->AddCircle(destinationPosOnScreen, 6.f, translationLineColor);
+         drawList->AddLine(ImVec2(sourcePosOnScreen.x + dif.x, sourcePosOnScreen.y + dif.y), ImVec2(destinationPosOnScreen.x - dif.x, destinationPosOnScreen.y - dif.y), translationLineColor, 2.f);
+         */
+         char tmps[512];
+         //vec_t deltaInfo = gContext.mModel.v.position - gContext.mMatrixOrigin;
+         int componentInfoIndex = (type - MT_SCALE_X) * 3;
+         ImFormatString(tmps, sizeof(tmps), scaleInfoMask[type - MT_SCALE_X], scaleDisplay[translationInfoIndex[componentInfoIndex]]);
+         drawList->AddText(ImVec2(destinationPosOnScreen.x + 15, destinationPosOnScreen.y + 15), GetColorU32(TEXT_SHADOW), tmps);
+         drawList->AddText(ImVec2(destinationPosOnScreen.x + 14, destinationPosOnScreen.y + 14), GetColorU32(TEXT), tmps);
+      }
+   }
+
+
+   static void DrawScaleUniveralGizmo(OPERATION op, int type)
+   {
+      ImDrawList* drawList = gContext.mDrawList;
+
+      if (!Intersects(op, SCALEU))
+      {
+         return;
+      }
+
+      // colors
+      ImU32 colors[7];
+      ComputeColors(colors, type, SCALEU);
+
+      // draw
+      vec_t scaleDisplay = { 1.f, 1.f, 1.f, 1.f };
+
+      if (gContext.mbUsing && (gContext.mActualID == -1 || gContext.mActualID == gContext.mEditingID))
+      {
+         scaleDisplay = gContext.mScale;
+      }
+
+      for (int i = 0; i < 3; i++)
+      {
+         if (!Intersects(op, static_cast<OPERATION>(SCALE_XU << i)))
+         {
+            continue;
+         }
+         const bool usingAxis = (gContext.mbUsing && type == MT_SCALE_X + i);
+         if (!gContext.mbUsing || usingAxis)
+         {
+            vec_t dirPlaneX, dirPlaneY, dirAxis;
+            bool belowAxisLimit, belowPlaneLimit;
+            ComputeTripodAxisAndVisibility(i, dirAxis, dirPlaneX, dirPlaneY, belowAxisLimit, belowPlaneLimit, true);
+
+            // draw axis
+            if (belowAxisLimit)
+            {
+               bool hasTranslateOnAxis = Contains(op, static_cast<OPERATION>(TRANSLATE_X << i));
+               float markerScale = hasTranslateOnAxis ? 1.4f : 1.0f;
+               //ImVec2 baseSSpace = worldToPos(dirAxis * 0.1f * gContext.mScreenFactor, gContext.mMVPLocal);
+               //ImVec2 worldDirSSpaceNoScale = worldToPos(dirAxis * markerScale * gContext.mScreenFactor, gContext.mMVP);
+               ImVec2 worldDirSSpace = worldToPos((dirAxis * markerScale * scaleDisplay[i]) * gContext.mScreenFactor, gContext.mMVPLocal);
+
+#if 0
+               if (gContext.mbUsing && (gContext.mActualID == -1 || gContext.mActualID == gContext.mEditingID))
+               {
+                  drawList->AddLine(baseSSpace, worldDirSSpaceNoScale, IM_COL32(0x40, 0x40, 0x40, 0xFF), 3.f);
+                  drawList->AddCircleFilled(worldDirSSpaceNoScale, 6.f, IM_COL32(0x40, 0x40, 0x40, 0xFF));
+               }
+               /*
+               if (!hasTranslateOnAxis || gContext.mbUsing)
+               {
+                  drawList->AddLine(baseSSpace, worldDirSSpace, colors[i + 1], 3.f);
+               }
+               */
+#endif
+               drawList->AddCircleFilled(worldDirSSpace, 12.f, colors[i + 1]);
+            }
+         }
+      }
+
+      // draw screen cirle
+      drawList->AddCircle(gContext.mScreenSquareCenter, 20.f, colors[0], 32, gContext.mStyle.CenterCircleSize);
+
+      if (gContext.mbUsing && (gContext.mActualID == -1 || gContext.mActualID == gContext.mEditingID) && IsScaleType(type))
+      {
+         //ImVec2 sourcePosOnScreen = worldToPos(gContext.mMatrixOrigin, gContext.mViewProjection);
+         ImVec2 destinationPosOnScreen = worldToPos(gContext.mModel.v.position, gContext.mViewProjection);
+         /*vec_t dif(destinationPosOnScreen.x - sourcePosOnScreen.x, destinationPosOnScreen.y - sourcePosOnScreen.y);
+         dif.Normalize();
+         dif *= 5.f;
+         drawList->AddCircle(sourcePosOnScreen, 6.f, translationLineColor);
+         drawList->AddCircle(destinationPosOnScreen, 6.f, translationLineColor);
+         drawList->AddLine(ImVec2(sourcePosOnScreen.x + dif.x, sourcePosOnScreen.y + dif.y), ImVec2(destinationPosOnScreen.x - dif.x, destinationPosOnScreen.y - dif.y), translationLineColor, 2.f);
+         */
+         char tmps[512];
+         //vec_t deltaInfo = gContext.mModel.v.position - gContext.mMatrixOrigin;
+         int componentInfoIndex = (type - MT_SCALE_X) * 3;
+         ImFormatString(tmps, sizeof(tmps), scaleInfoMask[type - MT_SCALE_X], scaleDisplay[translationInfoIndex[componentInfoIndex]]);
+         drawList->AddText(ImVec2(destinationPosOnScreen.x + 15, destinationPosOnScreen.y + 15), GetColorU32(TEXT_SHADOW), tmps);
+         drawList->AddText(ImVec2(destinationPosOnScreen.x + 14, destinationPosOnScreen.y + 14), GetColorU32(TEXT), tmps);
+      }
+   }
+
+   static void DrawTranslationGizmo(OPERATION op, int type)
+   {
+      ImDrawList* drawList = gContext.mDrawList;
+      if (!drawList)
+      {
+         return;
+      }
+
+      if(!Intersects(op, TRANSLATE))
+      {
+         return;
+      }
+
+      // colors
+      ImU32 colors[7];
+      ComputeColors(colors, type, TRANSLATE);
+
+      const ImVec2 origin = worldToPos(gContext.mModel.v.position, gContext.mViewProjection);
+
+      // draw
+      bool belowAxisLimit = false;
+      bool belowPlaneLimit = false;
+      for (int i = 0; i < 3; ++i)
+      {
+         vec_t dirPlaneX, dirPlaneY, dirAxis;
+         ComputeTripodAxisAndVisibility(i, dirAxis, dirPlaneX, dirPlaneY, belowAxisLimit, belowPlaneLimit);
+
+         if (!gContext.mbUsing || (gContext.mbUsing && type == MT_MOVE_X + i))
+         {
+            // draw axis
+            if (belowAxisLimit && Intersects(op, static_cast<OPERATION>(TRANSLATE_X << i)))
+            {
+               ImVec2 baseSSpace = worldToPos(dirAxis * 0.1f * gContext.mScreenFactor, gContext.mMVP);
+               ImVec2 worldDirSSpace = worldToPos(dirAxis * gContext.mScreenFactor, gContext.mMVP);
+
+               drawList->AddLine(baseSSpace, worldDirSSpace, colors[i + 1], gContext.mStyle.TranslationLineThickness);
+
+               // Arrow head begin
+               ImVec2 dir(origin - worldDirSSpace);
+
+               float d = sqrtf(ImLengthSqr(dir));
+               dir /= d; // Normalize
+               dir *= gContext.mStyle.TranslationLineArrowSize;
+
+               ImVec2 ortogonalDir(dir.y, -dir.x); // Perpendicular vector
+               ImVec2 a(worldDirSSpace + dir);
+               drawList->AddTriangleFilled(worldDirSSpace - dir, a + ortogonalDir, a - ortogonalDir, colors[i + 1]);
+               // Arrow head end
+
+               if (gContext.mAxisFactor[i] < 0.f)
+               {
+                  DrawHatchedAxis(dirAxis);
+               }
+            }
+         }
+         // draw plane
+         if (!gContext.mbUsing || (gContext.mbUsing && type == MT_MOVE_YZ + i))
+         {
+            if (belowPlaneLimit && Contains(op, TRANSLATE_PLANS[i]))
+            {
+               ImVec2 screenQuadPts[4];
+               for (int j = 0; j < 4; ++j)
+               {
+                  vec_t cornerWorldPos = (dirPlaneX * quadUV[j * 2] + dirPlaneY * quadUV[j * 2 + 1]) * gContext.mScreenFactor;
+                  screenQuadPts[j] = worldToPos(cornerWorldPos, gContext.mMVP);
+               }
+               drawList->AddPolyline(screenQuadPts, 4, GetColorU32(DIRECTION_X + i), true, 1.0f);
+               drawList->AddConvexPolyFilled(screenQuadPts, 4, colors[i + 4]);
+            }
+         }
+      }
+
+      drawList->AddCircleFilled(gContext.mScreenSquareCenter, gContext.mStyle.CenterCircleSize, colors[0], 32);
+
+      if (gContext.mbUsing && (gContext.mActualID == -1 || gContext.mActualID == gContext.mEditingID) && IsTranslateType(type))
+      {
+         ImU32 translationLineColor = GetColorU32(TRANSLATION_LINE);
+
+         ImVec2 sourcePosOnScreen = worldToPos(gContext.mMatrixOrigin, gContext.mViewProjection);
+         ImVec2 destinationPosOnScreen = worldToPos(gContext.mModel.v.position, gContext.mViewProjection);
+         vec_t dif = { destinationPosOnScreen.x - sourcePosOnScreen.x, destinationPosOnScreen.y - sourcePosOnScreen.y, 0.f, 0.f };
+         dif.Normalize();
+         dif *= 5.f;
+         drawList->AddCircle(sourcePosOnScreen, 6.f, translationLineColor);
+         drawList->AddCircle(destinationPosOnScreen, 6.f, translationLineColor);
+         drawList->AddLine(ImVec2(sourcePosOnScreen.x + dif.x, sourcePosOnScreen.y + dif.y), ImVec2(destinationPosOnScreen.x - dif.x, destinationPosOnScreen.y - dif.y), translationLineColor, 2.f);
+
+         char tmps[512];
+         vec_t deltaInfo = gContext.mModel.v.position - gContext.mMatrixOrigin;
+         int componentInfoIndex = (type - MT_MOVE_X) * 3;
+         ImFormatString(tmps, sizeof(tmps), translationInfoMask[type - MT_MOVE_X], deltaInfo[translationInfoIndex[componentInfoIndex]], deltaInfo[translationInfoIndex[componentInfoIndex + 1]], deltaInfo[translationInfoIndex[componentInfoIndex + 2]]);
+         drawList->AddText(ImVec2(destinationPosOnScreen.x + 15, destinationPosOnScreen.y + 15), GetColorU32(TEXT_SHADOW), tmps);
+         drawList->AddText(ImVec2(destinationPosOnScreen.x + 14, destinationPosOnScreen.y + 14), GetColorU32(TEXT), tmps);
+      }
+   }
+
+   static bool CanActivate()
+   {
+      // PREDITOR BEGIN
+      if (ImGui::IsMouseClicked(0) && ImGui::IsItemHovered())
+      {
+         return true;
+      }
+      return false;
+      // PREDITOR END
+   }
+
+   static void HandleAndDrawLocalBounds(const float* bounds, matrix_t* matrix, const float* snapValues, OPERATION operation)
+   {
+      ImGuiIO& io = ImGui::GetIO();
+      ImDrawList* drawList = gContext.mDrawList;
+
+      // compute best projection axis
+      vec_t axesWorldDirections[3];
+      vec_t bestAxisWorldDirection = { 0.0f, 0.0f, 0.0f, 0.0f };
+      int axes[3];
+      unsigned int numAxes = 1;
+      axes[0] = gContext.mBoundsBestAxis;
+      int bestAxis = axes[0];
+      if (!gContext.mbUsingBounds)
+      {
+         numAxes = 0;
+         float bestDot = 0.f;
+         for (int i = 0; i < 3; i++)
+         {
+            vec_t dirPlaneNormalWorld;
+            dirPlaneNormalWorld.TransformVector(directionUnary[i], gContext.mModelSource);
+            dirPlaneNormalWorld.Normalize();
+
+            float dt = fabsf(Dot(Normalized(gContext.mCameraEye - gContext.mModelSource.v.position), dirPlaneNormalWorld));
+            if (dt >= bestDot)
+            {
+               bestDot = dt;
+               bestAxis = i;
+               bestAxisWorldDirection = dirPlaneNormalWorld;
+            }
+
+            if (dt >= 0.1f)
+            {
+               axes[numAxes] = i;
+               axesWorldDirections[numAxes] = dirPlaneNormalWorld;
+               ++numAxes;
+            }
+         }
+      }
+
+      if (numAxes == 0)
+      {
+         axes[0] = bestAxis;
+         axesWorldDirections[0] = bestAxisWorldDirection;
+         numAxes = 1;
+      }
+
+      else if (bestAxis != axes[0])
+      {
+         unsigned int bestIndex = 0;
+         for (unsigned int i = 0; i < numAxes; i++)
+         {
+            if (axes[i] == bestAxis)
+            {
+               bestIndex = i;
+               break;
+            }
+         }
+         int tempAxis = axes[0];
+         axes[0] = axes[bestIndex];
+         axes[bestIndex] = tempAxis;
+         vec_t tempDirection = axesWorldDirections[0];
+         axesWorldDirections[0] = axesWorldDirections[bestIndex];
+         axesWorldDirections[bestIndex] = tempDirection;
+      }
+
+      for (unsigned int axisIndex = 0; axisIndex < numAxes; ++axisIndex)
+      {
+         bestAxis = axes[axisIndex];
+         bestAxisWorldDirection = axesWorldDirections[axisIndex];
+
+         // corners
+         vec_t aabb[4];
+
+         int secondAxis = (bestAxis + 1) % 3;
+         int thirdAxis = (bestAxis + 2) % 3;
+
+         for (int i = 0; i < 4; i++)
+         {
+            aabb[i][3] = aabb[i][bestAxis] = 0.f;
+            aabb[i][secondAxis] = bounds[secondAxis + 3 * (i >> 1)];
+            aabb[i][thirdAxis] = bounds[thirdAxis + 3 * ((i >> 1) ^ (i & 1))];
+         }
+
+         // draw bounds
+         unsigned int anchorAlpha = gContext.mbEnable ? IM_COL32_BLACK : IM_COL32(0, 0, 0, 0x80);
+
+         matrix_t boundsMVP = gContext.mModelSource * gContext.mViewProjection;
+         for (int i = 0; i < 4; i++)
+         {
+            ImVec2 worldBound1 = worldToPos(aabb[i], boundsMVP);
+            ImVec2 worldBound2 = worldToPos(aabb[(i + 1) % 4], boundsMVP);
+            if (!IsInContextRect(worldBound1) || !IsInContextRect(worldBound2))
+            {
+               continue;
+            }
+            float boundDistance = sqrtf(ImLengthSqr(worldBound1 - worldBound2));
+            int stepCount = (int)(boundDistance / 10.f);
+            stepCount = min(stepCount, 1000);
+            for (int j = 0; j < stepCount; j++)
+            {
+               float stepLength = 1.f / (float)stepCount;
+               float t1 = (float)j * stepLength;
+               float t2 = (float)j * stepLength + stepLength * 0.5f;
+               ImVec2 worldBoundSS1 = ImLerp(worldBound1, worldBound2, ImVec2(t1, t1));
+               ImVec2 worldBoundSS2 = ImLerp(worldBound1, worldBound2, ImVec2(t2, t2));
+               //drawList->AddLine(worldBoundSS1, worldBoundSS2, IM_COL32(0, 0, 0, 0) + anchorAlpha, 3.f);
+               drawList->AddLine(worldBoundSS1, worldBoundSS2, IM_COL32(0xAA, 0xAA, 0xAA, 0) + anchorAlpha, 2.f);
+            }
+            vec_t midPoint = (aabb[i] + aabb[(i + 1) % 4]) * 0.5f;
+            ImVec2 midBound = worldToPos(midPoint, boundsMVP);
+            static const float AnchorBigRadius = 8.f;
+            static const float AnchorSmallRadius = 6.f;
+            bool overBigAnchor = ImLengthSqr(worldBound1 - io.MousePos) <= (AnchorBigRadius * AnchorBigRadius);
+            bool overSmallAnchor = ImLengthSqr(midBound - io.MousePos) <= (AnchorBigRadius * AnchorBigRadius);
+
+            int type = MT_NONE;
+            vec_t gizmoHitProportion;
+
+            if(Intersects(operation, TRANSLATE))
+            {
+               type = GetMoveType(operation, &gizmoHitProportion);
+            }
+            if(Intersects(operation, ROTATE) && type == MT_NONE)
+            {
+               type = GetRotateType(operation);
+            }
+            if(Intersects(operation, SCALE) && type == MT_NONE)
+            {
+               type = GetScaleType(operation);
+            }
+
+            if (type != MT_NONE)
+            {
+               overBigAnchor = false;
+               overSmallAnchor = false;
+            }
+
+            ImU32 selectionColor = GetColorU32(SELECTION);
+
+            unsigned int bigAnchorColor = overBigAnchor ? selectionColor : (IM_COL32(0xAA, 0xAA, 0xAA, 0) + anchorAlpha);
+            unsigned int smallAnchorColor = overSmallAnchor ? selectionColor : (IM_COL32(0xAA, 0xAA, 0xAA, 0) + anchorAlpha);
+
+            drawList->AddCircleFilled(worldBound1, AnchorBigRadius, IM_COL32_BLACK);
+            drawList->AddCircleFilled(worldBound1, AnchorBigRadius - 1.2f, bigAnchorColor);
+
+            drawList->AddCircleFilled(midBound, AnchorSmallRadius, IM_COL32_BLACK);
+            drawList->AddCircleFilled(midBound, AnchorSmallRadius - 1.2f, smallAnchorColor);
+            int oppositeIndex = (i + 2) % 4;
+            // big anchor on corners
+            if (!gContext.mbUsingBounds && gContext.mbEnable && overBigAnchor && CanActivate())
+            {
+               gContext.mBoundsPivot.TransformPoint(aabb[(i + 2) % 4], gContext.mModelSource);
+               gContext.mBoundsAnchor.TransformPoint(aabb[i], gContext.mModelSource);
+               gContext.mBoundsPlan = BuildPlan(gContext.mBoundsAnchor, bestAxisWorldDirection);
+               gContext.mBoundsBestAxis = bestAxis;
+               gContext.mBoundsAxis[0] = secondAxis;
+               gContext.mBoundsAxis[1] = thirdAxis;
+
+               gContext.mBoundsLocalPivot.Set(0.f);
+               gContext.mBoundsLocalPivot[secondAxis] = aabb[oppositeIndex][secondAxis];
+               gContext.mBoundsLocalPivot[thirdAxis] = aabb[oppositeIndex][thirdAxis];
+
+               gContext.mbUsingBounds = true;
+               gContext.mEditingID = gContext.mActualID;
+               gContext.mBoundsMatrix = gContext.mModelSource;
+            }
+            // small anchor on middle of segment
+            if (!gContext.mbUsingBounds && gContext.mbEnable && overSmallAnchor && CanActivate())
+            {
+               vec_t midPointOpposite = (aabb[(i + 2) % 4] + aabb[(i + 3) % 4]) * 0.5f;
+               gContext.mBoundsPivot.TransformPoint(midPointOpposite, gContext.mModelSource);
+               gContext.mBoundsAnchor.TransformPoint(midPoint, gContext.mModelSource);
+               gContext.mBoundsPlan = BuildPlan(gContext.mBoundsAnchor, bestAxisWorldDirection);
+               gContext.mBoundsBestAxis = bestAxis;
+               int indices[] = { secondAxis , thirdAxis };
+               gContext.mBoundsAxis[0] = indices[i % 2];
+               gContext.mBoundsAxis[1] = -1;
+
+               gContext.mBoundsLocalPivot.Set(0.f);
+               gContext.mBoundsLocalPivot[gContext.mBoundsAxis[0]] = aabb[oppositeIndex][indices[i % 2]];// bounds[gContext.mBoundsAxis[0]] * (((i + 1) & 2) ? 1.f : -1.f);
+
+               gContext.mbUsingBounds = true;
+               gContext.mEditingID = gContext.mActualID;
+               gContext.mBoundsMatrix = gContext.mModelSource;
+            }
+         }
+
+         if (gContext.mbUsingBounds && (gContext.mActualID == -1 || gContext.mActualID == gContext.mEditingID))
+         {
+            matrix_t scale;
+            scale.SetToIdentity();
+
+            // compute projected mouse position on plan
+            const float len = IntersectRayPlane(gContext.mRayOrigin, gContext.mRayVector, gContext.mBoundsPlan);
+            vec_t newPos = gContext.mRayOrigin + gContext.mRayVector * len;
+
+            // compute a reference and delta vectors base on mouse move
+            vec_t deltaVector = (newPos - gContext.mBoundsPivot).Abs();
+            vec_t referenceVector = (gContext.mBoundsAnchor - gContext.mBoundsPivot).Abs();
+
+            // for 1 or 2 axes, compute a ratio that's used for scale and snap it based on resulting length
+            for (int i = 0; i < 2; i++)
+            {
+               int axisIndex1 = gContext.mBoundsAxis[i];
+               if (axisIndex1 == -1)
+               {
+                  continue;
+               }
+
+               float ratioAxis = 1.f;
+               vec_t axisDir = gContext.mBoundsMatrix.component[axisIndex1].Abs();
+
+               float dtAxis = axisDir.Dot(referenceVector);
+               float boundSize = bounds[axisIndex1 + 3] - bounds[axisIndex1];
+               if (dtAxis > FLT_EPSILON)
+               {
+                  ratioAxis = axisDir.Dot(deltaVector) / dtAxis;
+               }
+
+               if (snapValues)
+               {
+                  float length = boundSize * ratioAxis;
+                  ComputeSnap(&length, snapValues[axisIndex1]);
+                  if (boundSize > FLT_EPSILON)
+                  {
+                     ratioAxis = length / boundSize;
+                  }
+               }
+               scale.component[axisIndex1] *= ratioAxis;
+            }
+
+            // transform matrix
+            matrix_t preScale, postScale;
+            preScale.Translation(-gContext.mBoundsLocalPivot);
+            postScale.Translation(gContext.mBoundsLocalPivot);
+            matrix_t res = preScale * scale * postScale * gContext.mBoundsMatrix;
+            *matrix = res;
+
+            // info text
+            char tmps[512];
+            ImVec2 destinationPosOnScreen = worldToPos(gContext.mModel.v.position, gContext.mViewProjection);
+            ImFormatString(tmps, sizeof(tmps), "X: %.2f Y: %.2f Z: %.2f"
+               , (bounds[3] - bounds[0]) * gContext.mBoundsMatrix.component[0].Length() * scale.component[0].Length()
+               , (bounds[4] - bounds[1]) * gContext.mBoundsMatrix.component[1].Length() * scale.component[1].Length()
+               , (bounds[5] - bounds[2]) * gContext.mBoundsMatrix.component[2].Length() * scale.component[2].Length()
+            );
+            drawList->AddText(ImVec2(destinationPosOnScreen.x + 15, destinationPosOnScreen.y + 15), GetColorU32(TEXT_SHADOW), tmps);
+            drawList->AddText(ImVec2(destinationPosOnScreen.x + 14, destinationPosOnScreen.y + 14), GetColorU32(TEXT), tmps);
+         }
+
+         if (!io.MouseDown[0]) {
+            gContext.mbUsingBounds = false;
+            gContext.mEditingID = -1;
+         }
+         if (gContext.mbUsingBounds)
+         {
+            break;
+         }
+      }
+   }
+
+   ///////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+   //
+
+   static int GetScaleType(OPERATION op)
+   {
+      if (gContext.mbUsing)
+      {
+         return MT_NONE;
+      }
+      ImGuiIO& io = ImGui::GetIO();
+      int type = MT_NONE;
+
+      // screen
+      if (io.MousePos.x >= gContext.mScreenSquareMin.x && io.MousePos.x <= gContext.mScreenSquareMax.x &&
+         io.MousePos.y >= gContext.mScreenSquareMin.y && io.MousePos.y <= gContext.mScreenSquareMax.y &&
+         Contains(op, SCALE))
+      {
+         type = MT_SCALE_XYZ;
+      }
+
+      // compute
+      for (int i = 0; i < 3 && type == MT_NONE; i++)
+      {
+         if(!Intersects(op, static_cast<OPERATION>(SCALE_X << i)))
+         {
+            continue;
+         }
+         vec_t dirPlaneX, dirPlaneY, dirAxis;
+         bool belowAxisLimit, belowPlaneLimit;
+         ComputeTripodAxisAndVisibility(i, dirAxis, dirPlaneX, dirPlaneY, belowAxisLimit, belowPlaneLimit, true);
+         dirAxis.TransformVector(gContext.mModelLocal);
+         dirPlaneX.TransformVector(gContext.mModelLocal);
+         dirPlaneY.TransformVector(gContext.mModelLocal);
+
+         const float len = IntersectRayPlane(gContext.mRayOrigin, gContext.mRayVector, BuildPlan(gContext.mModelLocal.v.position, dirAxis));
+         vec_t posOnPlan = gContext.mRayOrigin + gContext.mRayVector * len;
+
+         const float startOffset = Contains(op, static_cast<OPERATION>(TRANSLATE_X << i)) ? 1.0f : 0.1f;
+         const float endOffset = Contains(op, static_cast<OPERATION>(TRANSLATE_X << i)) ? 1.4f : 1.0f;
+         const ImVec2 posOnPlanScreen = worldToPos(posOnPlan, gContext.mViewProjection);
+         const ImVec2 axisStartOnScreen = worldToPos(gContext.mModelLocal.v.position + dirAxis * gContext.mScreenFactor * startOffset, gContext.mViewProjection);
+         const ImVec2 axisEndOnScreen = worldToPos(gContext.mModelLocal.v.position + dirAxis * gContext.mScreenFactor * endOffset, gContext.mViewProjection);
+
+         vec_t closestPointOnAxis = PointOnSegment(makeVect(posOnPlanScreen), makeVect(axisStartOnScreen), makeVect(axisEndOnScreen));
+
+         if ((closestPointOnAxis - makeVect(posOnPlanScreen)).Length() < 12.f) // pixel size
+         {
+            type = MT_SCALE_X + i;
+         }
+      }
+
+      // universal
+
+      vec_t deltaScreen = { io.MousePos.x - gContext.mScreenSquareCenter.x, io.MousePos.y - gContext.mScreenSquareCenter.y, 0.f, 0.f };
+      float dist = deltaScreen.Length();
+      if (Contains(op, SCALEU) && dist >= 17.0f && dist < 23.0f)
+      {
+         type = MT_SCALE_XYZ;
+      }
+
+      for (int i = 0; i < 3 && type == MT_NONE; i++)
+      {
+         if (!Intersects(op, static_cast<OPERATION>(SCALE_XU << i)))
+         {
+            continue;
+         }
+
+         vec_t dirPlaneX, dirPlaneY, dirAxis;
+         bool belowAxisLimit, belowPlaneLimit;
+         ComputeTripodAxisAndVisibility(i, dirAxis, dirPlaneX, dirPlaneY, belowAxisLimit, belowPlaneLimit, true);
+
+         // draw axis
+         if (belowAxisLimit)
+         {
+            bool hasTranslateOnAxis = Contains(op, static_cast<OPERATION>(TRANSLATE_X << i));
+            float markerScale = hasTranslateOnAxis ? 1.4f : 1.0f;
+            //ImVec2 baseSSpace = worldToPos(dirAxis * 0.1f * gContext.mScreenFactor, gContext.mMVPLocal);
+            //ImVec2 worldDirSSpaceNoScale = worldToPos(dirAxis * markerScale * gContext.mScreenFactor, gContext.mMVP);
+            ImVec2 worldDirSSpace = worldToPos((dirAxis * markerScale) * gContext.mScreenFactor, gContext.mMVPLocal);
+
+            float distance = sqrtf(ImLengthSqr(worldDirSSpace - io.MousePos));
+            if (distance < 12.f)
+            {
+               type = MT_SCALE_X + i;
+            }
+         }
+      }
+      return type;
+   }
+
+   static int GetRotateType(OPERATION op)
+   {
+      if (gContext.mbUsing)
+      {
+         return MT_NONE;
+      }
+      ImGuiIO& io = ImGui::GetIO();
+      int type = MT_NONE;
+
+      vec_t deltaScreen = { io.MousePos.x - gContext.mScreenSquareCenter.x, io.MousePos.y - gContext.mScreenSquareCenter.y, 0.f, 0.f };
+      float dist = deltaScreen.Length();
+      if (Intersects(op, ROTATE_SCREEN) && dist >= (gContext.mRadiusSquareCenter - 4.0f) && dist < (gContext.mRadiusSquareCenter + 4.0f))
+      {
+         type = MT_ROTATE_SCREEN;
+      }
+
+      const vec_t planNormals[] = { gContext.mModel.v.right, gContext.mModel.v.up, gContext.mModel.v.dir };
+
+      vec_t modelViewPos;
+      modelViewPos.TransformPoint(gContext.mModel.v.position, gContext.mViewMat);
+
+      for (int i = 0; i < 3 && type == MT_NONE; i++)
+      {
+         if(!Intersects(op, static_cast<OPERATION>(ROTATE_X << i)))
+         {
+            continue;
+         }
+         // pickup plan
+         vec_t pickupPlan = BuildPlan(gContext.mModel.v.position, planNormals[i]);
+
+         const float len = IntersectRayPlane(gContext.mRayOrigin, gContext.mRayVector, pickupPlan);
+         const vec_t intersectWorldPos = gContext.mRayOrigin + gContext.mRayVector * len;
+         vec_t intersectViewPos;
+         intersectViewPos.TransformPoint(intersectWorldPos, gContext.mViewMat);
+
+         if (ImAbs(modelViewPos.z) - ImAbs(intersectViewPos.z) < -FLT_EPSILON)
+         {
+            continue;
+         }
+
+         const vec_t localPos = intersectWorldPos - gContext.mModel.v.position;
+         vec_t idealPosOnCircle = Normalized(localPos);
+         idealPosOnCircle.TransformVector(gContext.mModelInverse);
+         const ImVec2 idealPosOnCircleScreen = worldToPos(idealPosOnCircle * rotationDisplayFactor * gContext.mScreenFactor, gContext.mMVP);
+
+         //gContext.mDrawList->AddCircle(idealPosOnCircleScreen, 5.f, IM_COL32_WHITE);
+         const ImVec2 distanceOnScreen = idealPosOnCircleScreen - io.MousePos;
+
+         const float distance = makeVect(distanceOnScreen).Length();
+         if (distance < 8.f) // pixel size
+         {
+            type = MT_ROTATE_X + i;
+         }
+      }
+
+      return type;
+   }
+
+   static int GetMoveType(OPERATION op, vec_t* gizmoHitProportion)
+   {
+      if(!Intersects(op, TRANSLATE) || gContext.mbUsing || !gContext.mbMouseOver)
+      {
+        return MT_NONE;
+      }
+      ImGuiIO& io = ImGui::GetIO();
+      int type = MT_NONE;
+
+      // screen
+      if (io.MousePos.x >= gContext.mScreenSquareMin.x && io.MousePos.x <= gContext.mScreenSquareMax.x &&
+         io.MousePos.y >= gContext.mScreenSquareMin.y && io.MousePos.y <= gContext.mScreenSquareMax.y &&
+         Contains(op, TRANSLATE))
+      {
+         type = MT_MOVE_SCREEN;
+      }
+
+      const vec_t screenCoord = makeVect(io.MousePos - ImVec2(gContext.mX, gContext.mY));
+
+      // compute
+      for (int i = 0; i < 3 && type == MT_NONE; i++)
+      {
+         vec_t dirPlaneX, dirPlaneY, dirAxis;
+         bool belowAxisLimit, belowPlaneLimit;
+         ComputeTripodAxisAndVisibility(i, dirAxis, dirPlaneX, dirPlaneY, belowAxisLimit, belowPlaneLimit);
+         dirAxis.TransformVector(gContext.mModel);
+         dirPlaneX.TransformVector(gContext.mModel);
+         dirPlaneY.TransformVector(gContext.mModel);
+
+         const float len = IntersectRayPlane(gContext.mRayOrigin, gContext.mRayVector, BuildPlan(gContext.mModel.v.position, dirAxis));
+         vec_t posOnPlan = gContext.mRayOrigin + gContext.mRayVector * len;
+
+         const ImVec2 axisStartOnScreen = worldToPos(gContext.mModel.v.position + dirAxis * gContext.mScreenFactor * 0.1f, gContext.mViewProjection) - ImVec2(gContext.mX, gContext.mY);
+         const ImVec2 axisEndOnScreen = worldToPos(gContext.mModel.v.position + dirAxis * gContext.mScreenFactor, gContext.mViewProjection) - ImVec2(gContext.mX, gContext.mY);
+
+         vec_t closestPointOnAxis = PointOnSegment(screenCoord, makeVect(axisStartOnScreen), makeVect(axisEndOnScreen));
+         if ((closestPointOnAxis - screenCoord).Length() < 12.f && Intersects(op, static_cast<OPERATION>(TRANSLATE_X << i))) // pixel size
+         {
+            type = MT_MOVE_X + i;
+         }
+
+         const float dx = dirPlaneX.Dot3((posOnPlan - gContext.mModel.v.position) * (1.f / gContext.mScreenFactor));
+         const float dy = dirPlaneY.Dot3((posOnPlan - gContext.mModel.v.position) * (1.f / gContext.mScreenFactor));
+         if (belowPlaneLimit && dx >= quadUV[0] && dx <= quadUV[4] && dy >= quadUV[1] && dy <= quadUV[3] && Contains(op, TRANSLATE_PLANS[i]))
+         {
+            type = MT_MOVE_YZ + i;
+         }
+
+         if (gizmoHitProportion)
+         {
+            *gizmoHitProportion = makeVect(dx, dy, 0.f);
+         }
+      }
+      return type;
+   }
+
+   static bool HandleTranslation(float* matrix, float* deltaMatrix, OPERATION op, int& type, const float* snap)
+   {
+      if(!Intersects(op, TRANSLATE) || type != MT_NONE)
+      {
+        return false;
+      }
+      const ImGuiIO& io = ImGui::GetIO();
+      const bool applyRotationLocaly = gContext.mMode == LOCAL || type == MT_MOVE_SCREEN;
+      bool modified = false;
+
+      // move
+      if (gContext.mbUsing && (gContext.mActualID == -1 || gContext.mActualID == gContext.mEditingID) && IsTranslateType(gContext.mCurrentOperation))
+      {
+#if IMGUI_VERSION_NUM >= 18723
+         ImGui::SetNextFrameWantCaptureMouse(true);
+#else
+         ImGui::CaptureMouseFromApp();
+#endif
+         const float signedLength = IntersectRayPlane(gContext.mRayOrigin, gContext.mRayVector, gContext.mTranslationPlan);
+         const float len = fabsf(signedLength); // near plan
+         const vec_t newPos = gContext.mRayOrigin + gContext.mRayVector * len;
+
+         // compute delta
+         const vec_t newOrigin = newPos - gContext.mRelativeOrigin * gContext.mScreenFactor;
+         vec_t delta = newOrigin - gContext.mModel.v.position;
+
+         // 1 axis constraint
+         if (gContext.mCurrentOperation >= MT_MOVE_X && gContext.mCurrentOperation <= MT_MOVE_Z)
+         {
+            const int axisIndex = gContext.mCurrentOperation - MT_MOVE_X;
+            const vec_t& axisValue = *(vec_t*)&gContext.mModel.m[axisIndex];
+            const float lengthOnAxis = Dot(axisValue, delta);
+            delta = axisValue * lengthOnAxis;
+         }
+
+         // snap
+         if (snap)
+         {
+            vec_t cumulativeDelta = gContext.mModel.v.position + delta - gContext.mMatrixOrigin;
+            if (applyRotationLocaly)
+            {
+               matrix_t modelSourceNormalized = gContext.mModelSource;
+               modelSourceNormalized.OrthoNormalize();
+               matrix_t modelSourceNormalizedInverse;
+               modelSourceNormalizedInverse.Inverse(modelSourceNormalized);
+               cumulativeDelta.TransformVector(modelSourceNormalizedInverse);
+               ComputeSnap(cumulativeDelta, snap);
+               cumulativeDelta.TransformVector(modelSourceNormalized);
+            }
+            else
+            {
+               ComputeSnap(cumulativeDelta, snap);
+            }
+            delta = gContext.mMatrixOrigin + cumulativeDelta - gContext.mModel.v.position;
+
+         }
+
+         if (delta != gContext.mTranslationLastDelta)
+         {
+            modified = true;
+         }
+         gContext.mTranslationLastDelta = delta;
+
+         // compute matrix & delta
+         matrix_t deltaMatrixTranslation;
+         deltaMatrixTranslation.Translation(delta);
+         if (deltaMatrix)
+         {
+            memcpy(deltaMatrix, deltaMatrixTranslation.m16, sizeof(float) * 16);
+         }
+
+         const matrix_t res = gContext.mModelSource * deltaMatrixTranslation;
+         *(matrix_t*)matrix = res;
+
+         if (!io.MouseDown[0])
+         {
+            gContext.mbUsing = false;
+         }
+
+         type = gContext.mCurrentOperation;
+      }
+      else
+      {
+         // find new possible way to move
+         vec_t gizmoHitProportion;
+         type = GetMoveType(op, &gizmoHitProportion);
+         if (type != MT_NONE)
+         {
+#if IMGUI_VERSION_NUM >= 18723
+            ImGui::SetNextFrameWantCaptureMouse(true);
+#else
+            ImGui::CaptureMouseFromApp();
+#endif
+         }
+         if (CanActivate() && type != MT_NONE)
+         {
+            gContext.mbUsing = true;
+            gContext.mEditingID = gContext.mActualID;
+            gContext.mCurrentOperation = type;
+            vec_t movePlanNormal[] = { gContext.mModel.v.right, gContext.mModel.v.up, gContext.mModel.v.dir,
+               gContext.mModel.v.right, gContext.mModel.v.up, gContext.mModel.v.dir,
+               -gContext.mCameraDir };
+
+            vec_t cameraToModelNormalized = Normalized(gContext.mModel.v.position - gContext.mCameraEye);
+            for (unsigned int i = 0; i < 3; i++)
+            {
+               vec_t orthoVector = Cross(movePlanNormal[i], cameraToModelNormalized);
+               movePlanNormal[i].Cross(orthoVector);
+               movePlanNormal[i].Normalize();
+            }
+            // pickup plan
+            gContext.mTranslationPlan = BuildPlan(gContext.mModel.v.position, movePlanNormal[type - MT_MOVE_X]);
+            const float len = IntersectRayPlane(gContext.mRayOrigin, gContext.mRayVector, gContext.mTranslationPlan);
+            gContext.mTranslationPlanOrigin = gContext.mRayOrigin + gContext.mRayVector * len;
+            gContext.mMatrixOrigin = gContext.mModel.v.position;
+
+            gContext.mRelativeOrigin = (gContext.mTranslationPlanOrigin - gContext.mModel.v.position) * (1.f / gContext.mScreenFactor);
+         }
+      }
+      return modified;
+   }
+
+   static bool HandleScale(float* matrix, float* deltaMatrix, OPERATION op, int& type, const float* snap)
+   {
+      if((!Intersects(op, SCALE) && !Intersects(op, SCALEU)) || type != MT_NONE || !gContext.mbMouseOver)
+      {
+         return false;
+      }
+      ImGuiIO& io = ImGui::GetIO();
+      bool modified = false;
+
+      if (!gContext.mbUsing)
+      {
+         // find new possible way to scale
+         type = GetScaleType(op);
+         if (type != MT_NONE)
+         {
+#if IMGUI_VERSION_NUM >= 18723
+            ImGui::SetNextFrameWantCaptureMouse(true);
+#else
+            ImGui::CaptureMouseFromApp();
+#endif
+         }
+         if (CanActivate() && type != MT_NONE)
+         {
+            gContext.mbUsing = true;
+            gContext.mEditingID = gContext.mActualID;
+            gContext.mCurrentOperation = type;
+            const vec_t movePlanNormal[] = { gContext.mModel.v.up, gContext.mModel.v.dir, gContext.mModel.v.right, gContext.mModel.v.dir, gContext.mModel.v.up, gContext.mModel.v.right, -gContext.mCameraDir };
+            // pickup plan
+
+            gContext.mTranslationPlan = BuildPlan(gContext.mModel.v.position, movePlanNormal[type - MT_SCALE_X]);
+            const float len = IntersectRayPlane(gContext.mRayOrigin, gContext.mRayVector, gContext.mTranslationPlan);
+            gContext.mTranslationPlanOrigin = gContext.mRayOrigin + gContext.mRayVector * len;
+            gContext.mMatrixOrigin = gContext.mModel.v.position;
+            gContext.mScale.Set(1.f, 1.f, 1.f);
+            gContext.mRelativeOrigin = (gContext.mTranslationPlanOrigin - gContext.mModel.v.position) * (1.f / gContext.mScreenFactor);
+            gContext.mScaleValueOrigin = makeVect(gContext.mModelSource.v.right.Length(), gContext.mModelSource.v.up.Length(), gContext.mModelSource.v.dir.Length());
+            gContext.mSaveMousePosx = io.MousePos.x;
+         }
+      }
+      // scale
+      if (gContext.mbUsing && (gContext.mActualID == -1 || gContext.mActualID == gContext.mEditingID) && IsScaleType(gContext.mCurrentOperation))
+      {
+#if IMGUI_VERSION_NUM >= 18723
+         ImGui::SetNextFrameWantCaptureMouse(true);
+#else
+         ImGui::CaptureMouseFromApp();
+#endif
+         const float len = IntersectRayPlane(gContext.mRayOrigin, gContext.mRayVector, gContext.mTranslationPlan);
+         vec_t newPos = gContext.mRayOrigin + gContext.mRayVector * len;
+         vec_t newOrigin = newPos - gContext.mRelativeOrigin * gContext.mScreenFactor;
+         vec_t delta = newOrigin - gContext.mModelLocal.v.position;
+
+         // 1 axis constraint
+         if (gContext.mCurrentOperation >= MT_SCALE_X && gContext.mCurrentOperation <= MT_SCALE_Z)
+         {
+            int axisIndex = gContext.mCurrentOperation - MT_SCALE_X;
+            const vec_t& axisValue = *(vec_t*)&gContext.mModelLocal.m[axisIndex];
+            float lengthOnAxis = Dot(axisValue, delta);
+            delta = axisValue * lengthOnAxis;
+
+            vec_t baseVector = gContext.mTranslationPlanOrigin - gContext.mModelLocal.v.position;
+            float ratio = Dot(axisValue, baseVector + delta) / Dot(axisValue, baseVector);
+
+            gContext.mScale[axisIndex] = max(ratio, 0.001f);
+         }
+         else
+         {
+            float scaleDelta = (io.MousePos.x - gContext.mSaveMousePosx) * 0.01f;
+            gContext.mScale.Set(max(1.f + scaleDelta, 0.001f));
+         }
+
+         // snap
+         if (snap)
+         {
+            float scaleSnap[] = { snap[0], snap[0], snap[0] };
+            ComputeSnap(gContext.mScale, scaleSnap);
+         }
+
+         // no 0 allowed
+         for (int i = 0; i < 3; i++)
+            gContext.mScale[i] = max(gContext.mScale[i], 0.001f);
+
+         if (gContext.mScaleLast != gContext.mScale)
+         {
+            modified = true;
+         }
+         gContext.mScaleLast = gContext.mScale;
+
+         // compute matrix & delta
+         matrix_t deltaMatrixScale;
+         deltaMatrixScale.Scale(gContext.mScale * gContext.mScaleValueOrigin);
+
+         matrix_t res = deltaMatrixScale * gContext.mModelLocal;
+         *(matrix_t*)matrix = res;
+
+         if (deltaMatrix)
+         {
+            vec_t deltaScale = gContext.mScale * gContext.mScaleValueOrigin;
+
+            vec_t originalScaleDivider;
+            originalScaleDivider.x = 1 / gContext.mModelScaleOrigin.x;
+            originalScaleDivider.y = 1 / gContext.mModelScaleOrigin.y;
+            originalScaleDivider.z = 1 / gContext.mModelScaleOrigin.z;
+
+            deltaScale = deltaScale * originalScaleDivider;
+
+            deltaMatrixScale.Scale(deltaScale);
+            memcpy(deltaMatrix, deltaMatrixScale.m16, sizeof(float) * 16);
+         }
+
+         if (!io.MouseDown[0])
+         {
+            gContext.mbUsing = false;
+            gContext.mScale.Set(1.f, 1.f, 1.f);
+         }
+
+         type = gContext.mCurrentOperation;
+      }
+      return modified;
+   }
+
+   static bool HandleRotation(float* matrix, float* deltaMatrix, OPERATION op, int& type, const float* snap)
+   {
+      if(!Intersects(op, ROTATE) || type != MT_NONE || !gContext.mbMouseOver)
+      {
+        return false;
+      }
+      ImGuiIO& io = ImGui::GetIO();
+      bool applyRotationLocaly = gContext.mMode == LOCAL;
+      bool modified = false;
+
+      if (!gContext.mbUsing)
+      {
+         type = GetRotateType(op);
+
+         if (type != MT_NONE)
+         {
+#if IMGUI_VERSION_NUM >= 18723
+            ImGui::SetNextFrameWantCaptureMouse(true);
+#else
+            ImGui::CaptureMouseFromApp();
+#endif
+         }
+
+         if (type == MT_ROTATE_SCREEN)
+         {
+            applyRotationLocaly = true;
+         }
+
+         if (CanActivate() && type != MT_NONE)
+         {
+            gContext.mbUsing = true;
+            gContext.mEditingID = gContext.mActualID;
+            gContext.mCurrentOperation = type;
+            const vec_t rotatePlanNormal[] = { gContext.mModel.v.right, gContext.mModel.v.up, gContext.mModel.v.dir, -gContext.mCameraDir };
+            // pickup plan
+            if (applyRotationLocaly)
+            {
+               gContext.mTranslationPlan = BuildPlan(gContext.mModel.v.position, rotatePlanNormal[type - MT_ROTATE_X]);
+            }
+            else
+            {
+               gContext.mTranslationPlan = BuildPlan(gContext.mModelSource.v.position, directionUnary[type - MT_ROTATE_X]);
+            }
+
+            const float len = IntersectRayPlane(gContext.mRayOrigin, gContext.mRayVector, gContext.mTranslationPlan);
+            vec_t localPos = gContext.mRayOrigin + gContext.mRayVector * len - gContext.mModel.v.position;
+            gContext.mRotationVectorSource = Normalized(localPos);
+            gContext.mRotationAngleOrigin = ComputeAngleOnPlan();
+         }
+      }
+
+      // rotation
+      if (gContext.mbUsing && (gContext.mActualID == -1 || gContext.mActualID == gContext.mEditingID) && IsRotateType(gContext.mCurrentOperation))
+      {
+#if IMGUI_VERSION_NUM >= 18723
+         ImGui::SetNextFrameWantCaptureMouse(true);
+#else
+         ImGui::CaptureMouseFromApp();
+#endif
+         gContext.mRotationAngle = ComputeAngleOnPlan();
+         if (snap)
+         {
+            float snapInRadian = snap[0] * DEG2RAD;
+            ComputeSnap(&gContext.mRotationAngle, snapInRadian);
+         }
+         vec_t rotationAxisLocalSpace;
+
+         rotationAxisLocalSpace.TransformVector(makeVect(gContext.mTranslationPlan.x, gContext.mTranslationPlan.y, gContext.mTranslationPlan.z, 0.f), gContext.mModelInverse);
+         rotationAxisLocalSpace.Normalize();
+
+         matrix_t deltaRotation;
+         deltaRotation.RotationAxis(rotationAxisLocalSpace, gContext.mRotationAngle - gContext.mRotationAngleOrigin);
+         if (gContext.mRotationAngle != gContext.mRotationAngleOrigin)
+         {
+            modified = true;
+         }
+         gContext.mRotationAngleOrigin = gContext.mRotationAngle;
+
+         matrix_t scaleOrigin;
+         scaleOrigin.Scale(gContext.mModelScaleOrigin);
+
+         if (applyRotationLocaly)
+         {
+            *(matrix_t*)matrix = scaleOrigin * deltaRotation * gContext.mModelLocal;
+         }
+         else
+         {
+            matrix_t res = gContext.mModelSource;
+            res.v.position.Set(0.f);
+
+            *(matrix_t*)matrix = res * deltaRotation;
+            ((matrix_t*)matrix)->v.position = gContext.mModelSource.v.position;
+         }
+
+         if (deltaMatrix)
+         {
+            *(matrix_t*)deltaMatrix = gContext.mModelInverse * deltaRotation * gContext.mModel;
+         }
+
+         if (!io.MouseDown[0])
+         {
+            gContext.mbUsing = false;
+            gContext.mEditingID = -1;
+         }
+         type = gContext.mCurrentOperation;
+      }
+      return modified;
+   }
+
+   void DecomposeMatrixToComponents(const float* matrix, float* translation, float* rotation, float* scale)
+   {
+      matrix_t mat = *(matrix_t*)matrix;
+
+      scale[0] = mat.v.right.Length();
+      scale[1] = mat.v.up.Length();
+      scale[2] = mat.v.dir.Length();
+
+      mat.OrthoNormalize();
+
+      rotation[0] = RAD2DEG * atan2f(mat.m[1][2], mat.m[2][2]);
+      rotation[1] = RAD2DEG * atan2f(-mat.m[0][2], sqrtf(mat.m[1][2] * mat.m[1][2] + mat.m[2][2] * mat.m[2][2]));
+      rotation[2] = RAD2DEG * atan2f(mat.m[0][1], mat.m[0][0]);
+
+      translation[0] = mat.v.position.x;
+      translation[1] = mat.v.position.y;
+      translation[2] = mat.v.position.z;
+   }
+
+   void RecomposeMatrixFromComponents(const float* translation, const float* rotation, const float* scale, float* matrix)
+   {
+      matrix_t& mat = *(matrix_t*)matrix;
+
+      matrix_t rot[3];
+      for (int i = 0; i < 3; i++)
+      {
+         rot[i].RotationAxis(directionUnary[i], rotation[i] * DEG2RAD);
+      }
+
+      mat = rot[0] * rot[1] * rot[2];
+
+      float validScale[3];
+      for (int i = 0; i < 3; i++)
+      {
+         if (fabsf(scale[i]) < FLT_EPSILON)
+         {
+            validScale[i] = 0.001f;
+         }
+         else
+         {
+            validScale[i] = scale[i];
+         }
+      }
+      mat.v.right *= validScale[0];
+      mat.v.up *= validScale[1];
+      mat.v.dir *= validScale[2];
+      mat.v.position.Set(translation[0], translation[1], translation[2], 1.f);
+   }
+
+   void SetID(int id)
+   {
+      gContext.mActualID = id;
+   }
+
+   void AllowAxisFlip(bool value)
+   {
+     gContext.mAllowAxisFlip = value;
+   }
+
+   void SetAxisLimit(float value)
+   {
+     gContext.mAxisLimit=value;
+   }
+
+   void SetPlaneLimit(float value)
+   {
+     gContext.mPlaneLimit = value;
+   }
+
+   bool Manipulate(const float* view, const float* projection, OPERATION operation, MODE mode, float* matrix, float* deltaMatrix, const float* snap, const float* localBounds, const float* boundsSnap)
+   {
+      // Scale is always local or matrix will be skewed when applying world scale or oriented matrix
+      ComputeContext(view, projection, matrix, (operation & SCALE) ? LOCAL : mode);
+
+      // set delta to identity
+      if (deltaMatrix)
+      {
+         ((matrix_t*)deltaMatrix)->SetToIdentity();
+      }
+
+      // behind camera
+      vec_t camSpacePosition;
+      camSpacePosition.TransformPoint(makeVect(0.f, 0.f, 0.f), gContext.mMVP);
+      if (!gContext.mIsOrthographic && camSpacePosition.z < 0.001f)
+      {
+         return false;
+      }
+
+      // --
+      int type = MT_NONE;
+      bool manipulated = false;
+      if (gContext.mbEnable)
+      {
+         if (!gContext.mbUsingBounds)
+         {
+            manipulated = HandleTranslation(matrix, deltaMatrix, operation, type, snap) ||
+                          HandleScale(matrix, deltaMatrix, operation, type, snap) ||
+                          HandleRotation(matrix, deltaMatrix, operation, type, snap);
+         }
+      }
+
+      if (localBounds && !gContext.mbUsing)
+      {
+         HandleAndDrawLocalBounds(localBounds, (matrix_t*)matrix, boundsSnap, operation);
+      }
+
+      gContext.mOperation = operation;
+      if (!gContext.mbUsingBounds)
+      {
+         DrawRotationGizmo(operation, type);
+         DrawTranslationGizmo(operation, type);
+         DrawScaleGizmo(operation, type);
+         DrawScaleUniveralGizmo(operation, type);
+      }
+      return manipulated;
+   }
+
+   void SetGizmoSizeClipSpace(float value)
+   {
+      gContext.mGizmoSizeClipSpace = value;
+   }
+
+   ///////////////////////////////////////////////////////////////////////////////////////////////////
+   void ComputeFrustumPlanes(vec_t* frustum, const float* clip)
+   {
+      frustum[0].x = clip[3] - clip[0];
+      frustum[0].y = clip[7] - clip[4];
+      frustum[0].z = clip[11] - clip[8];
+      frustum[0].w = clip[15] - clip[12];
+
+      frustum[1].x = clip[3] + clip[0];
+      frustum[1].y = clip[7] + clip[4];
+      frustum[1].z = clip[11] + clip[8];
+      frustum[1].w = clip[15] + clip[12];
+
+      frustum[2].x = clip[3] + clip[1];
+      frustum[2].y = clip[7] + clip[5];
+      frustum[2].z = clip[11] + clip[9];
+      frustum[2].w = clip[15] + clip[13];
+
+      frustum[3].x = clip[3] - clip[1];
+      frustum[3].y = clip[7] - clip[5];
+      frustum[3].z = clip[11] - clip[9];
+      frustum[3].w = clip[15] - clip[13];
+
+      frustum[4].x = clip[3] - clip[2];
+      frustum[4].y = clip[7] - clip[6];
+      frustum[4].z = clip[11] - clip[10];
+      frustum[4].w = clip[15] - clip[14];
+
+      frustum[5].x = clip[3] + clip[2];
+      frustum[5].y = clip[7] + clip[6];
+      frustum[5].z = clip[11] + clip[10];
+      frustum[5].w = clip[15] + clip[14];
+
+      for (int i = 0; i < 6; i++)
+      {
+         frustum[i].Normalize();
+      }
+   }
+
+   void DrawCubes(const float* view, const float* projection, const float* matrices, int matrixCount)
+   {
+      matrix_t viewInverse;
+      viewInverse.Inverse(*(matrix_t*)view);
+
+      struct CubeFace
+      {
+         float z;
+         ImVec2 faceCoordsScreen[4];
+         ImU32 color;
+      };
+      CubeFace* faces = (CubeFace*)_malloca(sizeof(CubeFace) * matrixCount * 6);
+
+      if (!faces)
+      {
+         return;
+      }
+
+      vec_t frustum[6];
+      matrix_t viewProjection = *(matrix_t*)view * *(matrix_t*)projection;
+      ComputeFrustumPlanes(frustum, viewProjection.m16);
+
+      int cubeFaceCount = 0;
+      for (int cube = 0; cube < matrixCount; cube++)
+      {
+         const float* matrix = &matrices[cube * 16];
+
+         matrix_t res = *(matrix_t*)matrix * *(matrix_t*)view * *(matrix_t*)projection;
+
+         for (int iFace = 0; iFace < 6; iFace++)
+         {
+            const int normalIndex = (iFace % 3);
+            const int perpXIndex = (normalIndex + 1) % 3;
+            const int perpYIndex = (normalIndex + 2) % 3;
+            const float invert = (iFace > 2) ? -1.f : 1.f;
+
+            const vec_t faceCoords[4] = { directionUnary[normalIndex] + directionUnary[perpXIndex] + directionUnary[perpYIndex],
+               directionUnary[normalIndex] + directionUnary[perpXIndex] - directionUnary[perpYIndex],
+               directionUnary[normalIndex] - directionUnary[perpXIndex] - directionUnary[perpYIndex],
+               directionUnary[normalIndex] - directionUnary[perpXIndex] + directionUnary[perpYIndex],
+            };
+
+            // clipping
+            /*
+            bool skipFace = false;
+            for (unsigned int iCoord = 0; iCoord < 4; iCoord++)
+            {
+               vec_t camSpacePosition;
+               camSpacePosition.TransformPoint(faceCoords[iCoord] * 0.5f * invert, res);
+               if (camSpacePosition.z < 0.001f)
+               {
+                  skipFace = true;
+                  break;
+               }
+            }
+            if (skipFace)
+            {
+               continue;
+            }
+            */
+            vec_t centerPosition, centerPositionVP;
+            centerPosition.TransformPoint(directionUnary[normalIndex] * 0.5f * invert, *(matrix_t*)matrix);
+            centerPositionVP.TransformPoint(directionUnary[normalIndex] * 0.5f * invert, res);
+
+            bool inFrustum = true;
+            for (int iFrustum = 0; iFrustum < 6; iFrustum++)
+            {
+               float dist = DistanceToPlane(centerPosition, frustum[iFrustum]);
+               if (dist < 0.f)
+               {
+                  inFrustum = false;
+                  break;
+               }
+            }
+
+            if (!inFrustum)
+            {
+               continue;
+            }
+            CubeFace& cubeFace = faces[cubeFaceCount];
+
+            // 3D->2D
+            //ImVec2 faceCoordsScreen[4];
+            for (unsigned int iCoord = 0; iCoord < 4; iCoord++)
+            {
+               cubeFace.faceCoordsScreen[iCoord] = worldToPos(faceCoords[iCoord] * 0.5f * invert, res);
+            }
+
+            ImU32 directionColor = GetColorU32(DIRECTION_X + normalIndex);
+            cubeFace.color = directionColor | IM_COL32(0x80, 0x80, 0x80, 0);
+
+            cubeFace.z = centerPositionVP.z / centerPositionVP.w;
+            cubeFaceCount++;
+         }
+      }
+      qsort(faces, cubeFaceCount, sizeof(CubeFace), [](void const* _a, void const* _b) {
+         CubeFace* a = (CubeFace*)_a;
+         CubeFace* b = (CubeFace*)_b;
+         if (a->z < b->z)
+         {
+            return 1;
+         }
+         return -1;
+         });
+      // draw face with lighter color
+      for (int iFace = 0; iFace < cubeFaceCount; iFace++)
+      {
+         const CubeFace& cubeFace = faces[iFace];
+         gContext.mDrawList->AddConvexPolyFilled(cubeFace.faceCoordsScreen, 4, cubeFace.color);
+      }
+
+      _freea(faces);
+   }
+
+   void DrawGrid(const float* view, const float* projection, const float* matrix, const float gridSize)
+   {
+      matrix_t viewProjection = *(matrix_t*)view * *(matrix_t*)projection;
+      vec_t frustum[6];
+      ComputeFrustumPlanes(frustum, viewProjection.m16);
+      matrix_t res = *(matrix_t*)matrix * viewProjection;
+
+      for (float f = -gridSize; f <= gridSize; f += 1.f)
+      {
+         for (int dir = 0; dir < 2; dir++)
+         {
+            vec_t ptA = makeVect(dir ? -gridSize : f, 0.f, dir ? f : -gridSize);
+            vec_t ptB = makeVect(dir ? gridSize : f, 0.f, dir ? f : gridSize);
+            bool visible = true;
+            for (int i = 0; i < 6; i++)
+            {
+               float dA = DistanceToPlane(ptA, frustum[i]);
+               float dB = DistanceToPlane(ptB, frustum[i]);
+               if (dA < 0.f && dB < 0.f)
+               {
+                  visible = false;
+                  break;
+               }
+               if (dA > 0.f && dB > 0.f)
+               {
+                  continue;
+               }
+               if (dA < 0.f)
+               {
+                  float len = fabsf(dA - dB);
+                  float t = fabsf(dA) / len;
+                  ptA.Lerp(ptB, t);
+               }
+               if (dB < 0.f)
+               {
+                  float len = fabsf(dB - dA);
+                  float t = fabsf(dB) / len;
+                  ptB.Lerp(ptA, t);
+               }
+            }
+            if (visible)
+            {
+               ImU32 col = IM_COL32(0x80, 0x80, 0x80, 0xFF);
+               col = (fmodf(fabsf(f), 10.f) < FLT_EPSILON) ? IM_COL32(0x90, 0x90, 0x90, 0xFF) : col;
+               col = (fabsf(f) < FLT_EPSILON) ? IM_COL32(0x40, 0x40, 0x40, 0xFF): col;
+
+               float thickness = 1.f;
+               thickness = (fmodf(fabsf(f), 10.f) < FLT_EPSILON) ? 1.5f : thickness;
+               thickness = (fabsf(f) < FLT_EPSILON) ? 2.3f : thickness;
+
+               gContext.mDrawList->AddLine(worldToPos(ptA, res), worldToPos(ptB, res), col, thickness);
+            }
+         }
+      }
+   }
+
+   void ViewManipulate(float* view, const float* projection, OPERATION operation, MODE mode, float* matrix, float length, ImVec2 position, ImVec2 size, ImU32 backgroundColor)
+   {
+      // Scale is always local or matrix will be skewed when applying world scale or oriented matrix
+      ComputeContext(view, projection, matrix, (operation & SCALE) ? LOCAL : mode);
+      ViewManipulate(view, length, position, size, backgroundColor);
+   }
+
+   void ViewManipulate(float* view, float length, ImVec2 position, ImVec2 size, ImU32 backgroundColor)
+   {
+      static bool isDraging = false;
+      static bool isClicking = false;
+      static bool isInside = false;
+      static vec_t interpolationUp;
+      static vec_t interpolationDir;
+      static int interpolationFrames = 0;
+      const vec_t referenceUp = makeVect(0.f, 1.f, 0.f);
+
+      matrix_t svgView, svgProjection;
+      svgView = gContext.mViewMat;
+      svgProjection = gContext.mProjectionMat;
+
+      ImGuiIO& io = ImGui::GetIO();
+      gContext.mDrawList->AddRectFilled(position, position + size, backgroundColor);
+      matrix_t viewInverse;
+      viewInverse.Inverse(*(matrix_t*)view);
+
+      const vec_t camTarget = viewInverse.v.position - viewInverse.v.dir * length;
+
+      // view/projection matrices
+      const float distance = 3.f;
+      matrix_t cubeProjection, cubeView;
+      float fov = acosf(distance / (sqrtf(distance * distance + 3.f))) * RAD2DEG;
+      Perspective(fov / sqrtf(2.f), size.x / size.y, 0.01f, 1000.f, cubeProjection.m16);
+
+      vec_t dir = makeVect(viewInverse.m[2][0], viewInverse.m[2][1], viewInverse.m[2][2]);
+      vec_t up = makeVect(viewInverse.m[1][0], viewInverse.m[1][1], viewInverse.m[1][2]);
+      vec_t eye = dir * distance;
+      vec_t zero = makeVect(0.f, 0.f);
+      LookAt(&eye.x, &zero.x, &up.x, cubeView.m16);
+
+      // set context
+      gContext.mViewMat = cubeView;
+      gContext.mProjectionMat = cubeProjection;
+      ComputeCameraRay(gContext.mRayOrigin, gContext.mRayVector, position, size);
+
+      const matrix_t res = cubeView * cubeProjection;
+
+      // panels
+      static const ImVec2 panelPosition[9] = { ImVec2(0.75f,0.75f), ImVec2(0.25f, 0.75f), ImVec2(0.f, 0.75f),
+         ImVec2(0.75f, 0.25f), ImVec2(0.25f, 0.25f), ImVec2(0.f, 0.25f),
+         ImVec2(0.75f, 0.f), ImVec2(0.25f, 0.f), ImVec2(0.f, 0.f) };
+
+      static const ImVec2 panelSize[9] = { ImVec2(0.25f,0.25f), ImVec2(0.5f, 0.25f), ImVec2(0.25f, 0.25f),
+         ImVec2(0.25f, 0.5f), ImVec2(0.5f, 0.5f), ImVec2(0.25f, 0.5f),
+         ImVec2(0.25f, 0.25f), ImVec2(0.5f, 0.25f), ImVec2(0.25f, 0.25f) };
+
+      // tag faces
+      bool boxes[27]{};
+      static int overBox = -1;
+      for (int iPass = 0; iPass < 2; iPass++)
+      {
+         for (int iFace = 0; iFace < 6; iFace++)
+         {
+            const int normalIndex = (iFace % 3);
+            const int perpXIndex = (normalIndex + 1) % 3;
+            const int perpYIndex = (normalIndex + 2) % 3;
+            const float invert = (iFace > 2) ? -1.f : 1.f;
+            const vec_t indexVectorX = directionUnary[perpXIndex] * invert;
+            const vec_t indexVectorY = directionUnary[perpYIndex] * invert;
+            const vec_t boxOrigin = directionUnary[normalIndex] * -invert - indexVectorX - indexVectorY;
+
+            // plan local space
+            const vec_t n = directionUnary[normalIndex] * invert;
+            vec_t viewSpaceNormal = n;
+            vec_t viewSpacePoint = n * 0.5f;
+            viewSpaceNormal.TransformVector(cubeView);
+            viewSpaceNormal.Normalize();
+            viewSpacePoint.TransformPoint(cubeView);
+            const vec_t viewSpaceFacePlan = BuildPlan(viewSpacePoint, viewSpaceNormal);
+
+            // back face culling
+            if (viewSpaceFacePlan.w > 0.f)
+            {
+               continue;
+            }
+
+            const vec_t facePlan = BuildPlan(n * 0.5f, n);
+
+            const float len = IntersectRayPlane(gContext.mRayOrigin, gContext.mRayVector, facePlan);
+            vec_t posOnPlan = gContext.mRayOrigin + gContext.mRayVector * len - (n * 0.5f);
+
+            float localx = Dot(directionUnary[perpXIndex], posOnPlan) * invert + 0.5f;
+            float localy = Dot(directionUnary[perpYIndex], posOnPlan) * invert + 0.5f;
+
+            // panels
+            const vec_t dx = directionUnary[perpXIndex];
+            const vec_t dy = directionUnary[perpYIndex];
+            const vec_t origin = directionUnary[normalIndex] - dx - dy;
+            for (int iPanel = 0; iPanel < 9; iPanel++)
+            {
+               vec_t boxCoord = boxOrigin + indexVectorX * float(iPanel % 3) + indexVectorY * float(iPanel / 3) + makeVect(1.f, 1.f, 1.f);
+               const ImVec2 p = panelPosition[iPanel] * 2.f;
+               const ImVec2 s = panelSize[iPanel] * 2.f;
+               ImVec2 faceCoordsScreen[4];
+               vec_t panelPos[4] = { dx * p.x + dy * p.y,
+                                     dx * p.x + dy * (p.y + s.y),
+                                     dx * (p.x + s.x) + dy * (p.y + s.y),
+                                     dx * (p.x + s.x) + dy * p.y };
+
+               for (unsigned int iCoord = 0; iCoord < 4; iCoord++)
+               {
+                  faceCoordsScreen[iCoord] = worldToPos((panelPos[iCoord] + origin) * 0.5f * invert, res, position, size);
+               }
+
+               const ImVec2 panelCorners[2] = { panelPosition[iPanel], panelPosition[iPanel] + panelSize[iPanel] };
+               bool insidePanel = localx > panelCorners[0].x && localx < panelCorners[1].x && localy > panelCorners[0].y && localy < panelCorners[1].y;
+               int boxCoordInt = int(boxCoord.x * 9.f + boxCoord.y * 3.f + boxCoord.z);
+               IM_ASSERT(boxCoordInt < 27);
+               boxes[boxCoordInt] |= insidePanel && (!isDraging) && gContext.mbMouseOver;
+
+               // draw face with lighter color
+               if (iPass)
+               {
+                  ImU32 directionColor = GetColorU32(DIRECTION_X + normalIndex);
+                  gContext.mDrawList->AddConvexPolyFilled(faceCoordsScreen, 4, (directionColor | IM_COL32(0x80, 0x80, 0x80, 0x80)) | (isInside ? IM_COL32(0x08, 0x08, 0x08, 0) : 0));
+                  if (boxes[boxCoordInt])
+                  {
+                     gContext.mDrawList->AddConvexPolyFilled(faceCoordsScreen, 4, IM_COL32(0xF0, 0xA0, 0x60, 0x80));
+
+                     if (io.MouseDown[0] && !isClicking && !isDraging && GImGui->ActiveId == 0) {
+                        overBox = boxCoordInt;
+                        isClicking = true;
+                        isDraging = true;
+                     }
+                  }
+               }
+            }
+         }
+      }
+      if (interpolationFrames)
+      {
+         interpolationFrames--;
+         vec_t newDir = viewInverse.v.dir;
+         newDir.Lerp(interpolationDir, 0.2f);
+         newDir.Normalize();
+
+         vec_t newUp = viewInverse.v.up;
+         newUp.Lerp(interpolationUp, 0.3f);
+         newUp.Normalize();
+         newUp = interpolationUp;
+         vec_t newEye = camTarget + newDir * length;
+         LookAt(&newEye.x, &camTarget.x, &newUp.x, view);
+      }
+      isInside = gContext.mbMouseOver && ImRect(position, position + size).Contains(io.MousePos);
+
+      if (io.MouseDown[0] && (fabsf(io.MouseDelta[0]) || fabsf(io.MouseDelta[1])) && isClicking)
+      {
+         isClicking = false;
+      }
+
+      if (!io.MouseDown[0])
+      {
+         if (isClicking)
+         {
+            // apply new view direction
+            int cx = overBox / 9;
+            int cy = (overBox - cx * 9) / 3;
+            int cz = overBox % 3;
+            interpolationDir = makeVect(1.f - (float)cx, 1.f - (float)cy, 1.f - (float)cz);
+            interpolationDir.Normalize();
+
+            if (fabsf(Dot(interpolationDir, referenceUp)) > 1.0f - 0.01f)
+            {
+               vec_t right = viewInverse.v.right;
+               if (fabsf(right.x) > fabsf(right.z))
+               {
+                  right.z = 0.f;
+               }
+               else
+               {
+                  right.x = 0.f;
+               }
+               right.Normalize();
+               interpolationUp = Cross(interpolationDir, right);
+               interpolationUp.Normalize();
+            }
+            else
+            {
+               interpolationUp = referenceUp;
+            }
+            interpolationFrames = 40;
+            
+         }
+         isClicking = false;
+         isDraging = false;
+      }
+
+
+      if (isDraging)
+      {
+         matrix_t rx, ry, roll;
+
+         rx.RotationAxis(referenceUp, -io.MouseDelta.x * 0.01f);
+         ry.RotationAxis(viewInverse.v.right, -io.MouseDelta.y * 0.01f);
+
+         roll = rx * ry;
+
+         vec_t newDir = viewInverse.v.dir;
+         newDir.TransformVector(roll);
+         newDir.Normalize();
+
+         // clamp
+         vec_t planDir = Cross(viewInverse.v.right, referenceUp);
+         planDir.y = 0.f;
+         planDir.Normalize();
+         float dt = Dot(planDir, newDir);
+         if (dt < 0.0f)
+         {
+            newDir += planDir * dt;
+            newDir.Normalize();
+         }
+
+         vec_t newEye = camTarget + newDir * length;
+         LookAt(&newEye.x, &camTarget.x, &referenceUp.x, view);
+      }
+
+      // restore view/projection because it was used to compute ray
+      ComputeContext(svgView.m16, svgProjection.m16, gContext.mModelSource.m16, gContext.mMode);
+   }
+};

--- a/Preditor/Common/ImGuizmo/ImGuizmo.h
+++ b/Preditor/Common/ImGuizmo/ImGuizmo.h
@@ -1,0 +1,272 @@
+// https://github.com/CedricGuillemet/ImGuizmo
+// v 1.89 WIP
+//
+// The MIT License(MIT)
+//
+// Copyright(c) 2021 Cedric Guillemet
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+//
+// -------------------------------------------------------------------------------------------
+// History :
+// 2019/11/03 View gizmo
+// 2016/09/11 Behind camera culling. Scaling Delta matrix not multiplied by source matrix scales. local/world rotation and translation fixed. Display message is incorrect (X: ... Y:...) in local mode.
+// 2016/09/09 Hatched negative axis. Snapping. Documentation update.
+// 2016/09/04 Axis switch and translation plan autohiding. Scale transform stability improved
+// 2016/09/01 Mogwai changed to Manipulate. Draw debug cube. Fixed inverted scale. Mixing scale and translation/rotation gives bad results.
+// 2016/08/31 First version
+//
+// -------------------------------------------------------------------------------------------
+// Future (no order):
+//
+// - Multi view
+// - display rotation/translation/scale infos in local/world space and not only local
+// - finish local/world matrix application
+// - OPERATION as bitmask
+// 
+// -------------------------------------------------------------------------------------------
+// Example 
+#if 0
+void EditTransform(const Camera& camera, matrix_t& matrix)
+{
+   static ImGuizmo::OPERATION mCurrentGizmoOperation(ImGuizmo::ROTATE);
+   static ImGuizmo::MODE mCurrentGizmoMode(ImGuizmo::WORLD);
+   if (ImGui::IsKeyPressed(90))
+      mCurrentGizmoOperation = ImGuizmo::TRANSLATE;
+   if (ImGui::IsKeyPressed(69))
+      mCurrentGizmoOperation = ImGuizmo::ROTATE;
+   if (ImGui::IsKeyPressed(82)) // r Key
+      mCurrentGizmoOperation = ImGuizmo::SCALE;
+   if (ImGui::RadioButton("Translate", mCurrentGizmoOperation == ImGuizmo::TRANSLATE))
+      mCurrentGizmoOperation = ImGuizmo::TRANSLATE;
+   ImGui::SameLine();
+   if (ImGui::RadioButton("Rotate", mCurrentGizmoOperation == ImGuizmo::ROTATE))
+      mCurrentGizmoOperation = ImGuizmo::ROTATE;
+   ImGui::SameLine();
+   if (ImGui::RadioButton("Scale", mCurrentGizmoOperation == ImGuizmo::SCALE))
+      mCurrentGizmoOperation = ImGuizmo::SCALE;
+   float matrixTranslation[3], matrixRotation[3], matrixScale[3];
+   ImGuizmo::DecomposeMatrixToComponents(matrix.m16, matrixTranslation, matrixRotation, matrixScale);
+   ImGui::InputFloat3("Tr", matrixTranslation, 3);
+   ImGui::InputFloat3("Rt", matrixRotation, 3);
+   ImGui::InputFloat3("Sc", matrixScale, 3);
+   ImGuizmo::RecomposeMatrixFromComponents(matrixTranslation, matrixRotation, matrixScale, matrix.m16);
+
+   if (mCurrentGizmoOperation != ImGuizmo::SCALE)
+   {
+      if (ImGui::RadioButton("Local", mCurrentGizmoMode == ImGuizmo::LOCAL))
+         mCurrentGizmoMode = ImGuizmo::LOCAL;
+      ImGui::SameLine();
+      if (ImGui::RadioButton("World", mCurrentGizmoMode == ImGuizmo::WORLD))
+         mCurrentGizmoMode = ImGuizmo::WORLD;
+   }
+   static bool useSnap(false);
+   if (ImGui::IsKeyPressed(83))
+      useSnap = !useSnap;
+   ImGui::Checkbox("", &useSnap);
+   ImGui::SameLine();
+   vec_t snap;
+   switch (mCurrentGizmoOperation)
+   {
+   case ImGuizmo::TRANSLATE:
+      snap = config.mSnapTranslation;
+      ImGui::InputFloat3("Snap", &snap.x);
+      break;
+   case ImGuizmo::ROTATE:
+      snap = config.mSnapRotation;
+      ImGui::InputFloat("Angle Snap", &snap.x);
+      break;
+   case ImGuizmo::SCALE:
+      snap = config.mSnapScale;
+      ImGui::InputFloat("Scale Snap", &snap.x);
+      break;
+   }
+   ImGuiIO& io = ImGui::GetIO();
+   ImGuizmo::SetRect(0, 0, io.DisplaySize.x, io.DisplaySize.y);
+   ImGuizmo::Manipulate(camera.mView.m16, camera.mProjection.m16, mCurrentGizmoOperation, mCurrentGizmoMode, matrix.m16, NULL, useSnap ? &snap.x : NULL);
+}
+#endif
+#pragma once
+
+#ifdef USE_IMGUI_API
+#include "imconfig.h"
+#endif
+#ifndef IMGUI_API
+#define IMGUI_API
+#endif
+
+#ifndef IMGUIZMO_NAMESPACE
+#define IMGUIZMO_NAMESPACE ImGuizmo
+#endif
+
+namespace IMGUIZMO_NAMESPACE
+{
+   // call inside your own window and before Manipulate() in order to draw gizmo to that window.
+   // Or pass a specific ImDrawList to draw to (e.g. ImGui::GetForegroundDrawList()).
+   IMGUI_API void SetDrawlist(ImDrawList* drawlist = nullptr);
+
+   // call BeginFrame right after ImGui_XXXX_NewFrame();
+   IMGUI_API void BeginFrame();
+
+   // this is necessary because when imguizmo is compiled into a dll, and imgui into another
+   // globals are not shared between them.
+   // More details at https://stackoverflow.com/questions/19373061/what-happens-to-global-and-static-variables-in-a-shared-library-when-it-is-dynam
+   // expose method to set imgui context
+   IMGUI_API void SetImGuiContext(ImGuiContext* ctx);
+
+   // return true if mouse cursor is over any gizmo control (axis, plan or screen component)
+   IMGUI_API bool IsOver();
+
+   // return true if mouse IsOver or if the gizmo is in moving state
+   IMGUI_API bool IsUsing();
+
+   // return true if any gizmo is in moving state
+   IMGUI_API bool IsUsingAny();
+
+   // enable/disable the gizmo. Stay in the state until next call to Enable.
+   // gizmo is rendered with gray half transparent color when disabled
+   IMGUI_API void Enable(bool enable);
+
+   // helper functions for manualy editing translation/rotation/scale with an input float
+   // translation, rotation and scale float points to 3 floats each
+   // Angles are in degrees (more suitable for human editing)
+   // example:
+   // float matrixTranslation[3], matrixRotation[3], matrixScale[3];
+   // ImGuizmo::DecomposeMatrixToComponents(gizmoMatrix.m16, matrixTranslation, matrixRotation, matrixScale);
+   // ImGui::InputFloat3("Tr", matrixTranslation, 3);
+   // ImGui::InputFloat3("Rt", matrixRotation, 3);
+   // ImGui::InputFloat3("Sc", matrixScale, 3);
+   // ImGuizmo::RecomposeMatrixFromComponents(matrixTranslation, matrixRotation, matrixScale, gizmoMatrix.m16);
+   //
+   // These functions have some numerical stability issues for now. Use with caution.
+   IMGUI_API void DecomposeMatrixToComponents(const float* matrix, float* translation, float* rotation, float* scale);
+   IMGUI_API void RecomposeMatrixFromComponents(const float* translation, const float* rotation, const float* scale, float* matrix);
+
+   IMGUI_API void SetRect(float x, float y, float width, float height);
+   // default is false
+   IMGUI_API void SetOrthographic(bool isOrthographic);
+
+   // Render a cube with face color corresponding to face normal. Usefull for debug/tests
+   IMGUI_API void DrawCubes(const float* view, const float* projection, const float* matrices, int matrixCount);
+   IMGUI_API void DrawGrid(const float* view, const float* projection, const float* matrix, const float gridSize);
+
+   // call it when you want a gizmo
+   // Needs view and projection matrices. 
+   // matrix parameter is the source matrix (where will be gizmo be drawn) and might be transformed by the function. Return deltaMatrix is optional
+   // translation is applied in world space
+   enum OPERATION
+   {
+      TRANSLATE_X      = (1u << 0),
+      TRANSLATE_Y      = (1u << 1),
+      TRANSLATE_Z      = (1u << 2),
+      ROTATE_X         = (1u << 3),
+      ROTATE_Y         = (1u << 4),
+      ROTATE_Z         = (1u << 5),
+      ROTATE_SCREEN    = (1u << 6),
+      SCALE_X          = (1u << 7),
+      SCALE_Y          = (1u << 8),
+      SCALE_Z          = (1u << 9),
+      BOUNDS           = (1u << 10),
+      SCALE_XU         = (1u << 11),
+      SCALE_YU         = (1u << 12),
+      SCALE_ZU         = (1u << 13),
+
+      TRANSLATE = TRANSLATE_X | TRANSLATE_Y | TRANSLATE_Z,
+      ROTATE = ROTATE_X | ROTATE_Y | ROTATE_Z | ROTATE_SCREEN,
+      SCALE = SCALE_X | SCALE_Y | SCALE_Z,
+      SCALEU = SCALE_XU | SCALE_YU | SCALE_ZU, // universal
+      UNIVERSAL = TRANSLATE | ROTATE | SCALEU
+   };
+
+   inline OPERATION operator|(OPERATION lhs, OPERATION rhs)
+   {
+     return static_cast<OPERATION>(static_cast<int>(lhs) | static_cast<int>(rhs));
+   }
+
+   enum MODE
+   {
+      LOCAL,
+      WORLD
+   };
+
+   IMGUI_API bool Manipulate(const float* view, const float* projection, OPERATION operation, MODE mode, float* matrix, float* deltaMatrix = NULL, const float* snap = NULL, const float* localBounds = NULL, const float* boundsSnap = NULL);
+   //
+   // Please note that this cubeview is patented by Autodesk : https://patents.google.com/patent/US7782319B2/en
+   // It seems to be a defensive patent in the US. I don't think it will bring troubles using it as
+   // other software are using the same mechanics. But just in case, you are now warned!
+   //
+   IMGUI_API void ViewManipulate(float* view, float length, ImVec2 position, ImVec2 size, ImU32 backgroundColor);
+
+   // use this version if you did not call Manipulate before and you are just using ViewManipulate
+   IMGUI_API void ViewManipulate(float* view, const float* projection, OPERATION operation, MODE mode, float* matrix, float length, ImVec2 position, ImVec2 size, ImU32 backgroundColor);
+
+   IMGUI_API void SetID(int id);
+
+   // return true if the cursor is over the operation's gizmo
+   IMGUI_API bool IsOver(OPERATION op);
+   IMGUI_API void SetGizmoSizeClipSpace(float value);
+
+   // Allow axis to flip
+   // When true (default), the guizmo axis flip for better visibility
+   // When false, they always stay along the positive world/local axis
+   IMGUI_API void AllowAxisFlip(bool value);
+
+   // Configure the limit where axis are hidden
+   IMGUI_API void SetAxisLimit(float value);
+   // Configure the limit where planes are hiden
+   IMGUI_API void SetPlaneLimit(float value);
+
+   enum COLOR
+   {
+      DIRECTION_X,      // directionColor[0]
+      DIRECTION_Y,      // directionColor[1]
+      DIRECTION_Z,      // directionColor[2]
+      PLANE_X,          // planeColor[0]
+      PLANE_Y,          // planeColor[1]
+      PLANE_Z,          // planeColor[2]
+      SELECTION,        // selectionColor
+      INACTIVE,         // inactiveColor
+      TRANSLATION_LINE, // translationLineColor
+      SCALE_LINE,
+      ROTATION_USING_BORDER,
+      ROTATION_USING_FILL,
+      HATCHED_AXIS_LINES,
+      TEXT,
+      TEXT_SHADOW,
+      COUNT
+   };
+
+   struct Style
+   {
+      IMGUI_API Style();
+
+      float TranslationLineThickness;   // Thickness of lines for translation gizmo
+      float TranslationLineArrowSize;   // Size of arrow at the end of lines for translation gizmo
+      float RotationLineThickness;      // Thickness of lines for rotation gizmo
+      float RotationOuterLineThickness; // Thickness of line surrounding the rotation gizmo
+      float ScaleLineThickness;         // Thickness of lines for scale gizmo
+      float ScaleLineCircleSize;        // Size of circle at the end of lines for scale gizmo
+      float HatchedAxisLineThickness;   // Thickness of hatched axis lines
+      float CenterCircleSize;           // Size of circle at the center of the translate/scale gizmo
+
+      ImVec4 Colors[COLOR::COUNT];
+   };
+
+   IMGUI_API Style& GetStyle();
+}

--- a/Preditor/Common/ImGuizmo/ImZoomSlider.h
+++ b/Preditor/Common/ImGuizmo/ImZoomSlider.h
@@ -1,0 +1,245 @@
+// https://github.com/CedricGuillemet/ImGuizmo
+// v 1.89 WIP
+//
+// The MIT License(MIT)
+//
+// Copyright(c) 2021 Cedric Guillemet
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+//
+#pragma once
+
+namespace ImZoomSlider
+{
+   typedef int ImGuiZoomSliderFlags;
+   enum ImGuiPopupFlags_
+   {
+      ImGuiZoomSliderFlags_None = 0,
+      ImGuiZoomSliderFlags_Vertical = 1,
+      ImGuiZoomSliderFlags_NoAnchors = 2,
+      ImGuiZoomSliderFlags_NoMiddleCarets = 4,
+      ImGuiZoomSliderFlags_NoWheel = 8,
+   };
+
+   template<typename T> bool ImZoomSlider(const T lower, const T higher, T& viewLower, T& viewHigher, float wheelRatio = 0.01f, ImGuiZoomSliderFlags flags = ImGuiZoomSliderFlags_None)
+   {
+      bool interacted = false;
+      ImGuiIO& io = ImGui::GetIO();
+      ImDrawList* draw_list = ImGui::GetWindowDrawList();
+
+      static const float handleSize = 12;
+      static const float roundRadius = 3.f;
+      static const char* controlName = "ImZoomSlider";
+
+      static bool movingScrollBarSvg = false;
+      static bool sizingRBarSvg = false;
+      static bool sizingLBarSvg = false;
+      static ImGuiID editingId = (ImGuiID)-1;
+      static float scrollingSource = 0.f;
+      static float saveViewLower;
+      static float saveViewHigher;
+
+      const bool isVertical = flags & ImGuiZoomSliderFlags_Vertical;
+      const ImVec2 canvasPos = ImGui::GetCursorScreenPos();
+      const ImVec2 canvasSize = ImGui::GetContentRegionAvail();
+      const float canvasSizeLength = isVertical ? ImGui::GetItemRectSize().y : canvasSize.x;
+      const ImVec2 scrollBarSize = isVertical ? ImVec2(14.f, canvasSizeLength) : ImVec2(canvasSizeLength, 14.f);
+
+      ImGui::InvisibleButton(controlName, scrollBarSize);
+      const ImGuiID currentId = ImGui::GetID(controlName);
+
+      const bool usingEditingId = currentId == editingId;
+      const bool canUseControl = usingEditingId || editingId == -1;
+      const bool movingScrollBar = usingEditingId ? movingScrollBarSvg : false;
+      const bool sizingRBar = usingEditingId ? sizingRBarSvg : false;
+      const bool sizingLBar = usingEditingId ? sizingLBarSvg : false;
+      const int componentIndex = isVertical ? 1 : 0;
+      const ImVec2 scrollBarMin = ImGui::GetItemRectMin();
+      const ImVec2 scrollBarMax = ImGui::GetItemRectMax();
+      const ImVec2 scrollBarA = ImVec2(scrollBarMin.x, scrollBarMin.y) - (isVertical ? ImVec2(2,0) : ImVec2(0,2));
+      const ImVec2 scrollBarB = isVertical ? ImVec2(scrollBarMax.x - 1.f, scrollBarMin.y + canvasSizeLength) : ImVec2(scrollBarMin.x + canvasSizeLength, scrollBarMax.y - 1.f);
+      const float scrollStart = ((viewLower - lower) / (higher - lower)) * canvasSizeLength + scrollBarMin[componentIndex];
+      const float scrollEnd = ((viewHigher - lower) / (higher - lower)) * canvasSizeLength + scrollBarMin[componentIndex];
+      const float screenSize = scrollEnd - scrollStart;
+      const ImVec2 scrollTopLeft = isVertical ? ImVec2(scrollBarMin.x, scrollStart) : ImVec2(scrollStart, scrollBarMin.y);
+      const ImVec2 scrollBottomRight = isVertical ? ImVec2(scrollBarMax.x - 2.f, scrollEnd) : ImVec2(scrollEnd, scrollBarMax.y - 2.f);
+      const bool inScrollBar = canUseControl && ImRect(scrollTopLeft, scrollBottomRight).Contains(io.MousePos);
+      const ImRect scrollBarRect(scrollBarA, scrollBarB);
+      const float deltaScreen = io.MousePos[componentIndex] - scrollingSource;
+      const float deltaView = ((higher - lower) / canvasSizeLength) * deltaScreen;
+      const uint32_t barColor = ImGui::GetColorU32((inScrollBar || movingScrollBar) ? ImGuiCol_FrameBgHovered : ImGuiCol_FrameBg);
+      const float middleCoord = (scrollStart + scrollEnd) * 0.5f;
+      const bool insideControl = canUseControl && ImRect(scrollBarMin, scrollBarMax).Contains(io.MousePos);
+      const bool hasAnchors = !(flags & ImGuiZoomSliderFlags_NoAnchors);
+      const float viewMinSize = ((3.f * handleSize) / canvasSizeLength) * (higher - lower);
+      const auto ClipView = [lower, higher, &viewLower, &viewHigher]() {
+         if (viewLower < lower)
+         {
+            const float deltaClip = lower - viewLower;
+            viewLower += deltaClip;
+            viewHigher += deltaClip;
+         }
+         if (viewHigher > higher)
+         {
+            const float deltaClip = viewHigher - higher;
+            viewLower -= deltaClip;
+            viewHigher -= deltaClip;
+         }
+      };
+
+      bool onLeft = false;
+      bool onRight = false;
+
+      draw_list->AddRectFilled(scrollBarA, scrollBarB, 0xFF101010, roundRadius);
+      draw_list->AddRectFilled(scrollBarA, scrollBarB, 0xFF222222, 0);
+      draw_list->AddRectFilled(scrollTopLeft, scrollBottomRight, barColor, roundRadius);
+
+      if (!(flags & ImGuiZoomSliderFlags_NoMiddleCarets))
+      {
+         for (float i = 0.5f; i < 3.f; i += 1.f)
+         {
+            const float coordA = middleCoord - handleSize * 0.5f;
+            const float coordB = middleCoord + handleSize * 0.5f;
+            ImVec2 base = scrollBarMin;
+            base.x += scrollBarSize.x * 0.25f * i;
+            base.y += scrollBarSize.y * 0.25f * i;
+
+            if (isVertical)
+            {
+               draw_list->AddLine(ImVec2(base.x, coordA), ImVec2(base.x, coordB), ImGui::GetColorU32(ImGuiCol_SliderGrab));
+            }
+            else
+            {
+               draw_list->AddLine(ImVec2(coordA, base.y), ImVec2(coordB, base.y), ImGui::GetColorU32(ImGuiCol_SliderGrab));
+            }
+         }
+      }
+
+      // Mouse wheel
+      if (io.MouseClicked[0] && insideControl && !inScrollBar)
+      {
+         const float ratio = (io.MousePos[componentIndex] - scrollBarMin[componentIndex]) / (scrollBarMax[componentIndex] - scrollBarMin[componentIndex]);
+         const float size = (higher - lower);
+         const float halfViewSize = (viewHigher - viewLower) * 0.5f;
+         const float middle = ratio * size + lower;
+         viewLower = middle - halfViewSize;
+         viewHigher = middle + halfViewSize;
+         ClipView();
+         interacted = true;
+      }
+
+      if (!(flags & ImGuiZoomSliderFlags_NoWheel) && inScrollBar && fabsf(io.MouseWheel) > 0.f)
+      {
+         const float ratio = (io.MousePos[componentIndex] - scrollStart) / (scrollEnd - scrollStart);
+         const float amount = io.MouseWheel * wheelRatio * (viewHigher - viewLower);
+         
+         viewLower -= ratio * amount;
+         viewHigher += (1.f - ratio) * amount;
+         ClipView();
+         interacted = true;
+      }
+
+      if (screenSize > handleSize * 2.f && hasAnchors)
+      {
+         const ImRect barHandleLeft(scrollTopLeft, isVertical ? ImVec2(scrollBottomRight.x, scrollTopLeft.y + handleSize) : ImVec2(scrollTopLeft.x + handleSize, scrollBottomRight.y));
+         const ImRect barHandleRight(isVertical ? ImVec2(scrollTopLeft.x, scrollBottomRight.y - handleSize) : ImVec2(scrollBottomRight.x - handleSize, scrollTopLeft.y), scrollBottomRight);
+
+         onLeft = barHandleLeft.Contains(io.MousePos);
+         onRight = barHandleRight.Contains(io.MousePos);
+
+         draw_list->AddRectFilled(barHandleLeft.Min, barHandleLeft.Max, ImGui::GetColorU32((onLeft || sizingLBar) ? ImGuiCol_SliderGrabActive : ImGuiCol_SliderGrab), roundRadius);
+         draw_list->AddRectFilled(barHandleRight.Min, barHandleRight.Max, ImGui::GetColorU32((onRight || sizingRBar) ? ImGuiCol_SliderGrabActive : ImGuiCol_SliderGrab), roundRadius);
+      }
+
+      if (sizingRBar)
+      {
+         if (!io.MouseDown[0])
+         {
+            sizingRBarSvg = false;
+            editingId = (ImGuiID)-1;
+         }
+         else
+         {
+            viewHigher = ImMin(saveViewHigher + deltaView, higher);
+         }
+      }
+      else if (sizingLBar)
+      {
+         if (!io.MouseDown[0])
+         {
+            sizingLBarSvg = false;
+            editingId = (ImGuiID)-1;
+         }
+         else
+         {
+            viewLower = ImMax(saveViewLower + deltaView, lower);
+         }
+      }
+      else
+      {
+         if (movingScrollBar)
+         {
+            if (!io.MouseDown[0])
+            {
+               movingScrollBarSvg = false;
+               editingId = (ImGuiID)-1;
+            }
+            else
+            {
+               viewLower = saveViewLower + deltaView;
+               viewHigher = saveViewHigher + deltaView;
+               ClipView();
+            }
+         }
+         else
+         {
+            if (inScrollBar && ImGui::IsMouseClicked(0))
+            {
+               movingScrollBarSvg = true;
+               scrollingSource = io.MousePos[componentIndex];
+               saveViewLower = viewLower;
+               saveViewHigher = viewHigher;
+               editingId = currentId;
+            }
+            if (!sizingRBar && onRight && ImGui::IsMouseClicked(0) && hasAnchors)
+            {
+               sizingRBarSvg = true;
+               editingId = currentId;
+            }
+            if (!sizingLBar && onLeft && ImGui::IsMouseClicked(0) && hasAnchors)
+            {
+               sizingLBarSvg = true;
+               editingId = currentId;
+            }
+         }
+      }
+
+      // minimal size check
+      if ((viewHigher - viewLower) < viewMinSize)
+      {
+         const float middle = (viewLower + viewHigher) * 0.5f;
+         viewLower = middle - viewMinSize * 0.5f;
+         viewHigher = middle + viewMinSize * 0.5f;
+         ClipView();
+      }
+
+      return movingScrollBar || sizingRBar || sizingLBar || interacted;
+   }
+
+} // namespace

--- a/Preditor/Common/ImGuizmo/LICENSE
+++ b/Preditor/Common/ImGuizmo/LICENSE
@@ -1,0 +1,21 @@
+The MIT License (MIT)
+
+Copyright (c) 2016 Cedric Guillemet
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/Preditor/Common/ImGuizmo/README.md
+++ b/Preditor/Common/ImGuizmo/README.md
@@ -1,0 +1,192 @@
+# ImGuizmo
+
+Latest stable tagged version is 1.83. Current master version is 1.84 WIP.
+
+What started with the gizmo is now a collection of dear imgui widgets and more advanced controls.
+
+## Guizmos
+
+### ImViewGizmo
+
+Manipulate view orientation with 1 single line of code
+
+![Image of ImViewGizmo](http://i.imgur.com/7UVcyDd.gif)
+
+### ImGuizmo
+
+ImGizmo is a small (.h and .cpp) library built ontop of Dear ImGui that allow you to manipulate(Rotate & translate at the moment) 4x4 float matrices. No other dependancies. Coded with Immediate Mode (IM) philosophy in mind.
+
+Built against DearImgui 1.53WIP
+
+![Image of Rotation](http://i.imgur.com/y4mcVoT.gif)
+![Image of Translation](http://i.imgur.com/o8q8iHq.gif)
+![Image of Bounds](http://i.imgur.com/3Ez5LBr.gif)
+
+There is now a sample for Win32/OpenGL ! With a binary in bin directory.
+![Image of Sample](https://i.imgur.com/nXlzyqD.png)
+
+### ImSequencer
+
+A WIP little sequencer used to edit frame start/end for different events in a timeline.
+![Image of Rotation](http://i.imgur.com/BeyNwCn.png)
+Check the sample for the documentation. More to come...
+
+### Graph Editor
+
+Nodes + connections. Custom draw inside nodes is possible with the delegate system in place.
+![Image of GraphEditor](Images/nodeeditor.jpg)
+
+### API doc
+
+Call BeginFrame right after ImGui_XXXX_NewFrame();
+
+```C++
+void BeginFrame();
+```
+
+return true if mouse cursor is over any gizmo control (axis, plan or screen component)
+
+```C++
+bool IsOver();**
+```
+
+return true if mouse IsOver or if the gizmo is in moving state
+
+```C++
+bool IsUsing();**
+```
+
+enable/disable the gizmo. Stay in the state until next call to Enable. gizmo is rendered with gray half transparent color when disabled
+
+```C++
+void Enable(bool enable);**
+```
+
+helper functions for manualy editing translation/rotation/scale with an input float
+translation, rotation and scale float points to 3 floats each
+Angles are in degrees (more suitable for human editing)
+example:
+
+```C++
+ float matrixTranslation[3], matrixRotation[3], matrixScale[3];
+ ImGuizmo::DecomposeMatrixToComponents(gizmoMatrix.m16, matrixTranslation, matrixRotation, matrixScale);
+ ImGui::InputFloat3("Tr", matrixTranslation, 3);
+ ImGui::InputFloat3("Rt", matrixRotation, 3);
+ ImGui::InputFloat3("Sc", matrixScale, 3);
+ ImGuizmo::RecomposeMatrixFromComponents(matrixTranslation, matrixRotation, matrixScale, gizmoMatrix.m16);
+```
+
+These functions have some numerical stability issues for now. Use with caution.
+
+```C++
+void DecomposeMatrixToComponents(const float *matrix, float *translation, float *rotation, float *scale);
+void RecomposeMatrixFromComponents(const float *translation, const float *rotation, const float *scale, float *matrix);**
+```
+
+Render a cube with face color corresponding to face normal. Usefull for debug/test
+
+```C++
+void DrawCube(const float *view, const float *projection, float *matrix);**
+```
+
+Call it when you want a gizmo
+Needs view and projection matrices.
+Matrix parameter is the source matrix (where will be gizmo be drawn) and might be transformed by the function. Return deltaMatrix is optional. snap points to a float[3] for translation and to a single float for scale or rotation. Snap angle is in Euler Degrees.
+
+```C++
+    enum OPERATION
+    {
+        TRANSLATE,
+        ROTATE,
+        SCALE
+    };
+
+    enum MODE
+    {
+        LOCAL,
+        WORLD
+    };
+
+void Manipulate(const float *view, const float *projection, OPERATION operation, MODE mode, float *matrix, float *deltaMatrix = 0, float *snap = 0);**
+```
+
+### ImGui Example
+
+Code for :
+
+![Image of dialog](http://i.imgur.com/GL5flN1.png)
+
+```C++
+void EditTransform(const Camera& camera, matrix_t& matrix)
+{
+    static ImGuizmo::OPERATION mCurrentGizmoOperation(ImGuizmo::ROTATE);
+    static ImGuizmo::MODE mCurrentGizmoMode(ImGuizmo::WORLD);
+    if (ImGui::IsKeyPressed(90))
+        mCurrentGizmoOperation = ImGuizmo::TRANSLATE;
+    if (ImGui::IsKeyPressed(69))
+        mCurrentGizmoOperation = ImGuizmo::ROTATE;
+    if (ImGui::IsKeyPressed(82)) // r Key
+        mCurrentGizmoOperation = ImGuizmo::SCALE;
+    if (ImGui::RadioButton("Translate", mCurrentGizmoOperation == ImGuizmo::TRANSLATE))
+        mCurrentGizmoOperation = ImGuizmo::TRANSLATE;
+    ImGui::SameLine();
+    if (ImGui::RadioButton("Rotate", mCurrentGizmoOperation == ImGuizmo::ROTATE))
+        mCurrentGizmoOperation = ImGuizmo::ROTATE;
+    ImGui::SameLine();
+    if (ImGui::RadioButton("Scale", mCurrentGizmoOperation == ImGuizmo::SCALE))
+        mCurrentGizmoOperation = ImGuizmo::SCALE;
+    float matrixTranslation[3], matrixRotation[3], matrixScale[3];
+    ImGuizmo::DecomposeMatrixToComponents(matrix.m16, matrixTranslation, matrixRotation, matrixScale);
+    ImGui::InputFloat3("Tr", matrixTranslation, 3);
+    ImGui::InputFloat3("Rt", matrixRotation, 3);
+    ImGui::InputFloat3("Sc", matrixScale, 3);
+    ImGuizmo::RecomposeMatrixFromComponents(matrixTranslation, matrixRotation, matrixScale, matrix.m16);
+
+    if (mCurrentGizmoOperation != ImGuizmo::SCALE)
+    {
+        if (ImGui::RadioButton("Local", mCurrentGizmoMode == ImGuizmo::LOCAL))
+            mCurrentGizmoMode = ImGuizmo::LOCAL;
+        ImGui::SameLine();
+        if (ImGui::RadioButton("World", mCurrentGizmoMode == ImGuizmo::WORLD))
+            mCurrentGizmoMode = ImGuizmo::WORLD;
+    }
+    static bool useSnap(false);
+    if (ImGui::IsKeyPressed(83))
+        useSnap = !useSnap;
+    ImGui::Checkbox("", &useSnap);
+    ImGui::SameLine();
+    vec_t snap;
+    switch (mCurrentGizmoOperation)
+    {
+    case ImGuizmo::TRANSLATE:
+        snap = config.mSnapTranslation;
+        ImGui::InputFloat3("Snap", &snap.x);
+        break;
+    case ImGuizmo::ROTATE:
+        snap = config.mSnapRotation;
+        ImGui::InputFloat("Angle Snap", &snap.x);
+        break;
+    case ImGuizmo::SCALE:
+        snap = config.mSnapScale;
+        ImGui::InputFloat("Scale Snap", &snap.x);
+        break;
+    }
+    ImGuiIO& io = ImGui::GetIO();
+    ImGuizmo::SetRect(0, 0, io.DisplaySize.x, io.DisplaySize.y);
+    ImGuizmo::Manipulate(camera.mView.m16, camera.mProjection.m16, mCurrentGizmoOperation, mCurrentGizmoMode, matrix.m16, NULL, useSnap ? &snap.x : NULL);
+}
+```
+
+## Install
+
+ImGuizmo can be installed via [vcpkg](https://github.com/microsoft/vcpkg) and used cmake
+
+```bash
+vcpkg install imguizmo
+```
+
+See the [vcpkg example](/vcpkg-example) for more details
+
+## License
+
+ImGuizmo is licensed under the MIT License, see [LICENSE](/LICENSE) for more information.

--- a/Preditor/Common/Preditor/EditTools/IEditToolManager.h
+++ b/Preditor/Common/Preditor/EditTools/IEditToolManager.h
@@ -33,5 +33,6 @@ struct IEditToolManager
 
     //! Called from the viewport ImGui window context.
     //! @param  bounds  Viewport bounds.
-    virtual void DrawViewport(const Vec4& bounds, const Matrix44& viewMat) = 0;
+    //! @param  camera  Viewport camera.
+    virtual void DrawViewport(const Vec4& bounds, const CCamera& camera) = 0;
 };

--- a/Preditor/Common/Preditor/EditTools/IEditToolManager.h
+++ b/Preditor/Common/Preditor/EditTools/IEditToolManager.h
@@ -30,4 +30,8 @@ struct IEditToolManager
     //! @param  vpSize      Size of the viewport.
     //! @returns action result.
     virtual EEditToolResult OnLeftMouseClick(Vec2 clickPos, Vec2 vpSize) = 0;
+
+    //! Called from the viewport ImGui window context.
+    //! @param  bounds  Viewport bounds.
+    virtual void DrawViewport(const Vec4& bounds, const Matrix44& viewMat) = 0;
 };

--- a/Preditor/Common/Preditor/SceneEditor/IObjectManipulator.h
+++ b/Preditor/Common/Preditor/SceneEditor/IObjectManipulator.h
@@ -1,0 +1,13 @@
+#pragma once
+#include <Preditor/SceneEditor/Common.h>
+
+struct IObjectManipulator
+{
+    virtual ~IObjectManipulator() {}
+
+    //! @returns an object's world translation matrix.
+    virtual Matrix34 GetObjectWorldTM(SceneObjectId id) = 0;
+
+    //! Sets an object's world translation matrix.
+    virtual void SetObjectWorldTM(SceneObjectId id, const Matrix34& tm) = 0;
+};

--- a/Preditor/Common/Preditor/SceneEditor/IObjectManipulator.h
+++ b/Preditor/Common/Preditor/SceneEditor/IObjectManipulator.h
@@ -10,4 +10,7 @@ struct IObjectManipulator
 
     //! Sets an object's world translation matrix.
     virtual void SetObjectWorldTM(SceneObjectId id, const Matrix34& tm) = 0;
+
+    //! Gets the object's local-space bounding box.
+    virtual void GetObjectLocalBounds(SceneObjectId id, AABB& aabb) = 0;
 };

--- a/Preditor/EditTools/CMakeLists.txt
+++ b/Preditor/EditTools/CMakeLists.txt
@@ -4,6 +4,8 @@ set(SOURCE_FILES
 	EditTool.h
 	EditToolManager.cpp
 	EditToolManager.h
+	MoveTool.cpp
+	MoveTool.h
 	SelectTool.cpp
 	SelectTool.h
 	ToolSelectionWindow.cpp

--- a/Preditor/EditTools/CMakeLists.txt
+++ b/Preditor/EditTools/CMakeLists.txt
@@ -4,8 +4,8 @@ set(SOURCE_FILES
 	EditTool.h
 	EditToolManager.cpp
 	EditToolManager.h
-	MoveTool.cpp
-	MoveTool.h
+	ImGuizmoTool.cpp
+	ImGuizmoTool.h
 	SelectTool.cpp
 	SelectTool.h
 	ToolSelectionWindow.cpp

--- a/Preditor/EditTools/EditTool.h
+++ b/Preditor/EditTools/EditTool.h
@@ -26,7 +26,8 @@ public:
 
     //! Called from the viewport context.
     //! @param  bounds  Viewport bounds.
-    virtual void DrawViewport(const Vec4& bounds, const Matrix44& projMat, const Matrix44& viewMat) {}
+    //! @param  camera  Viewport camera.
+    virtual void DrawViewport(const Vec4& bounds, const CCamera& camera) {}
 
     //! Called when the viewport is left-clicked.
     //! @param  clickPos    Position where the mouse was clicked [(0,0) is in top-left corner].

--- a/Preditor/EditTools/EditTool.h
+++ b/Preditor/EditTools/EditTool.h
@@ -24,6 +24,10 @@ public:
     //! Called when the tool is disabled.
     virtual void OnDisabled();
 
+    //! Called from the viewport context.
+    //! @param  bounds  Viewport bounds.
+    virtual void DrawViewport(const Vec4& bounds, const Matrix44& projMat, const Matrix44& viewMat) {}
+
     //! Called when the viewport is left-clicked.
     //! @param  clickPos    Position where the mouse was clicked [(0,0) is in top-left corner].
     //! @param  vpSize      Size of the viewport.

--- a/Preditor/EditTools/EditToolManager.cpp
+++ b/Preditor/EditTools/EditToolManager.cpp
@@ -23,6 +23,12 @@ EditTools::EditToolManager::EditToolManager(ISceneEditor* pEditor)
     RegisterToolSelectKey("rotate", m_pRotateTool);
     RegisterToolSelectKey("scale", m_pScaleTool);
 
+    gPreditor->pInput->FindAction("transform_tools.toggle_pivot")->AddListener([this](const KeyActionEventArgs& e)
+        {
+            if (e.isPressed)
+                m_bPivotCenter ^= 1;
+        });
+
     gPreditor->pInput->FindAction("transform_tools.toggle_tool_space")->AddListener([this](const KeyActionEventArgs& e)
         {
             if (e.isPressed)
@@ -39,6 +45,10 @@ EditTools::EditToolManager::~EditToolManager()
 
 void EditTools::EditToolManager::ShowSelectionUI()
 {
+    if (ImGui::Button(m_bPivotCenter ? ICON_MD_CENTER_FOCUS_WEAK : ICON_MD_TRIP_ORIGIN))
+        m_bPivotCenter ^= 1;
+    ImGui::SameLine();
+
     if (ImGui::Button(m_bWorldTransform ? ICON_MD_LANGUAGE : ICON_MD_VIEW_IN_AR))
         m_bWorldTransform ^= 1;
     ImGui::SameLine();

--- a/Preditor/EditTools/EditToolManager.cpp
+++ b/Preditor/EditTools/EditToolManager.cpp
@@ -26,7 +26,7 @@ EditTools::EditToolManager::EditToolManager(ISceneEditor* pEditor)
     gPreditor->pInput->FindAction("transform_tools.toggle_tool_space")->AddListener([this](const KeyActionEventArgs& e)
         {
             if (e.isPressed)
-                m_bWorldTransforms ^= 1;
+                m_bWorldTransform ^= 1;
         });
 
     // Start with select tool
@@ -39,8 +39,8 @@ EditTools::EditToolManager::~EditToolManager()
 
 void EditTools::EditToolManager::ShowSelectionUI()
 {
-    if (ImGui::Button(m_bWorldTransforms ? ICON_MD_LANGUAGE : ICON_MD_VIEW_IN_AR))
-        m_bWorldTransforms ^= 1;
+    if (ImGui::Button(m_bWorldTransform ? ICON_MD_LANGUAGE : ICON_MD_VIEW_IN_AR))
+        m_bWorldTransform ^= 1;
     ImGui::SameLine();
 
     EditTool* tools[] = { m_pSelectTool.get(), m_pMoveTool.get(), m_pRotateTool.get(), m_pScaleTool.get() };

--- a/Preditor/EditTools/EditToolManager.cpp
+++ b/Preditor/EditTools/EditToolManager.cpp
@@ -70,17 +70,14 @@ EEditToolResult EditTools::EditToolManager::OnLeftMouseClick(Vec2 clickPos, Vec2
     return result;
 }
 
-void EditTools::EditToolManager::DrawViewport(const Vec4& bounds, const Matrix44& viewMat)
+void EditTools::EditToolManager::DrawViewport(const Vec4& bounds, const CCamera& camera)
 {
     if (!m_bIsActive)
         return;
 
     if (m_pCurTool)
     {
-        Matrix44 projMat;
-        gEnv->pRenderer->GetProjectionMatrix(projMat.GetData());
-        projMat.Transpose();
-        m_pCurTool->DrawViewport(bounds, projMat, viewMat);
+        m_pCurTool->DrawViewport(bounds, camera);
     }
 }
 

--- a/Preditor/EditTools/EditToolManager.cpp
+++ b/Preditor/EditTools/EditToolManager.cpp
@@ -23,6 +23,12 @@ EditTools::EditToolManager::EditToolManager(ISceneEditor* pEditor)
     RegisterToolSelectKey("rotate", m_pRotateTool);
     RegisterToolSelectKey("scale", m_pScaleTool);
 
+    gPreditor->pInput->FindAction("transform_tools.toggle_tool_space")->AddListener([this](const KeyActionEventArgs& e)
+        {
+            if (e.isPressed)
+                m_bWorldTransforms ^= 1;
+        });
+
     // Start with select tool
     SetCurrentTool(m_pSelectTool.get());
 }
@@ -33,6 +39,10 @@ EditTools::EditToolManager::~EditToolManager()
 
 void EditTools::EditToolManager::ShowSelectionUI()
 {
+    if (ImGui::Button(m_bWorldTransforms ? ICON_MD_LANGUAGE : ICON_MD_VIEW_IN_AR))
+        m_bWorldTransforms ^= 1;
+    ImGui::SameLine();
+
     EditTool* tools[] = { m_pSelectTool.get(), m_pMoveTool.get(), m_pRotateTool.get(), m_pScaleTool.get() };
     const char* names[] = { "Select", "Move", "Rotate", "Scale" };
 

--- a/Preditor/EditTools/EditToolManager.cpp
+++ b/Preditor/EditTools/EditToolManager.cpp
@@ -14,9 +14,9 @@ EditTools::EditToolManager::EditToolManager(ISceneEditor* pEditor)
     m_pEditor = pEditor;
 
     m_pSelectTool = std::make_unique<SelectTool>(this);
-    m_pMoveTool = std::make_unique<ImGuizmoTool>(this, ImGuizmo::OPERATION::TRANSLATE);
-    m_pRotateTool = std::make_unique<ImGuizmoTool>(this, ImGuizmo::OPERATION::ROTATE);
-    m_pScaleTool = std::make_unique<ImGuizmoTool>(this, ImGuizmo::OPERATION::SCALE);
+    m_pMoveTool = std::make_unique<ImGuizmoTool>(this, ImGuizmo::OPERATION::TRANSLATE, Vec3(0.25f));
+    m_pRotateTool = std::make_unique<ImGuizmoTool>(this, ImGuizmo::OPERATION::ROTATE, Vec3(5));
+    m_pScaleTool = std::make_unique<ImGuizmoTool>(this, ImGuizmo::OPERATION::SCALE, Vec3(0.25f));
 
     RegisterToolSelectKey("select", m_pSelectTool);
     RegisterToolSelectKey("move", m_pMoveTool);

--- a/Preditor/EditTools/EditToolManager.cpp
+++ b/Preditor/EditTools/EditToolManager.cpp
@@ -2,7 +2,7 @@
 #include "EditTool.h"
 #include "EditToolManager.h"
 #include "SelectTool.h"
-#include "MoveTool.h"
+#include "ImGuizmoTool.h"
 
 std::unique_ptr<IEditToolManager> IEditToolManager::CreateInstance(ISceneEditor* pEditor)
 {
@@ -14,7 +14,7 @@ EditTools::EditToolManager::EditToolManager(ISceneEditor* pEditor)
     m_pEditor = pEditor;
 
     m_pSelectTool = std::make_unique<SelectTool>(this);
-    m_pMoveTool = std::make_unique<MoveTool>(this);
+    m_pMoveTool = std::make_unique<ImGuizmoTool>(this, ImGuizmo::OPERATION::TRANSLATE);
 
     // Start with select tool
     SetCurrentTool(m_pSelectTool.get());

--- a/Preditor/EditTools/EditToolManager.cpp
+++ b/Preditor/EditTools/EditToolManager.cpp
@@ -15,6 +15,8 @@ EditTools::EditToolManager::EditToolManager(ISceneEditor* pEditor)
 
     m_pSelectTool = std::make_unique<SelectTool>(this);
     m_pMoveTool = std::make_unique<ImGuizmoTool>(this, ImGuizmo::OPERATION::TRANSLATE);
+    m_pRotateTool = std::make_unique<ImGuizmoTool>(this, ImGuizmo::OPERATION::ROTATE);
+    m_pScaleTool = std::make_unique<ImGuizmoTool>(this, ImGuizmo::OPERATION::SCALE);
 
     // Start with select tool
     SetCurrentTool(m_pSelectTool.get());
@@ -26,8 +28,8 @@ EditTools::EditToolManager::~EditToolManager()
 
 void EditTools::EditToolManager::ShowSelectionUI()
 {
-    EditTool* tools[] = { m_pSelectTool.get(), m_pMoveTool.get() };
-    const char* names[] = { "Select", "Move" };
+    EditTool* tools[] = { m_pSelectTool.get(), m_pMoveTool.get(), m_pRotateTool.get(), m_pScaleTool.get() };
+    const char* names[] = { "Select", "Move", "Rotate", "Scale" };
 
     for (size_t i = 0; i < std::size(tools); i++)
     {

--- a/Preditor/EditTools/EditToolManager.cpp
+++ b/Preditor/EditTools/EditToolManager.cpp
@@ -1,4 +1,4 @@
-#include <Prey/CryRenderer/IRenderer.h>
+#include <Preditor/Input/IPreditorInput.h>
 #include "EditTool.h"
 #include "EditToolManager.h"
 #include "SelectTool.h"
@@ -17,6 +17,11 @@ EditTools::EditToolManager::EditToolManager(ISceneEditor* pEditor)
     m_pMoveTool = std::make_unique<ImGuizmoTool>(this, ImGuizmo::OPERATION::TRANSLATE);
     m_pRotateTool = std::make_unique<ImGuizmoTool>(this, ImGuizmo::OPERATION::ROTATE);
     m_pScaleTool = std::make_unique<ImGuizmoTool>(this, ImGuizmo::OPERATION::SCALE);
+
+    RegisterToolSelectKey("select", m_pSelectTool);
+    RegisterToolSelectKey("move", m_pMoveTool);
+    RegisterToolSelectKey("rotate", m_pRotateTool);
+    RegisterToolSelectKey("scale", m_pScaleTool);
 
     // Start with select tool
     SetCurrentTool(m_pSelectTool.get());
@@ -103,4 +108,15 @@ void EditTools::EditToolManager::SetCurrentTool(EditTool* pTool)
         m_pCurTool = pTool;
         m_pCurTool->SetActive(m_bIsActive);
     }
+}
+
+void EditTools::EditToolManager::RegisterToolSelectKey(std::string_view action, std::unique_ptr<EditTool>& pTool)
+{
+    IKeyActionSet* pActionSet = gPreditor->pInput->GetKeyboard()->FindActionSet("tool_select");
+    IKeyAction* pAction = pActionSet->FindAction(action);
+    pAction->AddListener([this, &pTool](const KeyActionEventArgs& e)
+        {
+            if (e.isPressed)
+                SetCurrentTool(pTool.get());
+        });
 }

--- a/Preditor/EditTools/EditToolManager.h
+++ b/Preditor/EditTools/EditToolManager.h
@@ -34,6 +34,8 @@ private:
 
     std::unique_ptr<EditTool> m_pSelectTool;
     std::unique_ptr<ImGuizmoTool> m_pMoveTool;
+    std::unique_ptr<ImGuizmoTool> m_pRotateTool;
+    std::unique_ptr<ImGuizmoTool> m_pScaleTool;
 
     //! Changes the active tool to a different one.
     void SetCurrentTool(EditTool* pTool);

--- a/Preditor/EditTools/EditToolManager.h
+++ b/Preditor/EditTools/EditToolManager.h
@@ -5,7 +5,7 @@ namespace EditTools
 {
 
 class EditTool;
-class MoveTool;
+class ImGuizmoTool;
 
 class EditToolManager final : public IEditToolManager
 {
@@ -33,7 +33,7 @@ private:
     EditTool* m_pCurTool = nullptr;
 
     std::unique_ptr<EditTool> m_pSelectTool;
-    std::unique_ptr<MoveTool> m_pMoveTool;
+    std::unique_ptr<ImGuizmoTool> m_pMoveTool;
 
     //! Changes the active tool to a different one.
     void SetCurrentTool(EditTool* pTool);

--- a/Preditor/EditTools/EditToolManager.h
+++ b/Preditor/EditTools/EditToolManager.h
@@ -19,7 +19,7 @@ public:
     EditTool* GetCurrentTool() const { return m_pCurTool; }
 
     //! @returns whether transformation tools should tranform in the world space.
-    bool IsWorldTransform() const { return m_bWorldTransforms; }
+    bool IsWorldTransform() const { return m_bWorldTransform; }
 
     //! Shows controls for the tool selection UI.
     void ShowSelectionUI();
@@ -33,7 +33,7 @@ private:
     bool m_bIsActive = false;
     ISceneEditor* m_pEditor = nullptr;
     EditTool* m_pCurTool = nullptr;
-    bool m_bWorldTransforms = true;
+    bool m_bWorldTransform = true;
 
     std::unique_ptr<EditTool> m_pSelectTool;
     std::unique_ptr<EditTool> m_pMoveTool;

--- a/Preditor/EditTools/EditToolManager.h
+++ b/Preditor/EditTools/EditToolManager.h
@@ -18,6 +18,9 @@ public:
     //! @returns the current tool (or nullptr, if none).
     EditTool* GetCurrentTool() const { return m_pCurTool; }
 
+    //! @returns whether transformation tools should pivot around the center instead of local origin.
+    bool IsPivotCenter() const { return m_bPivotCenter; }
+
     //! @returns whether transformation tools should tranform in the world space.
     bool IsWorldTransform() const { return m_bWorldTransform; }
 
@@ -33,7 +36,8 @@ private:
     bool m_bIsActive = false;
     ISceneEditor* m_pEditor = nullptr;
     EditTool* m_pCurTool = nullptr;
-    bool m_bWorldTransform = true;
+    bool m_bPivotCenter = true;
+    bool m_bWorldTransform = false;
 
     std::unique_ptr<EditTool> m_pSelectTool;
     std::unique_ptr<EditTool> m_pMoveTool;

--- a/Preditor/EditTools/EditToolManager.h
+++ b/Preditor/EditTools/EditToolManager.h
@@ -5,6 +5,7 @@ namespace EditTools
 {
 
 class EditTool;
+class MoveTool;
 
 class EditToolManager final : public IEditToolManager
 {
@@ -24,6 +25,7 @@ public:
     // IEditToolManager
     virtual void SetEnabled(bool state) override;
     virtual EEditToolResult OnLeftMouseClick(Vec2 clickPos, Vec2 vpSize) override;
+    virtual void DrawViewport(const Vec4& bounds, const Matrix44& viewMat) override;
 
 private:
     bool m_bIsActive = false;
@@ -31,6 +33,7 @@ private:
     EditTool* m_pCurTool = nullptr;
 
     std::unique_ptr<EditTool> m_pSelectTool;
+    std::unique_ptr<MoveTool> m_pMoveTool;
 
     //! Changes the active tool to a different one.
     void SetCurrentTool(EditTool* pTool);

--- a/Preditor/EditTools/EditToolManager.h
+++ b/Preditor/EditTools/EditToolManager.h
@@ -18,6 +18,9 @@ public:
     //! @returns the current tool (or nullptr, if none).
     EditTool* GetCurrentTool() const { return m_pCurTool; }
 
+    //! @returns whether transformation tools should tranform in the world space.
+    bool IsWorldTransform() const { return m_bWorldTransforms; }
+
     //! Shows controls for the tool selection UI.
     void ShowSelectionUI();
 
@@ -30,6 +33,7 @@ private:
     bool m_bIsActive = false;
     ISceneEditor* m_pEditor = nullptr;
     EditTool* m_pCurTool = nullptr;
+    bool m_bWorldTransforms = true;
 
     std::unique_ptr<EditTool> m_pSelectTool;
     std::unique_ptr<EditTool> m_pMoveTool;

--- a/Preditor/EditTools/EditToolManager.h
+++ b/Preditor/EditTools/EditToolManager.h
@@ -25,7 +25,7 @@ public:
     // IEditToolManager
     virtual void SetEnabled(bool state) override;
     virtual EEditToolResult OnLeftMouseClick(Vec2 clickPos, Vec2 vpSize) override;
-    virtual void DrawViewport(const Vec4& bounds, const Matrix44& viewMat) override;
+    virtual void DrawViewport(const Vec4& bounds, const CCamera& camera) override;
 
 private:
     bool m_bIsActive = false;

--- a/Preditor/EditTools/EditToolManager.h
+++ b/Preditor/EditTools/EditToolManager.h
@@ -5,7 +5,6 @@ namespace EditTools
 {
 
 class EditTool;
-class ImGuizmoTool;
 
 class EditToolManager final : public IEditToolManager
 {
@@ -33,12 +32,15 @@ private:
     EditTool* m_pCurTool = nullptr;
 
     std::unique_ptr<EditTool> m_pSelectTool;
-    std::unique_ptr<ImGuizmoTool> m_pMoveTool;
-    std::unique_ptr<ImGuizmoTool> m_pRotateTool;
-    std::unique_ptr<ImGuizmoTool> m_pScaleTool;
+    std::unique_ptr<EditTool> m_pMoveTool;
+    std::unique_ptr<EditTool> m_pRotateTool;
+    std::unique_ptr<EditTool> m_pScaleTool;
 
     //! Changes the active tool to a different one.
     void SetCurrentTool(EditTool* pTool);
+
+    //! Adds an key action event handler to switch to the tool.
+    void RegisterToolSelectKey(std::string_view action, std::unique_ptr<EditTool>& pTool);
 };
 
 } // namespace EditTools

--- a/Preditor/EditTools/ImGuizmoTool.cpp
+++ b/Preditor/EditTools/ImGuizmoTool.cpp
@@ -1,9 +1,8 @@
-#include <ImGuizmo/ImGuizmo.h>
 #include <Preditor/SceneEditor/ISceneEditor.h>
 #include <Preditor/SceneEditor/IObjectManipulator.h>
 #include <Preditor/SceneEditor/SelectionManager.h>
 #include "EditToolManager.h"
-#include "MoveTool.h"
+#include "ImGuizmoTool.h"
 
 namespace
 {
@@ -77,16 +76,17 @@ void FrustumFromCamera(const CCamera& cam, float width, float height, float* m16
 
 } // namespace
 
-EditTools::MoveTool::MoveTool(EditToolManager* pMgr)
+EditTools::ImGuizmoTool::ImGuizmoTool(EditToolManager* pMgr, ImGuizmo::OPERATION operation)
     : EditTool(pMgr)
 {
+    m_Op = operation;
 }
 
-EditTools::MoveTool::~MoveTool()
+EditTools::ImGuizmoTool::~ImGuizmoTool()
 {
 }
 
-void EditTools::MoveTool::DrawViewport(const Vec4& bounds, const CCamera& camera)
+void EditTools::ImGuizmoTool::DrawViewport(const Vec4& bounds, const CCamera& camera)
 {
     ImVec2 windowPos = ImGui::GetWindowPos();
     ImGuizmo::SetDrawlist();
@@ -112,7 +112,7 @@ void EditTools::MoveTool::DrawViewport(const Vec4& bounds, const CCamera& camera
         ImGuizmo::Manipulate(
             viewMat.GetData(),
             projMat.GetData(),
-            ImGuizmo::TRANSLATE,
+            m_Op,
             ImGuizmo::WORLD,
             objectTM.GetData());
 
@@ -120,7 +120,7 @@ void EditTools::MoveTool::DrawViewport(const Vec4& bounds, const CCamera& camera
     }
 }
 
-EEditToolResult EditTools::MoveTool::OnLeftMouseClick(Vec2 clickPos, Vec2 vpSize)
+EEditToolResult EditTools::ImGuizmoTool::OnLeftMouseClick(Vec2 clickPos, Vec2 vpSize)
 {
     if (ImGuizmo::IsOver())
         return EEditToolResult::Handled;

--- a/Preditor/EditTools/ImGuizmoTool.cpp
+++ b/Preditor/EditTools/ImGuizmoTool.cpp
@@ -116,7 +116,7 @@ void EditTools::ImGuizmoTool::DrawViewport(const Vec4& bounds, const CCamera& ca
             viewMat.GetData(),
             projMat.GetData(),
             m_Op,
-            ImGuizmo::WORLD,
+            GetManager()->IsWorldTransform() ? ImGuizmo::WORLD : ImGuizmo::LOCAL,
             objectTM.GetData(),
             nullptr, // deltaMatrix
             m_pSnapKey->IsHeldDown() ? & m_Snap.x : nullptr);

--- a/Preditor/EditTools/ImGuizmoTool.cpp
+++ b/Preditor/EditTools/ImGuizmoTool.cpp
@@ -112,7 +112,7 @@ void EditTools::ImGuizmoTool::DrawViewport(const Vec4& bounds, const CCamera& ca
         Matrix44 projMat;
         FrustumFromCamera(camera, bounds.z - bounds.x, bounds.w - bounds.y, projMat.GetData());
 
-        ImGuizmo::Manipulate(
+        bool manipulated = ImGuizmo::Manipulate(
             viewMat.GetData(),
             projMat.GetData(),
             m_Op,
@@ -121,7 +121,8 @@ void EditTools::ImGuizmoTool::DrawViewport(const Vec4& bounds, const CCamera& ca
             nullptr, // deltaMatrix
             m_pSnapKey->IsHeldDown() ? & m_Snap.x : nullptr);
 
-        pManip->SetObjectWorldTM(activeObj, Matrix34(ImGuizmoToCry(objectTM)));
+        if (manipulated)
+            pManip->SetObjectWorldTM(activeObj, Matrix34(ImGuizmoToCry(objectTM)));
     }
 }
 

--- a/Preditor/EditTools/ImGuizmoTool.cpp
+++ b/Preditor/EditTools/ImGuizmoTool.cpp
@@ -1,3 +1,4 @@
+#include <Preditor/Input/IPreditorInput.h>
 #include <Preditor/SceneEditor/ISceneEditor.h>
 #include <Preditor/SceneEditor/IObjectManipulator.h>
 #include <Preditor/SceneEditor/SelectionManager.h>
@@ -76,10 +77,12 @@ void FrustumFromCamera(const CCamera& cam, float width, float height, float* m16
 
 } // namespace
 
-EditTools::ImGuizmoTool::ImGuizmoTool(EditToolManager* pMgr, ImGuizmo::OPERATION operation)
+EditTools::ImGuizmoTool::ImGuizmoTool(EditToolManager* pMgr, ImGuizmo::OPERATION operation, const Vec3& snap)
     : EditTool(pMgr)
 {
     m_Op = operation;
+    m_Snap = snap;
+    m_pSnapKey = gPreditor->pInput->FindAction("transform_tools.snap");
 }
 
 EditTools::ImGuizmoTool::~ImGuizmoTool()
@@ -114,7 +117,9 @@ void EditTools::ImGuizmoTool::DrawViewport(const Vec4& bounds, const CCamera& ca
             projMat.GetData(),
             m_Op,
             ImGuizmo::WORLD,
-            objectTM.GetData());
+            objectTM.GetData(),
+            nullptr, // deltaMatrix
+            m_pSnapKey->IsHeldDown() ? & m_Snap.x : nullptr);
 
         pManip->SetObjectWorldTM(activeObj, Matrix34(ImGuizmoToCry(objectTM)));
     }

--- a/Preditor/EditTools/ImGuizmoTool.h
+++ b/Preditor/EditTools/ImGuizmoTool.h
@@ -9,7 +9,7 @@ namespace EditTools
 class ImGuizmoTool : public EditTool
 {
 public:
-    ImGuizmoTool(EditToolManager* pMgr, ImGuizmo::OPERATION operation);
+    ImGuizmoTool(EditToolManager* pMgr, ImGuizmo::OPERATION operation, const Vec3& snap);
     ~ImGuizmoTool();
 
     // EditTool
@@ -18,7 +18,8 @@ public:
 
 private:
     ImGuizmo::OPERATION m_Op = (ImGuizmo::OPERATION)0;
-    IKeyAction* m_pAppendKey = nullptr;
+    Vec3 m_Snap = Vec3(ZERO);
+    IKeyAction* m_pSnapKey = nullptr;
 };
 
 } // namespace EditTools

--- a/Preditor/EditTools/ImGuizmoTool.h
+++ b/Preditor/EditTools/ImGuizmoTool.h
@@ -1,3 +1,4 @@
+#include <ImGuizmo/ImGuizmo.h>
 #include "EditTool.h"
 
 struct IKeyAction;
@@ -5,17 +6,18 @@ struct IKeyAction;
 namespace EditTools
 {
 
-class MoveTool : public EditTool
+class ImGuizmoTool : public EditTool
 {
 public:
-    MoveTool(EditToolManager* pMgr);
-    ~MoveTool();
+    ImGuizmoTool(EditToolManager* pMgr, ImGuizmo::OPERATION operation);
+    ~ImGuizmoTool();
 
     // EditTool
     virtual void DrawViewport(const Vec4& bounds, const CCamera& camera) override;
     virtual EEditToolResult OnLeftMouseClick(Vec2 clickPos, Vec2 vpSize);
 
 private:
+    ImGuizmo::OPERATION m_Op = (ImGuizmo::OPERATION)0;
     IKeyAction* m_pAppendKey = nullptr;
 };
 

--- a/Preditor/EditTools/MoveTool.cpp
+++ b/Preditor/EditTools/MoveTool.cpp
@@ -1,0 +1,105 @@
+#include <ImGuizmo/ImGuizmo.h>
+#include <Preditor/SceneEditor/ISceneEditor.h>
+#include <Preditor/SceneEditor/IObjectManipulator.h>
+#include <Preditor/SceneEditor/SelectionManager.h>
+#include "EditToolManager.h"
+#include "MoveTool.h"
+
+Matrix44 ToImGuizmo(const Matrix44& src)
+{
+    Matrix44 dest;
+
+    for (auto row = 0; row < 4; row++)
+    {
+        for (auto col = 0; col < 4; col++)
+            dest[row * 4 + col] = src[col * 4 + row];
+    }
+
+    return dest;
+}
+
+void Frustum(float left, float right, float bottom, float top, float znear, float zfar, float* m16)
+{
+    float temp, temp2, temp3, temp4;
+    temp = 2.0f * znear;
+    temp2 = right - left;
+    temp3 = top - bottom;
+    temp4 = zfar - znear;
+    m16[0] = temp / temp2;
+    m16[1] = 0.0;
+    m16[2] = 0.0;
+    m16[3] = 0.0;
+    m16[4] = 0.0;
+    m16[5] = temp / temp3;
+    m16[6] = 0.0;
+    m16[7] = 0.0;
+    m16[8] = (right + left) / temp2;
+    m16[9] = (top + bottom) / temp3;
+    m16[10] = (-zfar - znear) / temp4;
+    m16[11] = -1.0f;
+    m16[12] = 0.0;
+    m16[13] = 0.0;
+    m16[14] = (-temp * zfar) / temp4;
+    m16[15] = 0.0;
+}
+
+void Perspective(float fovyInDegrees, float aspectRatio, float znear, float zfar, float* m16)
+{
+    float ymax, xmax;
+    ymax = znear * tanf(fovyInDegrees * 3.141592f / 180.0f);
+    xmax = ymax * aspectRatio;
+    Frustum(-xmax, xmax, -ymax, ymax, znear, zfar, m16);
+}
+
+EditTools::MoveTool::MoveTool(EditToolManager* pMgr)
+    : EditTool(pMgr)
+{
+}
+
+EditTools::MoveTool::~MoveTool()
+{
+}
+
+void EditTools::MoveTool::DrawViewport(const Vec4& bounds, const Matrix44& projMat, const Matrix44& viewMat)
+{
+    ImVec2 windowPos = ImGui::GetWindowPos();
+    ImGuizmo::SetDrawlist();
+    ImGuizmo::SetRect(
+        windowPos.x + bounds.x,
+        windowPos.y + bounds.y,
+        bounds.z - bounds.x,
+        bounds.w - bounds.y);
+
+    ISceneEditor* pEditor = GetManager()->GetEditor();
+    SelectionManager* pSel = pEditor->GetSelection();
+    SceneObjectId activeObj = pSel->GetActiveObject();
+    
+    if (activeObj != INVALID_SCENE_OBJECT)
+    {
+        IObjectManipulator* pManip = pEditor->GetManipulator();
+        Matrix44 projMat2 = projMat.GetTransposed();
+        Matrix44 viewMat2 = viewMat.GetTransposed();
+        Matrix44 objectTM = pManip->GetObjectWorldTM(activeObj).GetTransposed();
+
+        // projMat2.m32 = -1 * projMat2.m32;
+        Matrix44 projMat2_compare = projMat.GetTransposed();
+        Perspective(90 / 2.0f, 1439.0f / 862.0f, 0.250f, 1024.0f, projMat2.GetData());
+
+        ImGuizmo::Manipulate(
+            viewMat2.GetData(),
+            projMat2.GetData(),
+            ImGuizmo::TRANSLATE,
+            ImGuizmo::WORLD,
+            objectTM.GetData());
+
+        pManip->SetObjectWorldTM(activeObj, Matrix34(objectTM.GetTransposed()));
+    }
+}
+
+EEditToolResult EditTools::MoveTool::OnLeftMouseClick(Vec2 clickPos, Vec2 vpSize)
+{
+    if (ImGuizmo::IsOver())
+        return EEditToolResult::Handled;
+    else
+        return EEditToolResult::Passthrough;
+}

--- a/Preditor/EditTools/MoveTool.h
+++ b/Preditor/EditTools/MoveTool.h
@@ -12,7 +12,7 @@ public:
     ~MoveTool();
 
     // EditTool
-    virtual void DrawViewport(const Vec4& bounds, const Matrix44& projMat, const Matrix44& viewMat) override;
+    virtual void DrawViewport(const Vec4& bounds, const CCamera& camera) override;
     virtual EEditToolResult OnLeftMouseClick(Vec2 clickPos, Vec2 vpSize);
 
 private:

--- a/Preditor/EditTools/MoveTool.h
+++ b/Preditor/EditTools/MoveTool.h
@@ -1,0 +1,22 @@
+#include "EditTool.h"
+
+struct IKeyAction;
+
+namespace EditTools
+{
+
+class MoveTool : public EditTool
+{
+public:
+    MoveTool(EditToolManager* pMgr);
+    ~MoveTool();
+
+    // EditTool
+    virtual void DrawViewport(const Vec4& bounds, const Matrix44& projMat, const Matrix44& viewMat) override;
+    virtual EEditToolResult OnLeftMouseClick(Vec2 clickPos, Vec2 vpSize);
+
+private:
+    IKeyAction* m_pAppendKey = nullptr;
+};
+
+} // namespace EditTools

--- a/Preditor/Engine/PreditorImGui.cpp
+++ b/Preditor/Engine/PreditorImGui.cpp
@@ -6,6 +6,7 @@
 #include <imgui.h>
 #include <imgui_internal.h>
 #include <imgui_impl_win32.h>
+#include <ImGuizmo/ImGuizmo.h>
 #include <App/Application.h>
 #include <Preditor/Main/IUserProjectSettings.h>
 #include <Preditor/Input/IPreditorInput.h>
@@ -173,6 +174,7 @@ void Engine::PreditorImGui::BeginFrame()
         ReloadFontsNow();
 
     ImGui::NewFrame();
+    ImGuizmo::BeginFrame();
 }
 
 void Engine::PreditorImGui::EndFrame()

--- a/Preditor/GameEditor/CMakeLists.txt
+++ b/Preditor/GameEditor/CMakeLists.txt
@@ -1,5 +1,7 @@
 set(SOURCE_FILES
 	CMakeLists.txt
+	EntityManipulator.cpp
+	EntityManipulator.h
 	EntitySelectionManager.cpp
 	EntitySelectionManager.h
 	GameEditMode.cpp

--- a/Preditor/GameEditor/EntityManipulator.cpp
+++ b/Preditor/GameEditor/EntityManipulator.cpp
@@ -34,3 +34,16 @@ void GameEditor::EntityManipulator::SetObjectWorldTM(SceneObjectId id, const Mat
 
     pEnt->SetWorldTM(tm, ENTITY_XFORM_EDITOR);
 }
+
+void GameEditor::EntityManipulator::GetObjectLocalBounds(SceneObjectId id, AABB& aabb)
+{
+    IEntity* pEnt = gEnv->pEntitySystem->GetEntity((EntityId)id);
+
+    if (!pEnt)
+    {
+        CryError("GetObjectLocalBounds called with invalid entity id {}", id);
+        return;
+    }
+
+    pEnt->GetLocalBounds(aabb);
+}

--- a/Preditor/GameEditor/EntityManipulator.cpp
+++ b/Preditor/GameEditor/EntityManipulator.cpp
@@ -1,0 +1,36 @@
+#include "EntityManipulator.h"
+
+GameEditor::EntityManipulator::EntityManipulator(GameEditMode* pEditor)
+{
+    m_pEditor = pEditor;
+}
+
+GameEditor::EntityManipulator::~EntityManipulator()
+{
+}
+
+Matrix34 GameEditor::EntityManipulator::GetObjectWorldTM(SceneObjectId id)
+{
+    IEntity* pEnt = gEnv->pEntitySystem->GetEntity((EntityId)id);
+
+    if (!pEnt)
+    {
+        CryError("GetObjectWorldTM called with invalid entity id {}", id);
+        return Matrix34(IDENTITY);
+    }
+
+    return pEnt->GetWorldTM();
+}
+
+void GameEditor::EntityManipulator::SetObjectWorldTM(SceneObjectId id, const Matrix34& tm)
+{
+    IEntity* pEnt = gEnv->pEntitySystem->GetEntity((EntityId)id);
+
+    if (!pEnt)
+    {
+        CryError("SetObjectWorldTM called with invalid entity id {}", id);
+        return;
+    }
+
+    pEnt->SetWorldTM(tm, ENTITY_XFORM_EDITOR);
+}

--- a/Preditor/GameEditor/EntityManipulator.h
+++ b/Preditor/GameEditor/EntityManipulator.h
@@ -1,0 +1,24 @@
+#pragma once
+#include <Preditor/SceneEditor/IObjectManipulator.h>
+
+namespace GameEditor
+{
+
+class GameEditMode;
+
+class EntityManipulator : public IObjectManipulator
+{
+public:
+    EntityManipulator(GameEditMode* pEditor);
+    ~EntityManipulator();
+
+protected:
+    // IObjectManipulator
+    virtual Matrix34 GetObjectWorldTM(SceneObjectId id) override;
+    virtual void SetObjectWorldTM(SceneObjectId id, const Matrix34& tm) override;
+
+private:
+    GameEditMode* m_pEditor = nullptr;
+};
+
+} // namespace GameEditor

--- a/Preditor/GameEditor/EntityManipulator.h
+++ b/Preditor/GameEditor/EntityManipulator.h
@@ -16,6 +16,7 @@ protected:
     // IObjectManipulator
     virtual Matrix34 GetObjectWorldTM(SceneObjectId id) override;
     virtual void SetObjectWorldTM(SceneObjectId id, const Matrix34& tm) override;
+    virtual void GetObjectLocalBounds(SceneObjectId id, AABB& aabb) override;
 
 private:
     GameEditMode* m_pEditor = nullptr;

--- a/Preditor/GameEditor/GameEditMode.cpp
+++ b/Preditor/GameEditor/GameEditMode.cpp
@@ -1,4 +1,5 @@
 #include <Preditor/EditTools/IEditToolManager.h>
+#include "EntityManipulator.h"
 #include "EntitySelectionManager.h"
 #include "GameEditMode.h"
 #include "GameViewportHandler.h"
@@ -16,6 +17,7 @@ GameEditor::GameEditMode::GameEditMode()
 {
     m_pSelection = std::make_unique<EntitySelectionManager>(this);
     m_pViewportHandler = std::make_unique<GameViewportHandler>(this);
+    m_pEntityManipulator = std::make_unique<EntityManipulator>(this);
     m_pEditToolManager = IEditToolManager::CreateInstance(this);
     m_pEntityHierarchy = std::make_unique<EntityHierarchy>();
     m_pEntityInspector = std::make_unique<EntityInspector>();
@@ -33,6 +35,11 @@ SelectionManager* GameEditor::GameEditMode::GetSelection()
 IViewportHandler* GameEditor::GameEditMode::GetViewport()
 {
     return m_pViewportHandler.get();
+}
+
+IObjectManipulator* GameEditor::GameEditMode::GetManipulator()
+{
+    return m_pEntityManipulator.get();
 }
 
 const char* GameEditor::GameEditMode::GetObjectName(SceneObjectId id)

--- a/Preditor/GameEditor/GameEditMode.h
+++ b/Preditor/GameEditor/GameEditMode.h
@@ -7,6 +7,7 @@ class EntityInspector;
 namespace GameEditor
 {
 
+class EntityManipulator;
 class EntitySelectionManager;
 class GameViewportHandler;
 
@@ -20,7 +21,7 @@ public:
     // ISceneEditor
     virtual SelectionManager* GetSelection() override;
     virtual IViewportHandler* GetViewport() override;
-    virtual IObjectManipulator* GetManipulator() override { return nullptr; } // TODO 2023-06-17
+    virtual IObjectManipulator* GetManipulator() override;
     virtual IEditToolManager* GetToolManager() override { return m_pEditToolManager.get(); }
     virtual UndoBuffer* GetUndoBuffer() override { return nullptr; } // TODO 2023-06-17
     virtual const char* GetObjectName(SceneObjectId id) override;
@@ -32,6 +33,7 @@ public:
 private:
     std::unique_ptr<EntitySelectionManager> m_pSelection;
     std::unique_ptr<GameViewportHandler> m_pViewportHandler;
+    std::unique_ptr<EntityManipulator> m_pEntityManipulator;
     std::unique_ptr<IEditToolManager> m_pEditToolManager;
     std::unique_ptr<EntityHierarchy> m_pEntityHierarchy;
     std::unique_ptr<EntityInspector> m_pEntityInspector;

--- a/Preditor/LevelEditor/CMakeLists.txt
+++ b/Preditor/LevelEditor/CMakeLists.txt
@@ -15,6 +15,8 @@ set(SOURCE_FILES
 	Objects/Object.cpp
 	Objects/Object.h
 
+	Utils/AffineParts.cpp
+	Utils/AffineParts.h
 	Utils/InspectorHelpers.cpp
 	Utils/InspectorHelpers.h
 
@@ -25,6 +27,8 @@ set(SOURCE_FILES
 	LevelViewportHandler.h
 	ObjectManager.cpp
 	ObjectManager.h
+	ObjectManipulator.cpp
+	ObjectManipulator.h
 	ObjectSelectionManager.cpp
 	ObjectSelectionManager.h
 	pch.h

--- a/Preditor/LevelEditor/Components/Transform.cpp
+++ b/Preditor/LevelEditor/Components/Transform.cpp
@@ -1,5 +1,6 @@
 #include "Components/Transform.h"
 #include "Objects/Object.h"
+#include "Utils/AffineParts.h"
 
 LevelEditor::Transform::Transform()
 {
@@ -35,6 +36,27 @@ void LevelEditor::Transform::SetPosRotScale(const Vec3& pos, const Quat& rot, co
     m_Rot = rot;
     m_Scale = scale;
     InvalidateTM(ENTITY_XFORM_POS | ENTITY_XFORM_ROT | ENTITY_XFORM_SCL);
+}
+
+void LevelEditor::Transform::SetLocalTM(const Matrix34& tm)
+{
+    if (tm.IsOrthonormal())
+    {
+        SetPosRotScale(tm.GetTranslation(), Quat(tm), Vec3(1.0f));
+    }
+    else
+    {
+        AffineParts affineParts;
+        affineParts.SpectralDecompose(tm);
+
+        SetPosRotScale(affineParts.pos, affineParts.rot, affineParts.scale);
+    }
+}
+
+void LevelEditor::Transform::SetWorldTM(const Matrix34& tm)
+{
+    // TODO 2023-07-16: Transform hierarchy
+    SetLocalTM(tm);
 }
 
 void LevelEditor::Transform::InvalidateTM(unsigned nWhyFlags)

--- a/Preditor/LevelEditor/Components/Transform.h
+++ b/Preditor/LevelEditor/Components/Transform.h
@@ -25,10 +25,14 @@ public:
     void SetRot(const Quat& rot);
     void SetScale(const Vec3& scale);
     void SetPosRotScale(const Vec3& pos, const Quat& rot, const Vec3& scale);
+    void SetLocalTM(const Matrix34& tm);
     //! @}
     
     //! @returns world-space tranformation matrix.
     const Matrix34& GetWorldTM() const { return m_WMat; }
+
+    //! Sets the world-space tranformation matrix.
+    void SetWorldTM(const Matrix34& tm);
 
     //! Invalidates the transformation matrix.
     //! @param  nWhyFlags   Mask of EEntityXFormFlags. Informs what has changed.

--- a/Preditor/LevelEditor/LevelEditMode.cpp
+++ b/Preditor/LevelEditor/LevelEditMode.cpp
@@ -13,6 +13,7 @@
 #include "LevelEditMode.h"
 #include "LevelViewportHandler.h"
 #include "ObjectManager.h"
+#include "ObjectManipulator.h"
 
 // Implements EntitySystemSink for play mode.
 struct LevelEditor::LevelEditMode::SInGameEntitySystemListener : public IEntitySystemSink
@@ -100,6 +101,7 @@ LevelEditor::LevelEditMode::LevelEditMode()
     m_pViewportHandler = std::make_unique<LevelViewportHandler>(this);
     m_pEditToolManager = IEditToolManager::CreateInstance(this);
     m_pObjectManager = std::make_unique<ObjectManager>();
+    m_pObjectManipulator = std::make_unique<ObjectManipulator>(this);
 
     // Disable save/load
     m_pCanSaveLoad = gEnv->pConsole->GetCVar("g_EnableLoadSave");
@@ -125,6 +127,11 @@ SelectionManager* LevelEditor::LevelEditMode::GetSelection()
 IViewportHandler* LevelEditor::LevelEditMode::GetViewport()
 {
     return m_pViewportHandler.get();
+}
+
+IObjectManipulator* LevelEditor::LevelEditMode::GetManipulator()
+{
+    return m_pObjectManipulator.get();
 }
 
 const char* LevelEditor::LevelEditMode::GetObjectName(SceneObjectId id)

--- a/Preditor/LevelEditor/LevelEditMode.h
+++ b/Preditor/LevelEditor/LevelEditMode.h
@@ -7,6 +7,7 @@ namespace LevelEditor
 class ObjectSelectionManager;
 class LevelViewportHandler;
 class ObjectManager;
+class ObjectManipulator;
 
 //! Runtime entity editing.
 class LevelEditMode : public ILevelSceneEditor
@@ -20,7 +21,7 @@ public:
     // ISceneEditor
     virtual SelectionManager* GetSelection() override;
     virtual IViewportHandler* GetViewport() override;
-    virtual IObjectManipulator* GetManipulator() override { return nullptr; } // TODO 2023-06-17
+    virtual IObjectManipulator* GetManipulator() override;
     virtual IEditToolManager* GetToolManager() override { return m_pEditToolManager.get(); }
     virtual UndoBuffer* GetUndoBuffer() override { return nullptr; } // TODO 2023-06-17
     virtual const char* GetObjectName(SceneObjectId id) override;
@@ -41,6 +42,7 @@ private:
     std::unique_ptr<LevelViewportHandler> m_pViewportHandler;
     std::unique_ptr<IEditToolManager> m_pEditToolManager;
     std::unique_ptr<ObjectManager> m_pObjectManager;
+    std::unique_ptr<ObjectManipulator> m_pObjectManipulator;
     ICVar* m_pCanSaveLoad = nullptr;
 
     std::unique_ptr<SInGameEntitySystemListener> m_pEntitySystemListener;

--- a/Preditor/LevelEditor/ObjectManipulator.cpp
+++ b/Preditor/LevelEditor/ObjectManipulator.cpp
@@ -1,0 +1,45 @@
+#include "Objects/Object.h"
+#include "LevelEditMode.h"
+#include "ObjectManager.h"
+#include "ObjectManipulator.h"
+
+LevelEditor::ObjectManipulator::ObjectManipulator(LevelEditMode* pEditor)
+{
+    m_pEditor = pEditor;
+}
+
+LevelEditor::ObjectManipulator::~ObjectManipulator()
+{
+}
+
+Matrix34 LevelEditor::ObjectManipulator::GetObjectWorldTM(SceneObjectId id)
+{
+    Object* pObject = m_pEditor->GetObjectManager()->GetObject(id);
+
+    if (!pObject)
+    {
+        CryError("GetObjectWorldTM called with invalid object id {}", id);
+        return Matrix34(IDENTITY);
+    }
+
+    return pObject->GetTransform()->GetWorldTM();
+}
+
+void LevelEditor::ObjectManipulator::SetObjectWorldTM(SceneObjectId id, const Matrix34& tm)
+{
+    Object* pObject = m_pEditor->GetObjectManager()->GetObject(id);
+
+    if (!pObject)
+    {
+        CryError("SetObjectWorldTM called with invalid entity id {}", id);
+        return;
+    }
+
+    pObject->GetTransform()->SetWorldTM(tm);
+}
+
+void LevelEditor::ObjectManipulator::GetObjectLocalBounds(SceneObjectId id, AABB& aabb)
+{
+    // TODO 2023-01-01: Implement this
+    aabb = AABB::RESET;
+}

--- a/Preditor/LevelEditor/ObjectManipulator.h
+++ b/Preditor/LevelEditor/ObjectManipulator.h
@@ -1,0 +1,25 @@
+#pragma once
+#include <Preditor/SceneEditor/IObjectManipulator.h>
+
+namespace LevelEditor
+{
+
+class LevelEditMode;
+
+class ObjectManipulator : public IObjectManipulator
+{
+public:
+    ObjectManipulator(LevelEditMode* pEditor);
+    ~ObjectManipulator();
+
+protected:
+    // IObjectManipulator
+    virtual Matrix34 GetObjectWorldTM(SceneObjectId id) override;
+    virtual void SetObjectWorldTM(SceneObjectId id, const Matrix34& tm) override;
+    virtual void GetObjectLocalBounds(SceneObjectId id, AABB& aabb) override;
+
+private:
+    LevelEditMode* m_pEditor = nullptr;
+};
+
+} // namespace GameEditor

--- a/Preditor/LevelEditor/Objects/EntityObject.cpp
+++ b/Preditor/LevelEditor/Objects/EntityObject.cpp
@@ -71,12 +71,12 @@ void LevelEditor::EntityObject::RespawnEntity()
     }
 }
 
-void LevelEditor::EntityObject::ApplyTranformToEntity()
+void LevelEditor::EntityObject::ApplyTranformToEntity(unsigned nWhyFlags)
 {
     if (m_pEntity)
     {
         Transform* t = GetTransform();
-        m_pEntity->SetPosRotScale(t->GetPos(), t->GetRot(), t->GetScale(), ENTITY_XFORM_EDITOR);
+        m_pEntity->SetPosRotScale(t->GetPos(), t->GetRot(), t->GetScale(), nWhyFlags | ENTITY_XFORM_EDITOR);
     }
 }
 
@@ -122,6 +122,12 @@ void LevelEditor::EntityObject::ShowInspectorSelf()
 
     if (ImGui::Button("Respawn"))
         RespawnEntity();
+}
+
+void LevelEditor::EntityObject::OnTransformChanged(unsigned nWhyFlags)
+{
+    Object::OnTransformChanged(nWhyFlags);
+    ApplyTranformToEntity(nWhyFlags);
 }
 
 void LevelEditor::EntityObject::OnEnterPlayMode()

--- a/Preditor/LevelEditor/Objects/EntityObject.h
+++ b/Preditor/LevelEditor/Objects/EntityObject.h
@@ -23,11 +23,12 @@ public:
     void RespawnEntity();
 
     //! Applies the object tranform to the entity.
-    void ApplyTranformToEntity();
+    void ApplyTranformToEntity(unsigned nWhyFlags = 0);
 
     // Object
     virtual void Init(XmlNodeRef objectNode) override;
     virtual void ShowInspectorSelf() override;
+    virtual void OnTransformChanged(unsigned nWhyFlags) override;
     virtual void OnEnterPlayMode() override;
     virtual void OnExitPlayMode() override;
     virtual bool IntersectRay(const ViewportRaycastInfo& ray, RayIntersectInfo& intersect) override;

--- a/Preditor/LevelEditor/Utils/AffineParts.cpp
+++ b/Preditor/LevelEditor/Utils/AffineParts.cpp
@@ -1,0 +1,780 @@
+// Copyright 2001-2016 Crytek GmbH / Crytek Group. All rights reserved.
+
+/**** Decompose.c ****/
+/* Ken Shoemake, 1993 */
+
+#include "AffineParts.h"
+
+#pragma warning ( push )  // conversion from 'double' to 'float', possible loss of data.
+#pragma warning ( disable : 4244 )  // conversion from 'double' to 'float', possible loss of data.
+#pragma warning ( disable : 6246 )  // Local declaration of 'i' hides declaration of the same name in outer scope.
+
+/**** Decompose.h - Basic declarations ****/
+typedef struct
+{
+	float x, y, z, w;
+} Quatern;                                  /* Quaternernion */
+enum QuaternPart {X, Y, Z, W};
+typedef Quatern HVect;         /* Homogeneous 3D vector */
+typedef float   HMatrix[4][4]; /* Right-handed, for column vectors */
+typedef struct
+{
+	HVect   t;  /* Translation components */
+	Quatern q;  /* Essential rotation   */
+	Quatern u;  /* Stretch rotation   */
+	HVect   k;  /* Stretch factors    */
+	float   f;  /* Sign of determinant    */
+} SAffineParts;
+
+/******* Matrix Preliminaries *******/
+
+/** Fill out 3x3 matrix to 4x4 **/
+#define mat_pad(A) (A[W][X] = A[X][W] = A[W][Y] = A[Y][W] = A[W][Z] = A[Z][W] = 0, A[W][W] = 1)
+
+/** Copy nxn matrix A to C using "gets" for assignment **/
+#define mat_copy(C, gets, A, n) { int i, j; for (i = 0; i < n; i++) \
+  for (j = 0; j < n; j++)                                           \
+    C[i][j] gets(A[i][j]); }
+
+/** Copy transpose of nxn matrix A to C using "gets" for assignment **/
+#define mat_tpose(AT, gets, A, n) { int i, j; for (i = 0; i < n; i++) \
+  for (j = 0; j < n; j++)                                             \
+    AT[i][j] gets(A[j][i]); }
+
+/** Assign nxn matrix C the element-wise combination of A and B using "op" **/
+#define mat_binop(C, gets, A, op, B, n) { int i, j; for (i = 0; i < n; i++) \
+  for (j = 0; j < n; j++)                                                   \
+    C[i][j] gets(A[i][j]) op(B[i][j]); }
+
+/** Multiply the upper left 3x3 parts of A and B to get AB **/
+static void mat_mult(HMatrix A, HMatrix B, HMatrix AB)
+{
+	int i, j;
+	for (i = 0; i < 3; i++)
+		for (j = 0; j < 3; j++)
+			AB[i][j] = A[i][0] * B[0][j] + A[i][1] * B[1][j] + A[i][2] * B[2][j];
+}
+
+/** Return dot product of length 3 vectors va and vb **/
+static float vdot(float* va, float* vb)
+{
+	return (va[0] * vb[0] + va[1] * vb[1] + va[2] * vb[2]);
+}
+
+/** Set v to cross product of length 3 vectors va and vb **/
+static void vcross(float* va, float* vb, float* v)
+{
+	v[0] = va[1] * vb[2] - va[2] * vb[1];
+	v[1] = va[2] * vb[0] - va[0] * vb[2];
+	v[2] = va[0] * vb[1] - va[1] * vb[0];
+}
+
+/** Set MadjT to transpose of inverse of M times determinant of M **/
+static void adjoint_transpose(HMatrix M, HMatrix MadjT)
+{
+	vcross(M[1], M[2], MadjT[0]);
+	vcross(M[2], M[0], MadjT[1]);
+	vcross(M[0], M[1], MadjT[2]);
+}
+
+/******* Quaternernion Preliminaries *******/
+
+/* Construct a (possibly non-unit) Quaternernion from real components. */
+static Quatern Qt_(float x, float y, float z, float w)
+{
+	Quatern qq;
+	qq.x = x;
+	qq.y = y;
+	qq.z = z;
+	qq.w = w;
+	return (qq);
+}
+
+/* Return conjugate of Quaternernion. */
+static Quatern Qt_Conj(Quatern q)
+{
+	Quatern qq;
+	qq.x = -q.x;
+	qq.y = -q.y;
+	qq.z = -q.z;
+	qq.w = q.w;
+	return (qq);
+}
+
+/* Return Quaternernion product qL * qR.  Note: order is important!
+ * To combine rotations, use the product Mul(qSecond, qFirst),
+ * which gives the effect of rotating by qFirst then qSecond. */
+static Quatern Qt_Mul(Quatern qL, Quatern qR)
+{
+	Quatern qq;
+	qq.w = qL.w * qR.w - qL.x * qR.x - qL.y * qR.y - qL.z * qR.z;
+	qq.x = qL.w * qR.x + qL.x * qR.w + qL.y * qR.z - qL.z * qR.y;
+	qq.y = qL.w * qR.y + qL.y * qR.w + qL.z * qR.x - qL.x * qR.z;
+	qq.z = qL.w * qR.z + qL.z * qR.w + qL.x * qR.y - qL.y * qR.x;
+	return (qq);
+}
+
+/* Return product of Quaternernion q by scalar w. */
+static Quatern Qt_Scale(Quatern q, float w)
+{
+	Quatern qq;
+	qq.w = q.w * w;
+	qq.x = q.x * w;
+	qq.y = q.y * w;
+	qq.z = q.z * w;
+	return (qq);
+}
+
+/* Construct a unit Quaternernion from rotation matrix.  Assumes matrix is
+ * used to multiply column vector on the left: vnew = mat vold.  Works
+ * correctly for right-handed coordinate system and right-handed rotations.
+ * Translation and perspective components ignored. */
+static Quatern Qt_FromMatrix(HMatrix mat)
+{
+	/* This algorithm avoids near-zero divides by looking for a large component
+	 * - first w, then x, y, or z.  When the trace is greater than zero,
+	 * |w| is greater than 1/2, which is as small as a largest component can be.
+	 * Otherwise, the largest diagonal entry corresponds to the largest of |x|,
+	 * |y|, or |z|, one of which must be larger than |w|, and at least 1/2. */
+	Quatern qu;
+	double tr, s;
+
+	tr = mat[X][X] + mat[Y][Y] + mat[Z][Z];
+	if (tr >= 0.0)
+	{
+		s = sqrtf(tr + mat[W][W]);
+		qu.w = s * 0.5;
+		s = 0.5 / s;
+		qu.x = (mat[Z][Y] - mat[Y][Z]) * s;
+		qu.y = (mat[X][Z] - mat[Z][X]) * s;
+		qu.z = (mat[Y][X] - mat[X][Y]) * s;
+	}
+	else
+	{
+		int h = X;
+		if (mat[Y][Y] > mat[X][X]) h = Y;
+		if (mat[Z][Z] > mat[h][h]) h = Z;
+		switch (h)
+		{
+#define caseMacro(i, j, k, I, J, K)                              \
+  case I:                                                        \
+    s = sqrt((mat[I][I] - (mat[J][J] + mat[K][K])) + mat[W][W]); \
+    qu.i = s * 0.5;                                              \
+    s = 0.5 / s;                                                 \
+    qu.j = (mat[I][J] + mat[J][I]) * s;                          \
+    qu.k = (mat[K][I] + mat[I][K]) * s;                          \
+    qu.w = (mat[K][J] - mat[J][K]) * s;                          \
+    break
+			caseMacro(x, y, z, X, Y, Z);
+			caseMacro(y, z, x, Y, Z, X);
+			caseMacro(z, x, y, Z, X, Y);
+		}
+	}
+	if (mat[W][W] != 1.0) qu = Qt_Scale(qu, 1.0f / sqrtf(mat[W][W]));
+	return (qu);
+}
+/******* Decomp Auxiliaries *******/
+
+static HMatrix mat_id = {
+	{ 1, 0, 0, 0 }, { 0, 1, 0, 0 }, { 0, 0, 1, 0 }, { 0, 0, 0, 1 }
+};
+
+/** Compute either the 1 or infinity norm of M, depending on tpose **/
+static float mat_norm(HMatrix M, int tpose)
+{
+	int i;
+	float sum, max;
+	max = 0.0;
+	for (i = 0; i < 3; i++)
+	{
+		if (tpose) sum = fabs(M[0][i]) + fabs(M[1][i]) + fabs(M[2][i]);
+		else     sum = fabs(M[i][0]) + fabs(M[i][1]) + fabs(M[i][2]);
+		if (max < sum) max = sum;
+	}
+	return max;
+}
+
+static float norm_inf(HMatrix M) { return mat_norm(M, 0); }
+static float norm_one(HMatrix M) { return mat_norm(M, 1); }
+
+/** Return index of column of M containing maximum abs entry, or -1 if M=0 **/
+static int find_max_col(HMatrix M)
+{
+	float abs, max;
+	int i, j, col;
+	max = 0.0;
+	col = -1;
+	for (i = 0; i < 3; i++)
+		for (j = 0; j < 3; j++)
+		{
+			abs = M[i][j];
+			if (abs < 0.0f) abs = -abs;
+			if (abs > max) { max = abs; col = j; }
+		}
+	return col;
+}
+
+/** Setup u for Household reflection to zero all v components but first **/
+static void make_reflector(float* v, float* u)
+{
+	float s = sqrtf(vdot(v, v));
+	u[0] = v[0];
+	u[1] = v[1];
+	u[2] = v[2] + ((v[2] < 0.0f) ? -s : s);
+	s = sqrtf(2.0f / vdot(u, u));
+	u[0] = u[0] * s;
+	u[1] = u[1] * s;
+	u[2] = u[2] * s;
+}
+
+/** Apply Householder reflection represented by u to column vectors of M **/
+static void reflect_cols(HMatrix M, float* u)
+{
+	int i, j;
+	for (i = 0; i < 3; i++)
+	{
+		float s = u[0] * M[0][i] + u[1] * M[1][i] + u[2] * M[2][i];
+		for (j = 0; j < 3; j++)
+			M[j][i] -= u[j] * s;
+	}
+}
+/** Apply Householder reflection represented by u to row vectors of M **/
+static void reflect_rows(HMatrix M, float* u)
+{
+	int i, j;
+	for (i = 0; i < 3; i++)
+	{
+		float s = vdot(u, M[i]);
+		for (j = 0; j < 3; j++)
+			M[i][j] -= u[j] * s;
+	}
+}
+
+/** Find orthogonal factor Q of rank 1 (or less) M **/
+static void do_rank1(HMatrix M, HMatrix Q)
+{
+	float v1[3], v2[3], s;
+	int col;
+	mat_copy(Q, =, mat_id, 4);
+	/* If rank(M) is 1, we should find a non-zero column in M */
+	col = find_max_col(M);
+	if (col < 0) return; /* Rank is 0 */
+	v1[0] = M[0][col];
+	v1[1] = M[1][col];
+	v1[2] = M[2][col];
+	make_reflector(v1, v1);
+	reflect_cols(M, v1);
+	v2[0] = M[2][0];
+	v2[1] = M[2][1];
+	v2[2] = M[2][2];
+	make_reflector(v2, v2);
+	reflect_rows(M, v2);
+	s = M[2][2];
+	if (s < 0.0f) Q[2][2] = -1.0;
+	reflect_cols(Q, v1);
+	reflect_rows(Q, v2);
+}
+
+/** Find orthogonal factor Q of rank 2 (or less) M using adjoint transpose **/
+static void do_rank2(HMatrix M, HMatrix MadjT, HMatrix Q)
+{
+	float v1[3], v2[3];
+	float w, x, y, z, c, s, d;
+	int col;
+	/* If rank(M) is 2, we should find a non-zero column in MadjT */
+	col = find_max_col(MadjT);
+	if (col < 0) { do_rank1(M, Q); return; } /* Rank<2 */
+	v1[0] = MadjT[0][col];
+	v1[1] = MadjT[1][col];
+	v1[2] = MadjT[2][col];
+	make_reflector(v1, v1);
+	reflect_cols(M, v1);
+	vcross(M[0], M[1], v2);
+	make_reflector(v2, v2);
+	reflect_rows(M, v2);
+	w = M[0][0];
+	x = M[0][1];
+	y = M[1][0];
+	z = M[1][1];
+	if (w * z > x * y)
+	{
+		c = z + w;
+		s = y - x;
+		d = sqrtf(c * c + s * s);
+		c = c / d;
+		s = s / d;
+		Q[0][0] = Q[1][1] = c;
+		Q[0][1] = -(Q[1][0] = s);
+	}
+	else
+	{
+		c = z - w;
+		s = y + x;
+		d = sqrtf(c * c + s * s);
+		c = c / d;
+		s = s / d;
+		Q[0][0] = -(Q[1][1] = c);
+		Q[0][1] = Q[1][0] = s;
+	}
+	Q[0][2] = Q[2][0] = Q[1][2] = Q[2][1] = 0.0;
+	Q[2][2] = 1.0;
+	reflect_cols(Q, v1);
+	reflect_rows(Q, v2);
+}
+
+/******* Polar Decomposition *******/
+
+/* Polar Decomposition of 3x3 matrix in 4x4,
+ * M = QS.  See Nicholas Higham and Robert S. Schreiber,
+ * Fast Polar Decomposition of An Arbitrary Matrix,
+ * Technical Report 88-942, October 1988,
+ * Department of Computer Science, Cornell University.
+ */
+static float polar_decomp(HMatrix M, HMatrix Q, HMatrix S)
+{
+#define TOL 1.0e-6
+	HMatrix Mk, MadjTk, Ek;
+	float det, M_one, M_inf, MadjT_one, MadjT_inf, E_one, gamma, g1, g2;
+	int i, j;
+	mat_tpose(Mk, =, M, 3);
+	M_one = norm_one(Mk);
+	M_inf = norm_inf(Mk);
+	do
+	{
+		adjoint_transpose(Mk, MadjTk);
+		det = vdot(Mk[0], MadjTk[0]);
+		if (det == 0.0f) { do_rank2(Mk, MadjTk, Mk); break; }
+		MadjT_one = norm_one(MadjTk);
+		MadjT_inf = norm_inf(MadjTk);
+		gamma = sqrtf(sqrtf((MadjT_one * MadjT_inf) / (M_one * M_inf)) / fabs(det));
+		g1 = gamma * 0.5f;
+		g2 = 0.5f / (gamma * det);
+		mat_copy(Ek, =, Mk, 3);
+		mat_binop(Mk, =, g1 * Mk, +, g2 * MadjTk, 3);
+		mat_copy(Ek, -=, Mk, 3);
+		E_one = norm_one(Ek);
+		M_one = norm_one(Mk);
+		M_inf = norm_inf(Mk);
+	}
+	while (E_one > (M_one * TOL));
+	mat_tpose(Q, =, Mk, 3);
+	mat_pad(Q);
+	mat_mult(Mk, M, S);
+	mat_pad(S);
+	for (i = 0; i < 3; i++)
+		for (j = i; j < 3; j++)
+			S[i][j] = S[j][i] = 0.5f * (S[i][j] + S[j][i]);
+	return (det);
+}
+
+/******* Spectral Decomposition *******/
+
+/* Compute the spectral decomposition of symmetric positive semi-definite S.
+ * Returns rotation in U and scale factors in result, so that if K is a diagonal
+ * matrix of the scale factors, then S = U K (U transpose). Uses Jacobi method.
+ * See Gene H. Golub and Charles F. Van Loan. Matrix Computations. Hopkins 1983.
+ */
+static HVect spect_decomp(HMatrix S, HMatrix U)
+{
+	HVect kv;
+	double Diag[3], OffD[3];  /* OffD is off-diag (by omitted index) */
+	double g, h, fabsh, fabsOffDi, t, theta, c, s, tau, ta, OffDq, a, b;
+	static char nxt[] = { Y, Z, X };
+	int sweep, i, j;
+	mat_copy(U, =, mat_id, 4);
+	Diag[X] = S[X][X];
+	Diag[Y] = S[Y][Y];
+	Diag[Z] = S[Z][Z];
+	OffD[X] = S[Y][Z];
+	OffD[Y] = S[Z][X];
+	OffD[Z] = S[X][Y];
+	for (sweep = 20; sweep > 0; sweep--)
+	{
+		float sm = fabs(OffD[X]) + fabs(OffD[Y]) + fabs(OffD[Z]);
+		if (sm == 0.0f) break;
+		for (i = Z; i >= X; i--)
+		{
+			int p = nxt[i];
+			int q = nxt[p];
+			fabsOffDi = fabs(OffD[i]);
+			g = 100.0 * fabsOffDi;
+			if (fabsOffDi > 0.0f)
+			{
+				h = Diag[q] - Diag[p];
+				fabsh = fabs(h);
+				if (fabsh > FLT_EPSILON && (fabsh + g == fabsh))
+				{
+					t = OffD[i] / h;
+				}
+				else
+				{
+					theta = 0.5 * h / OffD[i];
+					t = 1.0f / (fabs(theta) + sqrtf(theta * theta + 1.0));
+					if (theta < 0.0f) t = -t;
+				}
+				c = 1.0f / sqrtf(t * t + 1.0f);
+				s = t * c;
+				tau = s / (c + 1.0f);
+				ta = t * OffD[i];
+				OffD[i] = 0.0f;
+				Diag[p] -= ta;
+				Diag[q] += ta;
+				OffDq = OffD[q];
+				OffD[q] -= s * (OffD[p] + tau * OffD[q]);
+				OffD[p] += s * (OffDq - tau * OffD[p]);
+				for (j = Z; j >= X; j--)
+				{
+					a = U[j][p];
+					b = U[j][q];
+					U[j][p] -= s * (b + tau * a);
+					U[j][q] += s * (a - tau * b);
+				}
+			}
+		}
+	}
+	kv.x = Diag[X];
+	kv.y = Diag[Y];
+	kv.z = Diag[Z];
+	kv.w = 1.0;
+	return (kv);
+}
+
+/******* Spectral Axis Adjustment *******/
+
+/* Given a unit Quaternernion, q, and a scale vector, k, find a unit Quaternernion, p,
+ * which permutes the axes and turns freely in the plane of duplicate scale
+ * factors, such that q p has the largest possible w component, i.e. the
+ * smallest possible angle. Permutes k's components to go with q p instead of q.
+ * See Ken Shoemake and Tom Duff. Matrix Animation and Polar Decomposition.
+ * Proceedings of Graphics Interface 1992. Details on p. 262-263.
+ */
+static Quatern snuggle(Quatern q, HVect* k)
+{
+#define SQRTHALF (0.7071067811865475244f)
+#define sgn(n, v)     ((n) ? -(v) : (v))
+#define swap(a, i, j) { a[3] = a[i]; a[i] = a[j]; a[j] = a[3]; }
+#define cycle(a, p)   if (p) { a[3] = a[0]; a[0] = a[1]; a[1] = a[2]; a[2] = a[3]; } \
+  else { a[3] = a[2]; a[2] = a[1]; a[1] = a[0]; a[0] = a[3]; }
+	Quatern p;
+	float ka[4];
+	int i, turn = -1;
+	ka[X] = k->x;
+	ka[Y] = k->y;
+	ka[Z] = k->z;
+	if (ka[X] == ka[Y]) { if (ka[X] == ka[Z]) turn = W; else turn = Z; }
+	else
+	{
+		if (ka[X] == ka[Z])
+			turn = Y;
+		else if (ka[Y] == ka[Z])
+			turn = X;
+	}
+	if (turn >= 0)
+	{
+		Quatern qtoz, qp;
+		unsigned neg[3], win;
+		double mag[3], t;
+		static Quatern qxtoz = { 0, SQRTHALF, 0, SQRTHALF };
+		static Quatern qytoz = { SQRTHALF, 0, 0, SQRTHALF };
+		static Quatern qppmm = { 0.5, 0.5, -0.5, -0.5 };
+		static Quatern qpppp = { 0.5, 0.5, 0.5, 0.5 };
+		static Quatern qmpmm = { -0.5, 0.5, -0.5, -0.5 };
+		static Quatern qpppm = { 0.5, 0.5, 0.5, -0.5 };
+		static Quatern q0001 = { 0.0, 0.0, 0.0, 1.0 };
+		static Quatern q1000 = { 1.0, 0.0, 0.0, 0.0 };
+		switch (turn)
+		{
+		default:
+			return (Qt_Conj(q));
+		case X:
+			q = Qt_Mul(q, qtoz = qxtoz);
+			swap(ka, X, Z);
+			break;
+		case Y:
+			q = Qt_Mul(q, qtoz = qytoz);
+			swap(ka, Y, Z);
+			break;
+		case Z:
+			qtoz = q0001;
+			break;
+		}
+		q = Qt_Conj(q);
+		mag[0] = (double)q.z * q.z + (double)q.w * q.w - 0.5;
+		mag[1] = (double)q.x * q.z - (double)q.y * q.w;
+		mag[2] = (double)q.y * q.z + (double)q.x * q.w;
+		for (i = 0; i < 3; i++)
+			if (neg[i] = (mag[i] < 0.0)) mag[i] = -mag[i];
+		if (mag[0] > mag[1]) { if (mag[0] > mag[2]) win = 0; else win = 2; }
+		else { if (mag[1] > mag[2]) win = 1; else win = 2; }
+		switch (win)
+		{
+		case 0:
+			if (neg[0]) p = q1000; else p = q0001; break;
+		case 1:
+			if (neg[1]) p = qppmm; else p = qpppp; cycle(ka, 0);
+			break;
+		case 2:
+			if (neg[2]) p = qmpmm; else p = qpppm; cycle(ka, 1);
+			break;
+		}
+		qp = Qt_Mul(q, p);
+		t = sqrtf(mag[win] + 0.5f);
+		p = Qt_Mul(p, Qt_(0.0, 0.0, -qp.z / t, qp.w / t));
+		p = Qt_Mul(qtoz, Qt_Conj(p));
+	}
+	else
+	{
+		float qa[4], pa[4];
+		unsigned lo, hi, neg[4], par = 0;
+		double all, big, two;
+		qa[0] = q.x;
+		qa[1] = q.y;
+		qa[2] = q.z;
+		qa[3] = q.w;
+		for (i = 0; i < 4; i++)
+		{
+			pa[i] = 0.0;
+			if (neg[i] = (qa[i] < 0.0)) qa[i] = -qa[i];
+			par ^= neg[i];
+		}
+		/* Find two largest components, indices in hi and lo */
+		if (qa[0] > qa[1]) lo = 0; else lo = 1;
+		if (qa[2] > qa[3]) hi = 2; else hi = 3;
+		if (qa[lo] > qa[hi])
+		{
+			if (qa[lo ^ 1] > qa[hi]) { hi = lo; lo ^= 1; }
+			else { hi ^= lo; lo ^= hi; hi ^= lo; }
+		}
+		else { if (qa[hi ^ 1] > qa[lo]) lo = hi ^ 1; }
+		all = (qa[0] + qa[1] + qa[2] + qa[3]) * 0.5;
+		two = (qa[hi] + qa[lo]) * SQRTHALF;
+		big = qa[hi];
+		if (all > two)
+		{
+			if (all > big)/*all*/
+			{
+				{
+					int i;
+					for (i = 0; i < 4; i++)
+						pa[i] = sgn(neg[i], 0.5);
+				}
+				cycle(ka, par)
+			}
+			else { /*big*/ pa[hi] = sgn(neg[hi], 1.0); }
+		}
+		else
+		{
+			if (two > big)/*two*/
+			{
+				pa[hi] = sgn(neg[hi], SQRTHALF);
+				pa[lo] = sgn(neg[lo], SQRTHALF);
+				if (lo > hi) { hi ^= lo; lo ^= hi; hi ^= lo; }
+				if (hi == W) { hi = "\001\002\000"[lo]; lo = 3 - hi - lo; }
+				swap(ka, hi, lo)
+			}
+			else { /*big*/ pa[hi] = sgn(neg[hi], 1.0); }
+		}
+		p.x = -pa[0];
+		p.y = -pa[1];
+		p.z = -pa[2];
+		p.w = pa[3];
+	}
+	k->x = ka[X];
+	k->y = ka[Y];
+	k->z = ka[Z];
+	return (p);
+
+#undef SQRTHALF
+#undef sgn
+#undef swap
+#undef cycle
+}
+
+/******* Decompose Affine Matrix *******/
+
+/* Decompose 4x4 affine matrix A as TFRUK(U transpose), where t contains the
+ * translation components, q contains the rotation R, u contains U, k contains
+ * scale factors, and f contains the sign of the determinant.
+ * Assumes A transforms column vectors in right-handed coordinates.
+ * See Ken Shoemake and Tom Duff. Matrix Animation and Polar Decomposition.
+ * Proceedings of Graphics Interface 1992.
+ */
+static void decomp_affine(HMatrix A, SAffineParts* parts)
+{
+	HMatrix Q, S, U;
+	Quatern p;
+	float det;
+	parts->t = Qt_(A[X][W], A[Y][W], A[Z][W], 0);
+	det = polar_decomp(A, Q, S);
+	if (det < 0.0)
+	{
+		mat_copy(Q, =, -Q, 3);
+		parts->f = -1;
+	}
+	else parts->f = 1;
+	parts->q = Qt_FromMatrix(Q);
+	parts->k = spect_decomp(S, U);
+	parts->u = Qt_FromMatrix(U);
+	p = snuggle(parts->u, &parts->k);
+	parts->u = Qt_Mul(parts->u, p);
+}
+
+static void spectral_decomp_affine(HMatrix A, SAffineParts* parts)
+{
+	HMatrix Q, S, U;
+	float det;
+
+	parts->t = Qt_(A[X][W], A[Y][W], A[Z][W], 0);
+	det = polar_decomp(A, Q, S);
+	if (det < 0.0)
+	{
+		mat_copy(Q, =, -Q, 3);
+		parts->f = -1;
+	}
+	else parts->f = 1;
+	parts->q = Qt_FromMatrix(Q);
+	parts->k = spect_decomp(S, U);
+	parts->u = Qt_FromMatrix(U);
+}
+
+/******* Invert Affine Decomposition *******/
+
+/* Compute inverse of affine decomposition.
+ */
+/*
+   static  void invert_affine(SAffineParts *parts, SAffineParts *inverse)
+   {
+    Quatern t, p;
+    inverse->f = parts->f;
+    inverse->q = Qt_Conj(parts->q);
+    inverse->u = Qt_Mul(parts->q, parts->u);
+    inverse->k.x = (parts->k.x==0.0) ? 0.0 : 1.0/parts->k.x;
+    inverse->k.y = (parts->k.y==0.0) ? 0.0 : 1.0/parts->k.y;
+    inverse->k.z = (parts->k.z==0.0) ? 0.0 : 1.0/parts->k.z;
+    inverse->k.w = parts->k.w;
+    t = Qt_(-parts->t.x, -parts->t.y, -parts->t.z, 0);
+    t = Qt_Mul(Qt_Conj(inverse->u), Qt_Mul(t, inverse->u));
+    t = Qt_(inverse->k.x*t.x, inverse->k.y*t.y, inverse->k.z*t.z, 0);
+    p = Qt_Mul(inverse->q, inverse->u);
+    t = Qt_Mul(p, Qt_Mul(t, Qt_Conj(p)));
+    inverse->t = (inverse->f>0.0) ? t : Qt_(-t.x, -t.y, -t.z, 0);
+   }
+
+
+   void  AffineParts::invert() {
+   SAffineParts parts,inverse;
+
+   parts.q.w = q.w; parts.q.x = q.x; parts.q.y = q.y; parts.q.z = q.z;
+   //parts.u.w = u.w; parts.u.x = u.x; parts.u.y = u.y; parts.u.z = u.z;
+   parts.u.w = 0; parts.u.x = 1; parts.u.y = 0; parts.u.z = 0;
+   parts.t.x = t.x; parts.t.y = t.y; parts.t.z = t.z;
+   parts.k.x = k.x; parts.k.y = k.y; parts.k.z = k.z;
+   //parts.f = f;
+   parts.f = 1;
+
+   invert_affine( &parts,&inverse );
+
+   q.set( inverse.q.w,inverse.q.x,inverse.q.y,inverse.q.z );
+   //  u.set( inverse.u.w,inverse.u.x,inverse.u.y,inverse.u.z );
+   t.set( inverse.t.x,inverse.t.y,inverse.t.z );
+   k.set( inverse.k.x,inverse.k.y,inverse.k.z );
+   //  f = inverse.f;
+   }
+ */
+
+// Decompose matrix to affine parts.
+void AffineParts::Decompose(const Matrix44& tm)
+{
+	SAffineParts parts;
+	HMatrix H;
+
+	H[X][X] = tm(0, 0);
+	H[X][Y] = tm(0, 1);
+	H[X][Z] = tm(0, 2);
+
+	H[Y][X] = tm(1, 0);
+	H[Y][Y] = tm(1, 1);
+	H[Y][Z] = tm(1, 2);
+
+	H[Z][X] = tm(2, 0);
+	H[Z][Y] = tm(2, 1);
+	H[Z][Z] = tm(2, 2);
+
+	H[X][W] = tm(0, 3);
+	H[Y][W] = tm(1, 3);
+	H[Z][W] = tm(2, 3);
+
+	decomp_affine(H, &parts);
+
+	rot = Quat(parts.q.w, parts.q.x, parts.q.y, parts.q.z);
+	rotScale = Quat(parts.u.w, parts.u.x, parts.u.y, parts.u.z);
+	pos = Vec3(parts.t.x, parts.t.y, parts.t.z);
+	scale = Vec3(parts.k.x, parts.k.y, parts.k.z);
+	fDet = parts.f;
+}
+
+// Spectral matrix decomposition to affine parts.
+void AffineParts::SpectralDecompose(const Matrix44& tm)
+{
+	SAffineParts parts;
+	HMatrix H;
+	memset(&H, 0, sizeof(H));
+
+	H[X][X] = tm(0, 0);
+	H[X][Y] = tm(0, 1);
+	H[X][Z] = tm(0, 2);
+
+	H[Y][X] = tm(1, 0);
+	H[Y][Y] = tm(1, 1);
+	H[Y][Z] = tm(1, 2);
+
+	H[Z][X] = tm(2, 0);
+	H[Z][Y] = tm(2, 1);
+	H[Z][Z] = tm(2, 2);
+
+	H[X][W] = tm(0, 3);
+	H[Y][W] = tm(1, 3);
+	H[Z][W] = tm(2, 3);
+
+	spectral_decomp_affine(H, &parts);
+
+	rot = Quat(parts.q.w, parts.q.x, parts.q.y, parts.q.z);
+	rotScale = Quat(parts.u.w, parts.u.x, parts.u.y, parts.u.z);
+	pos = Vec3(parts.t.x, parts.t.y, parts.t.z);
+	scale = Vec3(parts.k.x, parts.k.y, parts.k.z);
+	fDet = parts.f;
+}
+
+// Spectral matrix decomposition to affine parts.
+void AffineParts::SpectralDecompose(const Matrix34& tm)
+{
+	SAffineParts parts;
+	HMatrix H;
+	memset(&H, 0, sizeof(H));
+
+	H[X][X] = tm.m00;
+	H[X][Y] = tm.m01;
+	H[X][Z] = tm.m02;
+
+	H[Y][X] = tm.m10;
+	H[Y][Y] = tm.m11;
+	H[Y][Z] = tm.m12;
+
+	H[Z][X] = tm.m20;
+	H[Z][Y] = tm.m21;
+	H[Z][Z] = tm.m22;
+
+	H[X][W] = tm.m03;
+	H[Y][W] = tm.m13;
+	H[Z][W] = tm.m23;
+
+	spectral_decomp_affine(H, &parts);
+
+	rot = Quat(parts.q.w, parts.q.x, parts.q.y, parts.q.z);
+	rotScale = Quat(parts.u.w, parts.u.x, parts.u.y, parts.u.z);
+	pos = Vec3(parts.t.x, parts.t.y, parts.t.z);
+	scale = Vec3(parts.k.x, parts.k.y, parts.k.z);
+	fDet = parts.f;
+}
+
+#pragma warning ( pop )  // conversion from 'double' to 'float', possible loss of data.

--- a/Preditor/LevelEditor/Utils/AffineParts.h
+++ b/Preditor/LevelEditor/Utils/AffineParts.h
@@ -1,0 +1,44 @@
+// Copyright 2001-2016 Crytek GmbH / Crytek Group. All rights reserved.
+
+// -------------------------------------------------------------------------
+//  File name:   affineparts.h
+//  Version:     v1.00
+//  Created:     19/8/2002 by Timur.
+//  Compilers:   Visual Studio.NET
+//  Description:
+// -------------------------------------------------------------------------
+//  History:
+//
+////////////////////////////////////////////////////////////////////////////
+
+#ifndef __affineparts_h__
+#define __affineparts_h__
+
+#if _MSC_VER > 1000
+	#pragma once
+#endif
+
+struct AffineParts
+{
+	Vec3  pos;      //!< Translation components
+	Quat  rot;      //!< Essential rotation.
+	Quat  rotScale; //!< Stretch rotation.
+	Vec3  scale;    //!< Stretch factors.
+	float fDet;     //!< Sign of determinant.
+
+	/** Decompose matrix to its affnie parts.
+	 */
+	void Decompose(const Matrix44& mat);
+
+	/** Decompose matrix to its affnie parts.
+	    Assume there`s no stretch rotation.
+	 */
+	void SpectralDecompose(const Matrix44& mat);
+
+	/** Decompose matrix to its affnie parts.
+	   Assume there`s no stretch rotation.
+	 */
+	void SpectralDecompose(const Matrix34& mat);
+};
+
+#endif // __affineparts_h__

--- a/Preditor/Viewport/SceneViewport.cpp
+++ b/Preditor/Viewport/SceneViewport.cpp
@@ -199,7 +199,7 @@ void Viewport::SceneViewport::ShowUI()
 	{
 		pEditor->GetToolManager()->DrawViewport(
 			Vec4(imageBounds.x, imageBounds.y, imageBounds.z, imageBounds.w),
-			m_CamInfo.lastFrameView);
+			m_Cam);
 	}
 }
 

--- a/Preditor/Viewport/SceneViewport.cpp
+++ b/Preditor/Viewport/SceneViewport.cpp
@@ -194,6 +194,13 @@ void Viewport::SceneViewport::ShowUI()
 
 		ImGui::SetWindowFocus();
 	}
+
+	if (pEditor)
+	{
+		pEditor->GetToolManager()->DrawViewport(
+			Vec4(imageBounds.x, imageBounds.y, imageBounds.z, imageBounds.w),
+			m_CamInfo.lastFrameView);
+	}
 }
 
 void Viewport::SceneViewport::OnSystemEvent(ESystemEvent event, UINT_PTR wparam, UINT_PTR lparam)
@@ -369,6 +376,8 @@ void Viewport::SceneViewport::UpdateCamera()
 		info.nearPlane,
 		info.farPlane,
 		1.0f);
+
+	m_CamInfo.lastFrameView = m_Cam.GetViewMatrix();
 }
 
 void Viewport::SceneViewport::CopyViewCameraTransform()

--- a/Preditor/Viewport/SceneViewport.cpp
+++ b/Preditor/Viewport/SceneViewport.cpp
@@ -186,12 +186,7 @@ void Viewport::SceneViewport::ShowUI()
 
 	if (m_IsInCameraMode)
 	{
-		Vec2 delta = gPreditor->pInput->GetMouse()->GetMouseDelta();
-		Ang3 rot = m_CamInfo.rot;
-		rot.z -= delta.x;
-		rot.x -= delta.y;
-		m_CamInfo.rot = Ang3(Quat(rot)); // Quick and dirty 360 deg wrapping
-
+		ProcessInput();
 		ImGui::SetWindowFocus();
 	}
 
@@ -301,69 +296,90 @@ void Viewport::SceneViewport::ShowCameraMenu()
 	}
 }
 
+void Viewport::SceneViewport::ProcessInput()
+{
+	CameraInfo& info = m_CamInfo;
+	float timeDelta = gEnv->pTimer->GetRealFrameTime(); // TODO 2023-08-27: Use custom timer, GetRealFrameTime is unreliable
+
+	// Rotation
+	Vec2 delta = gPreditor->pInput->GetMouse()->GetMouseDelta();
+	Ang3 rot = m_CamInfo.rot;
+	rot.z -= delta.x;
+	rot.x -= delta.y;
+
+	Quat qrot(rot);
+	m_CamInfo.rot = Ang3(qrot); // Quick and dirty 360 deg wrapping
+
+	// Position
+	Vec3 dir = Vec3(ZERO);
+	const Vec3 fwd = Vec3(0, 1, 0);
+	const Vec3 right = Vec3(1, 0, 0);
+	const Vec3 up = Vec3(0, 0, 1);
+
+	if (m_pFwd->IsHeldDown())
+		dir += fwd;
+	if (m_pBkwd->IsHeldDown())
+		dir -= fwd;
+
+	if (m_pRight->IsHeldDown())
+		dir += right;
+	if (m_pLeft->IsHeldDown())
+		dir -= right;
+
+	if (m_pUp->IsHeldDown())
+		dir += up;
+	if (m_pDown->IsHeldDown())
+		dir -= up;
+
+	dir.NormalizeSafe();
+
+	Vec2 speedLimit = Vec2(CV_ed_ViewMinSpeed, CV_ed_ViewMaxSpeed);
+	float accel = CV_ed_ViewAccel;
+
+	if (m_pSpeedUp->IsHeldDown())
+	{
+		speedLimit *= CV_ed_ViewBoostScale;
+		accel *= CV_ed_ViewBoostScale;
+	}
+
+	if (dir != Vec3(ZERO))
+	{
+		m_MoveSpeed += accel * timeDelta;
+		m_MoveSpeed = std::clamp(m_MoveSpeed, speedLimit.x, speedLimit.y);
+	}
+	else
+	{
+		m_MoveSpeed -= accel * timeDelta;
+		m_MoveSpeed = std::max(0.0f, m_MoveSpeed);
+	}
+
+	info.pos += (qrot * dir) * (m_MoveSpeed * timeDelta);
+
+	// Update the matrix
+	// This will not update the FOV, size, etc. They will lag behind by one frame
+	// when rendering the gizmo. But that's not an issue.
+	UpdateCameraMatrix();
+}
+
+void Viewport::SceneViewport::UpdateCameraMatrix()
+{
+	m_Cam.SetMatrix(Matrix34::Create(Vec3(1, 1, 1), Quat(m_CamInfo.rot), m_CamInfo.pos));
+}
+
 void Viewport::SceneViewport::UpdateCamera()
 {
+	const CCamera& viewCam = gEnv->pSystem->GetViewCamera();
 	CameraInfo& info = m_CamInfo;
 
 	if (!info.transformValid)
 	{
 		info.transformValid = true;
 		CopyViewCameraTransform();
-	}
-
-	Quat rotQuat = Quat(info.rot);
-
-	// Positional input
-	{
-		float timeDelta = gEnv->pTimer->GetRealFrameTime();
-
-		Vec3 dir = Vec3(ZERO);
-		const Vec3 fwd = Vec3(0, 1, 0);
-		const Vec3 right = Vec3(1, 0, 0);
-		const Vec3 up = Vec3(0, 0, 1);
-
-		if (m_pFwd->IsHeldDown())
-			dir += fwd;
-		if (m_pBkwd->IsHeldDown())
-			dir -= fwd;
-
-		if (m_pRight->IsHeldDown())
-			dir += right;
-		if (m_pLeft->IsHeldDown())
-			dir -= right;
-
-		if (m_pUp->IsHeldDown())
-			dir += up;
-		if (m_pDown->IsHeldDown())
-			dir -= up;
-
-		dir.NormalizeSafe();
-
-		Vec2 speedLimit = Vec2(CV_ed_ViewMinSpeed, CV_ed_ViewMaxSpeed);
-		float accel = CV_ed_ViewAccel;
-
-		if (m_pSpeedUp->IsHeldDown())
-		{
-			speedLimit *= CV_ed_ViewBoostScale;
-			accel *= CV_ed_ViewBoostScale;
-		}
-
-		if (dir != Vec3(ZERO))
-		{
-			m_MoveSpeed += accel * timeDelta;
-			m_MoveSpeed = std::clamp(m_MoveSpeed, speedLimit.x, speedLimit.y);
-		}
-		else
-		{
-			m_MoveSpeed -= accel * timeDelta;
-			m_MoveSpeed = std::max(0.0f, m_MoveSpeed);
-		}
-
-		info.pos += (rotQuat * dir) * (m_MoveSpeed * timeDelta);
+		UpdateCameraMatrix();
 	}
 
 	Matrix34 camMat;
-	camMat.SetRotation33(Matrix33(rotQuat));
+	camMat.SetRotation33(Matrix33(Quat(info.rot)));
 	camMat.SetTranslation(info.pos);
 	m_Cam.SetMatrixNoUpdate(camMat);
 

--- a/Preditor/Viewport/SceneViewport.cpp
+++ b/Preditor/Viewport/SceneViewport.cpp
@@ -376,8 +376,6 @@ void Viewport::SceneViewport::UpdateCamera()
 		info.nearPlane,
 		info.farPlane,
 		1.0f);
-
-	m_CamInfo.lastFrameView = m_Cam.GetViewMatrix();
 }
 
 void Viewport::SceneViewport::CopyViewCameraTransform()

--- a/Preditor/Viewport/SceneViewport.h
+++ b/Preditor/Viewport/SceneViewport.h
@@ -52,9 +52,6 @@ private:
 
         bool bDrawRealWorld = true;
         bool bDrawLookingGlass = true;
-
-        // Last frame's data
-        Matrix44 lastFrameView;
     };
 
     MouseGuard m_InputEnabled;

--- a/Preditor/Viewport/SceneViewport.h
+++ b/Preditor/Viewport/SceneViewport.h
@@ -79,6 +79,8 @@ private:
 
     void ShowCameraMenu();
 
+    void ProcessInput();
+    void UpdateCameraMatrix();
     void UpdateCamera();
     void CopyViewCameraTransform();
 

--- a/Preditor/Viewport/SceneViewport.h
+++ b/Preditor/Viewport/SceneViewport.h
@@ -52,6 +52,9 @@ private:
 
         bool bDrawRealWorld = true;
         bool bDrawLookingGlass = true;
+
+        // Last frame's data
+        Matrix44 lastFrameView;
     };
 
     MouseGuard m_InputEnabled;


### PR DESCRIPTION
Adds transformation tools to Preditor.

Currently implemented:
- [x] Move
- [x] Rotate
- [x] Scale

To-do:
- [x] Implement `IObjectManipulator` in `LevelEditor`
- [x] Move ImGuizmo code from `MoveTool` into `ImGuizmoTool`. Other tools will derive from `ImGuizmoTool`.
- [x] Refactor matrix passing from `SceneViewport` to `EditToolManager`.
- [x] Add key bindings.
- [x] Snapping on Ctrl.
- [x] Local/World mode.
- [x] Pivot/Center mode.
- [ ] Change axis colors and names
- [ ] Disable negative axis?

Current issues:
- ~~Gizmo is positioned incorrectly. Possibly because of incorrect projection matrix.~~
  - Related: https://github.com/CedricGuillemet/ImGuizmo/issues/218
    - CryEngine uses a right-handed coordinate system [(source)](https://docs.cryengine.com/display/CEPROG/Math)
  - Related: https://github.com/CedricGuillemet/ImGuizmo/issues/154
  - Related: https://github.com/CedricGuillemet/ImGuizmo/issues/83
  - [That's what it looks like (screenshot)](https://github.com/thelivingdiamond/Chairloader/assets/20199236/37646cb6-2a35-4529-bcb2-935a46a83332)
