### PR TITLE
Bump version to 1.2.2

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,7 +19,7 @@ set_property(GLOBAL PROPERTY USE_FOLDERS ON)
 # Chairloader Version
 set(_CHAIRLOADER_VERSION_MAJOR 1)  # Increment when breaking changes are made
 set(_CHAIRLOADER_VERSION_MINOR 2)  # Increment when new features are added
-set(_CHAIRLOADER_VERSION_PATCH 1)  # Increment when bug fixes are made
+set(_CHAIRLOADER_VERSION_PATCH 2)  # Increment when bug fixes are made
 set(_CHAIRLOADER_VERSION_BUILD 0)  # UNUSED
 set(_CHAIRLOADER_VERSION_TYPE "")  # Indicates a pre-release version (e.g. "-alpha")
 


### PR DESCRIPTION
## Bugfixes
- Actually support the latest GOG version (2023-06-08)
  - PAK modification check was temporarily disabled until a better solution is found
