### PR TITLE
Release 1.3.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,8 +18,8 @@ set_property(GLOBAL PROPERTY USE_FOLDERS ON)
 
 # Chairloader Version
 set(_CHAIRLOADER_VERSION_MAJOR 1)  # Increment when breaking changes are made
-set(_CHAIRLOADER_VERSION_MINOR 2)  # Increment when new features are added
-set(_CHAIRLOADER_VERSION_PATCH 3)  # Increment when bug fixes are made
+set(_CHAIRLOADER_VERSION_MINOR 3)  # Increment when new features are added
+set(_CHAIRLOADER_VERSION_PATCH 0)  # Increment when bug fixes are made
 set(_CHAIRLOADER_VERSION_BUILD 0)  # UNUSED
 set(_CHAIRLOADER_VERSION_TYPE "")  # Indicates a pre-release version (e.g. "-alpha")
 

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "chairloader",
-  "version-string": "1.2.3",
+  "version-string": "1.3.0",
   "description": "An extensible Prey (2017) modding framework",
   "builtin-baseline": "f7423ee180c4b7f40d43402c2feb3859161ef625",
   "$deps_": "Please, keep sorted alphabetically",


### PR DESCRIPTION
## Chairloader

> [!IMPORTANT]  
> This update breaks compatibility with some mods. Please, update mods after install.  
>  
> Modders, please follow the [migration guide](https://github.com/thelivingdiamond/Chairloader/wiki/XML-Modding-%E2%80%90-Migration-Guide-for-1.3.0).

- New XML Merging v3 algorithm
- Improved support for legacy mods
- Added built-in XML validation to catch errors in mods
- New install wizard
- Added `-novid` command line option to skip intro movies

## Preditor
- Added support for Level and Localization merging
- Improved merging error reporting on start-up

## Bugfixes
### ChairManager
- Fixed installation of ZIP mods that have a root folder
- Update checking no longer freezes ChairManager

### Chairloader
- Fixed save file path in Microsoft version
- Fixed crash when assertion failure dialog is shown during game shut down
- Fixed assertion failure on game shut down in Debug builds

### Preditor
- Fixed fatal error when starting Preditor due to save patch
- Fixed crash when opening Vec3/Quat context menu with empty clipboard

## Modding Changes
- New merging policy format
  - Describes full node and attribute structure
  - Attributes include type info for validation
- Added XML validation
  - Checks that each node is registered in the merging policy. Causes errors on unknown nodes.
  - Checks value of each attribute. Attributes have a type (e.g. int, float, string, GUID...).
  - Checks for duplicate nodes (e.g. two archetypes with same ID).
- Added XML Schemas for auto-completion in XML editors
- Prey files are now converted into an intermediate format for easier merging and modding
- Level merging changes:
  - Entity IDs are now generated automatically
  - serialize.xml is now generated from entities with `ch:serialize=true` attribute
  - See [Level Patching](https://github.com/thelivingdiamond/Chairloader/wiki/XML-Modding-%E2%80%90-Level-Patching) for details
- Added support for `ch:applyIf` in localization files
  - Can be added to `<Row>` nodes
  - Can be added as a new column named `ch:applyIf`
- Added [legacy mod converter](https://github.com/thelivingdiamond/Chairloader/wiki/XML-Modding-%E2%80%90-Legacy-Mod-Conversion) to automatically convert mods into Chairloader format