### PR TITLE
Release 1.3.4

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,7 +19,7 @@ set_property(GLOBAL PROPERTY USE_FOLDERS ON)
 # Chairloader Version
 set(_CHAIRLOADER_VERSION_MAJOR 1)  # Increment when breaking changes are made
 set(_CHAIRLOADER_VERSION_MINOR 3)  # Increment when new features are added
-set(_CHAIRLOADER_VERSION_PATCH 3)  # Increment when bug fixes are made
+set(_CHAIRLOADER_VERSION_PATCH 4)  # Increment when bug fixes are made
 set(_CHAIRLOADER_VERSION_BUILD 0)  # UNUSED
 set(_CHAIRLOADER_VERSION_TYPE "")  # Indicates a pre-release version (e.g. "-alpha")
 

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "chairloader",
-  "version-string": "1.3.3",
+  "version-string": "1.3.4",
   "description": "An extensible Prey (2017) modding framework",
   "builtin-baseline": "f7423ee180c4b7f40d43402c2feb3859161ef625",
   "$deps_": "Please, keep sorted alphabetically",


### PR DESCRIPTION
## Bugfixes
- Fixed game files being extracted when not actually needed
- Fixed detection of Chinese localization files

## Modding bugfixes
- Removed read-only flag from `ArkFabricationPlan` name attribute
- Fixed error when modifying a read-only attribute when `ch:basedOn` is used