### PR TITLE
Allow mods to modify EntitySpawnList

### DIFF
--- a/Data/ChairloaderPatch/Libs/Chairloader/Trainer/EntitySpawnList.xml
+++ b/Data/ChairloaderPatch/Libs/Chairloader/Trainer/EntitySpawnList.xml
@@ -1,44 +1,44 @@
 <?xml version="1.0"?>
-<EntitySpawnList>
-    <Category Header="Typhon">
-        <Category Header="Mimics">
-            <Npc Name="ArkNpcs.Mimics.Mimic">Mimic</Npc>
-            <Npc Name="ArkNpcs.Mimics.EliteMimic">Greater Mimic</Npc>
+<EntitySpawnList Header="Trainer">
+    <Category ch:index="100" Header="Typhon">
+        <Category ch:index="100" Header="Mimics">
+            <Npc ch:index="100" Name="ArkNpcs.Mimics.Mimic">Mimic</Npc>
+            <Npc ch:index="200" Name="ArkNpcs.Mimics.EliteMimic">Greater Mimic</Npc>
         </Category>
 
-        <Category Header="Phantoms">
-            <Npc Name="ArkNpcs.Phantoms.BasePhantom">Normal</Npc>
-            <Npc Name="ArkNpcs.Phantoms.ThermalPhantom">Thermal</Npc>
-            <Npc Name="ArkNpcs.Phantoms.EthericPhantom">Etheric</Npc>
-            <Npc Name="ArkNpcs.Phantoms.VoltaicPhantom">Voltaic</Npc>
+        <Category ch:index="200" Header="Phantoms">
+            <Npc ch:index="100" Name="ArkNpcs.Phantoms.BasePhantom">Normal</Npc>
+            <Npc ch:index="200" Name="ArkNpcs.Phantoms.ThermalPhantom">Thermal</Npc>
+            <Npc ch:index="300" Name="ArkNpcs.Phantoms.EthericPhantom">Etheric</Npc>
+            <Npc ch:index="400" Name="ArkNpcs.Phantoms.VoltaicPhantom">Voltaic</Npc>
         </Category>
 
-        <Npc Name="ArkNpcs.ArkNightmare">Nightmare</Npc>
-        <Npc Name="ArkNpcs.ArkPoltergeist">Poltergeist</Npc>
-        <Npc Name="ArkNpcs.Overseers.Telepath">Telepath</Npc>
-        <Npc Name="ArkNpcs.Overseers.Technopath">Technopath</Npc>
+        <Npc ch:index="300" Name="ArkNpcs.ArkNightmare">Nightmare</Npc>
+        <Npc ch:index="400" Name="ArkNpcs.ArkPoltergeist">Poltergeist</Npc>
+        <Npc ch:index="500" Name="ArkNpcs.Overseers.Telepath">Telepath</Npc>
+        <Npc ch:index="600" Name="ArkNpcs.Overseers.Technopath">Technopath</Npc>
     </Category>
 
-    <Category Header="Operators">
-        <Npc Name="ArkRobots.Operators\Generic.MedicalOperator">Medical</Npc>
-        <Npc Name="ArkRobots.Operators\Generic.EngineeringOperator">Engineering</Npc>
-        <Npc Name="ArkRobots.Operators\Generic.ScienceOperator">Science</Npc>
-        <Npc Name="ArkRobots.Operators\Generic.MilitaryOperator">Military</Npc>
+    <Category ch:index="200" Header="Operators">
+        <Npc ch:index="100" Name="ArkRobots.Operators\Generic.MedicalOperator">Medical</Npc>
+        <Npc ch:index="200" Name="ArkRobots.Operators\Generic.EngineeringOperator">Engineering</Npc>
+        <Npc ch:index="300" Name="ArkRobots.Operators\Generic.ScienceOperator">Science</Npc>
+        <Npc ch:index="400" Name="ArkRobots.Operators\Generic.MilitaryOperator">Military</Npc>
     </Category>
     
-    <Npc Name="ArkRobots.Turrets.Turret_Default">Turret</Npc>
+    <Npc ch:index="300" Name="ArkRobots.Turrets.Turret_Default">Turret</Npc>
 
-    <Category Header="Weapons">
-        <Entity Name="ArkPickups.Weapons.Wrench">Wrench</Entity>
-        <Entity Name="ArkPickups.Weapons.Shotgun">Shotgun</Entity>
-        <Entity Name="ArkPickups.Ammo.ShotgunShells">Shotgun Ammo</Entity>
-        <Entity Name="ArkPickups.Weapons.Pistol">Pistol</Entity>
-        <Entity Name="ArkPickups.Ammo.PistolBullets">Pistol Ammo</Entity>
-        <Entity Name="ArkPickups.Weapons.GooGun">Gloo Gun</Entity>
-        <Entity Name="ArkPickups.Ammo.GooGun">Gloo Gun Ammo</Entity>
-        <Entity Name="ArkPickups.Weapons.Instalaser">Q Beam</Entity>
-        <Entity Name="ArkPickups.Ammo.InstaLaser">Q Beam Ammo</Entity>
-        <Entity Name="ArkPickups.Weapons.StunGun">Stun Gun</Entity>
-        <Entity Name="ArkPickups.Ammo.StunGunAmmo">Stun Gun Ammo</Entity>
+    <Category ch:index="400" Header="Weapons">
+        <Entity ch:index="100" Name="ArkPickups.Weapons.Wrench">Wrench</Entity>
+        <Entity ch:index="200" Name="ArkPickups.Weapons.Shotgun">Shotgun</Entity>
+        <Entity ch:index="300" Name="ArkPickups.Ammo.ShotgunShells">Shotgun Ammo</Entity>
+        <Entity ch:index="400" Name="ArkPickups.Weapons.Pistol">Pistol</Entity>
+        <Entity ch:index="500" Name="ArkPickups.Ammo.PistolBullets">Pistol Ammo</Entity>
+        <Entity ch:index="600" Name="ArkPickups.Weapons.GooGun">Gloo Gun</Entity>
+        <Entity ch:index="700" Name="ArkPickups.Ammo.GooGun">Gloo Gun Ammo</Entity>
+        <Entity ch:index="800" Name="ArkPickups.Weapons.Instalaser">Q Beam</Entity>
+        <Entity ch:index="900" Name="ArkPickups.Ammo.InstaLaser">Q Beam Ammo</Entity>
+        <Entity ch:index="1000" Name="ArkPickups.Weapons.StunGun">Stun Gun</Entity>
+        <Entity ch:index="1100" Name="ArkPickups.Ammo.StunGunAmmo">Stun Gun Ammo</Entity>
     </Category>
 </EntitySpawnList>

--- a/Data/MergingLibrary/Libs/Chairloader/Trainer/EntitySpawnList.xml
+++ b/Data/MergingLibrary/Libs/Chairloader/Trainer/EntitySpawnList.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0"?>
+<MergingPolicy
+    xmlns="https://thelivingdiamond.github.io/Chairloader/Xsd/Chairloader"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="https://thelivingdiamond.github.io/Chairloader/Xsd/Chairloader ../../../../../Xsd/Chairloader/MergingPolicy.xsd">
+    <NodeByType name="EntitySpawnList" type="ChairloaderEntitySpawnListCategory" />
+</MergingPolicy>

--- a/Data/Testing/ChairMerger/FullTestCustomFileMerge/Configs/Mod1.xml
+++ b/Data/Testing/ChairMerger/FullTestCustomFileMerge/Configs/Mod1.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0"?>
+<Mod1>
+    <testString type="string">String from mod 1</testString>
+</Mod1>

--- a/Data/Testing/ChairMerger/FullTestCustomFileMerge/Expected/Main/Libs/Chairloader/Trainer/EntitySpawnList.xml
+++ b/Data/Testing/ChairMerger/FullTestCustomFileMerge/Expected/Main/Libs/Chairloader/Trainer/EntitySpawnList.xml
@@ -1,0 +1,55 @@
+<?xml version="1.0"?>
+<EntitySpawnList Header="Trainer">
+    <Category Header="Typhon">
+        <Category Header="Mimics">
+            <Npc Name="ArkNpcs.Mimics.Mimic">Mimic</Npc>
+            <Npc Name="ArkNpcs.Mimics.EliteMimic">Greater Mimic</Npc>
+        </Category>
+
+        <Category Header="Mimics with Hats">
+            <Npc Name="ArkNpcs.Mimics.Mimic.BeanieHat">Beanie</Npc>
+            <Npc Name="ArkNpcs.Mimics.Mimic.BucketHat">Bucket</Npc>
+            <Npc Name="ArkNpcs.Mimics.Mimic.CrownHat">Crown</Npc>
+            <Npc Name="ArkNpcs.Mimics.Mimic.RiceHat">Rice</Npc>
+            <Npc Name="ArkNpcs.Mimics.Mimic.Sombrero">Sombrero</Npc>
+            <Npc Name="ArkNpcs.Mimics.Mimic.StripedHat">Striped Hat</Npc>
+            <Npc Name="ArkNpcs.Mimics.Mimic.TopHat">Top Hat</Npc>
+            <Npc Name="ArkNpcs.Mimics.Mimic.WitchHat">Witch Hat</Npc>
+        </Category>
+
+        <Category Header="Phantoms">
+            <Npc Name="ArkNpcs.Phantoms.BasePhantom">Normal</Npc>
+            <Npc Name="ArkNpcs.Phantoms.ThermalPhantom">Thermal</Npc>
+            <Npc Name="ArkNpcs.Phantoms.EthericPhantom">Etheric</Npc>
+            <Npc Name="ArkNpcs.Phantoms.VoltaicPhantom">Voltaic</Npc>
+        </Category>
+
+        <Npc Name="ArkNpcs.ArkNightmare">Nightmare</Npc>
+        <Npc Name="ArkNpcs.ArkPoltergeist">Poltergeist</Npc>
+        <Npc Name="ArkNpcs.Overseers.Telepath">Telepath</Npc>
+        <Npc Name="ArkNpcs.Overseers.Technopath">Technopath</Npc>
+    </Category>
+
+    <Category Header="Operators">
+        <Npc Name="ArkRobots.Operators\Generic.MedicalOperator">Medical</Npc>
+        <Npc Name="ArkRobots.Operators\Generic.EngineeringOperator">Engineering</Npc>
+        <Npc Name="ArkRobots.Operators\Generic.ScienceOperator">Science</Npc>
+        <Npc Name="ArkRobots.Operators\Generic.MilitaryOperator">Military</Npc>
+    </Category>
+    
+    <Npc Name="ArkRobots.Turrets.Turret_Default">Turret</Npc>
+
+    <Category Header="Weapons">
+        <Entity Name="ArkPickups.Weapons.Wrench">Wrench</Entity>
+        <Entity Name="ArkPickups.Weapons.Shotgun">Shotgun</Entity>
+        <Entity Name="ArkPickups.Ammo.ShotgunShells">Shotgun Ammo</Entity>
+        <Entity Name="ArkPickups.Weapons.Pistol">Pistol</Entity>
+        <Entity Name="ArkPickups.Ammo.PistolBullets">Pistol Ammo</Entity>
+        <Entity Name="ArkPickups.Weapons.GooGun">Gloo Gun</Entity>
+        <Entity Name="ArkPickups.Ammo.GooGun">Gloo Gun Ammo</Entity>
+        <Entity Name="ArkPickups.Weapons.Instalaser">Q Beam</Entity>
+        <Entity Name="ArkPickups.Ammo.InstaLaser">Q Beam Ammo</Entity>
+        <Entity Name="ArkPickups.Weapons.StunGun">Stun Gun</Entity>
+        <Entity Name="ArkPickups.Ammo.StunGunAmmo">Stun Gun Ammo</Entity>
+    </Category>
+</EntitySpawnList>

--- a/Data/Testing/ChairMerger/FullTestCustomFileMerge/Expected/Main/UI/texture.dds
+++ b/Data/Testing/ChairMerger/FullTestCustomFileMerge/Expected/Main/UI/texture.dds
@@ -1,0 +1,1 @@
+I'm a texture!

--- a/Data/Testing/ChairMerger/FullTestCustomFileMerge/Mod1/Data/Libs/Chairloader/Trainer/EntitySpawnList.xml
+++ b/Data/Testing/ChairMerger/FullTestCustomFileMerge/Mod1/Data/Libs/Chairloader/Trainer/EntitySpawnList.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0"?>
+<EntitySpawnList>
+    <Category ch:index="100" Header="Typhon">
+        <Category ch:index="110" Header="Mimics with Hats">
+            <Npc ch:index="100" Name="ArkNpcs.Mimics.Mimic.BeanieHat">Beanie</Npc>
+            <Npc ch:index="200" Name="ArkNpcs.Mimics.Mimic.BucketHat">Bucket</Npc>
+            <Npc ch:index="300" Name="ArkNpcs.Mimics.Mimic.CrownHat">Crown</Npc>
+            <Npc ch:index="400" Name="ArkNpcs.Mimics.Mimic.RiceHat">Rice</Npc>
+            <Npc ch:index="500" Name="ArkNpcs.Mimics.Mimic.Sombrero">Sombrero</Npc>
+            <Npc ch:index="600" Name="ArkNpcs.Mimics.Mimic.StripedHat">Striped Hat</Npc>
+            <Npc ch:index="700" Name="ArkNpcs.Mimics.Mimic.TopHat">Top Hat</Npc>
+            <Npc ch:index="800" Name="ArkNpcs.Mimics.Mimic.WitchHat">Witch Hat</Npc>
+        </Category>
+    </Category>
+</EntitySpawnList>

--- a/Data/Testing/ChairMerger/FullTestDllOnly/Expected/Main/Libs/Chairloader/Trainer/EntitySpawnList.xml
+++ b/Data/Testing/ChairMerger/FullTestDllOnly/Expected/Main/Libs/Chairloader/Trainer/EntitySpawnList.xml
@@ -1,0 +1,44 @@
+<?xml version="1.0"?>
+<EntitySpawnList Header="Trainer">
+    <Category Header="Typhon">
+        <Category Header="Mimics">
+            <Npc Name="ArkNpcs.Mimics.Mimic">Mimic</Npc>
+            <Npc Name="ArkNpcs.Mimics.EliteMimic">Greater Mimic</Npc>
+        </Category>
+
+        <Category Header="Phantoms">
+            <Npc Name="ArkNpcs.Phantoms.BasePhantom">Normal</Npc>
+            <Npc Name="ArkNpcs.Phantoms.ThermalPhantom">Thermal</Npc>
+            <Npc Name="ArkNpcs.Phantoms.EthericPhantom">Etheric</Npc>
+            <Npc Name="ArkNpcs.Phantoms.VoltaicPhantom">Voltaic</Npc>
+        </Category>
+
+        <Npc Name="ArkNpcs.ArkNightmare">Nightmare</Npc>
+        <Npc Name="ArkNpcs.ArkPoltergeist">Poltergeist</Npc>
+        <Npc Name="ArkNpcs.Overseers.Telepath">Telepath</Npc>
+        <Npc Name="ArkNpcs.Overseers.Technopath">Technopath</Npc>
+    </Category>
+
+    <Category Header="Operators">
+        <Npc Name="ArkRobots.Operators\Generic.MedicalOperator">Medical</Npc>
+        <Npc Name="ArkRobots.Operators\Generic.EngineeringOperator">Engineering</Npc>
+        <Npc Name="ArkRobots.Operators\Generic.ScienceOperator">Science</Npc>
+        <Npc Name="ArkRobots.Operators\Generic.MilitaryOperator">Military</Npc>
+    </Category>
+    
+    <Npc Name="ArkRobots.Turrets.Turret_Default">Turret</Npc>
+
+    <Category Header="Weapons">
+        <Entity Name="ArkPickups.Weapons.Wrench">Wrench</Entity>
+        <Entity Name="ArkPickups.Weapons.Shotgun">Shotgun</Entity>
+        <Entity Name="ArkPickups.Ammo.ShotgunShells">Shotgun Ammo</Entity>
+        <Entity Name="ArkPickups.Weapons.Pistol">Pistol</Entity>
+        <Entity Name="ArkPickups.Ammo.PistolBullets">Pistol Ammo</Entity>
+        <Entity Name="ArkPickups.Weapons.GooGun">Gloo Gun</Entity>
+        <Entity Name="ArkPickups.Ammo.GooGun">Gloo Gun Ammo</Entity>
+        <Entity Name="ArkPickups.Weapons.Instalaser">Q Beam</Entity>
+        <Entity Name="ArkPickups.Ammo.InstaLaser">Q Beam Ammo</Entity>
+        <Entity Name="ArkPickups.Weapons.StunGun">Stun Gun</Entity>
+        <Entity Name="ArkPickups.Ammo.StunGunAmmo">Stun Gun Ammo</Entity>
+    </Category>
+</EntitySpawnList>

--- a/Data/Testing/ChairMerger/FullTestEverything/Expected/Main/Libs/Chairloader/Trainer/EntitySpawnList.xml
+++ b/Data/Testing/ChairMerger/FullTestEverything/Expected/Main/Libs/Chairloader/Trainer/EntitySpawnList.xml
@@ -1,0 +1,44 @@
+<?xml version="1.0"?>
+<EntitySpawnList Header="Trainer">
+    <Category Header="Typhon">
+        <Category Header="Mimics">
+            <Npc Name="ArkNpcs.Mimics.Mimic">Mimic</Npc>
+            <Npc Name="ArkNpcs.Mimics.EliteMimic">Greater Mimic</Npc>
+        </Category>
+
+        <Category Header="Phantoms">
+            <Npc Name="ArkNpcs.Phantoms.BasePhantom">Normal</Npc>
+            <Npc Name="ArkNpcs.Phantoms.ThermalPhantom">Thermal</Npc>
+            <Npc Name="ArkNpcs.Phantoms.EthericPhantom">Etheric</Npc>
+            <Npc Name="ArkNpcs.Phantoms.VoltaicPhantom">Voltaic</Npc>
+        </Category>
+
+        <Npc Name="ArkNpcs.ArkNightmare">Nightmare</Npc>
+        <Npc Name="ArkNpcs.ArkPoltergeist">Poltergeist</Npc>
+        <Npc Name="ArkNpcs.Overseers.Telepath">Telepath</Npc>
+        <Npc Name="ArkNpcs.Overseers.Technopath">Technopath</Npc>
+    </Category>
+
+    <Category Header="Operators">
+        <Npc Name="ArkRobots.Operators\Generic.MedicalOperator">Medical</Npc>
+        <Npc Name="ArkRobots.Operators\Generic.EngineeringOperator">Engineering</Npc>
+        <Npc Name="ArkRobots.Operators\Generic.ScienceOperator">Science</Npc>
+        <Npc Name="ArkRobots.Operators\Generic.MilitaryOperator">Military</Npc>
+    </Category>
+    
+    <Npc Name="ArkRobots.Turrets.Turret_Default">Turret</Npc>
+
+    <Category Header="Weapons">
+        <Entity Name="ArkPickups.Weapons.Wrench">Wrench</Entity>
+        <Entity Name="ArkPickups.Weapons.Shotgun">Shotgun</Entity>
+        <Entity Name="ArkPickups.Ammo.ShotgunShells">Shotgun Ammo</Entity>
+        <Entity Name="ArkPickups.Weapons.Pistol">Pistol</Entity>
+        <Entity Name="ArkPickups.Ammo.PistolBullets">Pistol Ammo</Entity>
+        <Entity Name="ArkPickups.Weapons.GooGun">Gloo Gun</Entity>
+        <Entity Name="ArkPickups.Ammo.GooGun">Gloo Gun Ammo</Entity>
+        <Entity Name="ArkPickups.Weapons.Instalaser">Q Beam</Entity>
+        <Entity Name="ArkPickups.Ammo.InstaLaser">Q Beam Ammo</Entity>
+        <Entity Name="ArkPickups.Weapons.StunGun">Stun Gun</Entity>
+        <Entity Name="ArkPickups.Ammo.StunGunAmmo">Stun Gun Ammo</Entity>
+    </Category>
+</EntitySpawnList>

--- a/Data/Testing/ChairMerger/FullTestLevels/Expected/Main/Libs/Chairloader/Trainer/EntitySpawnList.xml
+++ b/Data/Testing/ChairMerger/FullTestLevels/Expected/Main/Libs/Chairloader/Trainer/EntitySpawnList.xml
@@ -1,0 +1,44 @@
+<?xml version="1.0"?>
+<EntitySpawnList Header="Trainer">
+    <Category Header="Typhon">
+        <Category Header="Mimics">
+            <Npc Name="ArkNpcs.Mimics.Mimic">Mimic</Npc>
+            <Npc Name="ArkNpcs.Mimics.EliteMimic">Greater Mimic</Npc>
+        </Category>
+
+        <Category Header="Phantoms">
+            <Npc Name="ArkNpcs.Phantoms.BasePhantom">Normal</Npc>
+            <Npc Name="ArkNpcs.Phantoms.ThermalPhantom">Thermal</Npc>
+            <Npc Name="ArkNpcs.Phantoms.EthericPhantom">Etheric</Npc>
+            <Npc Name="ArkNpcs.Phantoms.VoltaicPhantom">Voltaic</Npc>
+        </Category>
+
+        <Npc Name="ArkNpcs.ArkNightmare">Nightmare</Npc>
+        <Npc Name="ArkNpcs.ArkPoltergeist">Poltergeist</Npc>
+        <Npc Name="ArkNpcs.Overseers.Telepath">Telepath</Npc>
+        <Npc Name="ArkNpcs.Overseers.Technopath">Technopath</Npc>
+    </Category>
+
+    <Category Header="Operators">
+        <Npc Name="ArkRobots.Operators\Generic.MedicalOperator">Medical</Npc>
+        <Npc Name="ArkRobots.Operators\Generic.EngineeringOperator">Engineering</Npc>
+        <Npc Name="ArkRobots.Operators\Generic.ScienceOperator">Science</Npc>
+        <Npc Name="ArkRobots.Operators\Generic.MilitaryOperator">Military</Npc>
+    </Category>
+    
+    <Npc Name="ArkRobots.Turrets.Turret_Default">Turret</Npc>
+
+    <Category Header="Weapons">
+        <Entity Name="ArkPickups.Weapons.Wrench">Wrench</Entity>
+        <Entity Name="ArkPickups.Weapons.Shotgun">Shotgun</Entity>
+        <Entity Name="ArkPickups.Ammo.ShotgunShells">Shotgun Ammo</Entity>
+        <Entity Name="ArkPickups.Weapons.Pistol">Pistol</Entity>
+        <Entity Name="ArkPickups.Ammo.PistolBullets">Pistol Ammo</Entity>
+        <Entity Name="ArkPickups.Weapons.GooGun">Gloo Gun</Entity>
+        <Entity Name="ArkPickups.Ammo.GooGun">Gloo Gun Ammo</Entity>
+        <Entity Name="ArkPickups.Weapons.Instalaser">Q Beam</Entity>
+        <Entity Name="ArkPickups.Ammo.InstaLaser">Q Beam Ammo</Entity>
+        <Entity Name="ArkPickups.Weapons.StunGun">Stun Gun</Entity>
+        <Entity Name="ArkPickups.Ammo.StunGunAmmo">Stun Gun Ammo</Entity>
+    </Category>
+</EntitySpawnList>

--- a/Data/Testing/ChairMerger/FullTestLocalization/Expected/Main/Libs/Chairloader/Trainer/EntitySpawnList.xml
+++ b/Data/Testing/ChairMerger/FullTestLocalization/Expected/Main/Libs/Chairloader/Trainer/EntitySpawnList.xml
@@ -1,0 +1,44 @@
+<?xml version="1.0"?>
+<EntitySpawnList Header="Trainer">
+    <Category Header="Typhon">
+        <Category Header="Mimics">
+            <Npc Name="ArkNpcs.Mimics.Mimic">Mimic</Npc>
+            <Npc Name="ArkNpcs.Mimics.EliteMimic">Greater Mimic</Npc>
+        </Category>
+
+        <Category Header="Phantoms">
+            <Npc Name="ArkNpcs.Phantoms.BasePhantom">Normal</Npc>
+            <Npc Name="ArkNpcs.Phantoms.ThermalPhantom">Thermal</Npc>
+            <Npc Name="ArkNpcs.Phantoms.EthericPhantom">Etheric</Npc>
+            <Npc Name="ArkNpcs.Phantoms.VoltaicPhantom">Voltaic</Npc>
+        </Category>
+
+        <Npc Name="ArkNpcs.ArkNightmare">Nightmare</Npc>
+        <Npc Name="ArkNpcs.ArkPoltergeist">Poltergeist</Npc>
+        <Npc Name="ArkNpcs.Overseers.Telepath">Telepath</Npc>
+        <Npc Name="ArkNpcs.Overseers.Technopath">Technopath</Npc>
+    </Category>
+
+    <Category Header="Operators">
+        <Npc Name="ArkRobots.Operators\Generic.MedicalOperator">Medical</Npc>
+        <Npc Name="ArkRobots.Operators\Generic.EngineeringOperator">Engineering</Npc>
+        <Npc Name="ArkRobots.Operators\Generic.ScienceOperator">Science</Npc>
+        <Npc Name="ArkRobots.Operators\Generic.MilitaryOperator">Military</Npc>
+    </Category>
+    
+    <Npc Name="ArkRobots.Turrets.Turret_Default">Turret</Npc>
+
+    <Category Header="Weapons">
+        <Entity Name="ArkPickups.Weapons.Wrench">Wrench</Entity>
+        <Entity Name="ArkPickups.Weapons.Shotgun">Shotgun</Entity>
+        <Entity Name="ArkPickups.Ammo.ShotgunShells">Shotgun Ammo</Entity>
+        <Entity Name="ArkPickups.Weapons.Pistol">Pistol</Entity>
+        <Entity Name="ArkPickups.Ammo.PistolBullets">Pistol Ammo</Entity>
+        <Entity Name="ArkPickups.Weapons.GooGun">Gloo Gun</Entity>
+        <Entity Name="ArkPickups.Ammo.GooGun">Gloo Gun Ammo</Entity>
+        <Entity Name="ArkPickups.Weapons.Instalaser">Q Beam</Entity>
+        <Entity Name="ArkPickups.Ammo.InstaLaser">Q Beam Ammo</Entity>
+        <Entity Name="ArkPickups.Weapons.StunGun">Stun Gun</Entity>
+        <Entity Name="ArkPickups.Ammo.StunGunAmmo">Stun Gun Ammo</Entity>
+    </Category>
+</EntitySpawnList>

--- a/Data/Testing/ChairMerger/FullTestMain/Expected/Main/Libs/Chairloader/Trainer/EntitySpawnList.xml
+++ b/Data/Testing/ChairMerger/FullTestMain/Expected/Main/Libs/Chairloader/Trainer/EntitySpawnList.xml
@@ -1,0 +1,44 @@
+<?xml version="1.0"?>
+<EntitySpawnList Header="Trainer">
+    <Category Header="Typhon">
+        <Category Header="Mimics">
+            <Npc Name="ArkNpcs.Mimics.Mimic">Mimic</Npc>
+            <Npc Name="ArkNpcs.Mimics.EliteMimic">Greater Mimic</Npc>
+        </Category>
+
+        <Category Header="Phantoms">
+            <Npc Name="ArkNpcs.Phantoms.BasePhantom">Normal</Npc>
+            <Npc Name="ArkNpcs.Phantoms.ThermalPhantom">Thermal</Npc>
+            <Npc Name="ArkNpcs.Phantoms.EthericPhantom">Etheric</Npc>
+            <Npc Name="ArkNpcs.Phantoms.VoltaicPhantom">Voltaic</Npc>
+        </Category>
+
+        <Npc Name="ArkNpcs.ArkNightmare">Nightmare</Npc>
+        <Npc Name="ArkNpcs.ArkPoltergeist">Poltergeist</Npc>
+        <Npc Name="ArkNpcs.Overseers.Telepath">Telepath</Npc>
+        <Npc Name="ArkNpcs.Overseers.Technopath">Technopath</Npc>
+    </Category>
+
+    <Category Header="Operators">
+        <Npc Name="ArkRobots.Operators\Generic.MedicalOperator">Medical</Npc>
+        <Npc Name="ArkRobots.Operators\Generic.EngineeringOperator">Engineering</Npc>
+        <Npc Name="ArkRobots.Operators\Generic.ScienceOperator">Science</Npc>
+        <Npc Name="ArkRobots.Operators\Generic.MilitaryOperator">Military</Npc>
+    </Category>
+    
+    <Npc Name="ArkRobots.Turrets.Turret_Default">Turret</Npc>
+
+    <Category Header="Weapons">
+        <Entity Name="ArkPickups.Weapons.Wrench">Wrench</Entity>
+        <Entity Name="ArkPickups.Weapons.Shotgun">Shotgun</Entity>
+        <Entity Name="ArkPickups.Ammo.ShotgunShells">Shotgun Ammo</Entity>
+        <Entity Name="ArkPickups.Weapons.Pistol">Pistol</Entity>
+        <Entity Name="ArkPickups.Ammo.PistolBullets">Pistol Ammo</Entity>
+        <Entity Name="ArkPickups.Weapons.GooGun">Gloo Gun</Entity>
+        <Entity Name="ArkPickups.Ammo.GooGun">Gloo Gun Ammo</Entity>
+        <Entity Name="ArkPickups.Weapons.Instalaser">Q Beam</Entity>
+        <Entity Name="ArkPickups.Ammo.InstaLaser">Q Beam Ammo</Entity>
+        <Entity Name="ArkPickups.Weapons.StunGun">Stun Gun</Entity>
+        <Entity Name="ArkPickups.Ammo.StunGunAmmo">Stun Gun Ammo</Entity>
+    </Category>
+</EntitySpawnList>

--- a/Data/Testing/ChairMerger/_ChairloaderPatch/Libs/Chairloader/Trainer/EntitySpawnList.xml
+++ b/Data/Testing/ChairMerger/_ChairloaderPatch/Libs/Chairloader/Trainer/EntitySpawnList.xml
@@ -1,0 +1,44 @@
+<?xml version="1.0"?>
+<EntitySpawnList Header="Trainer">
+    <Category ch:index="100" Header="Typhon">
+        <Category ch:index="100" Header="Mimics">
+            <Npc ch:index="100" Name="ArkNpcs.Mimics.Mimic">Mimic</Npc>
+            <Npc ch:index="200" Name="ArkNpcs.Mimics.EliteMimic">Greater Mimic</Npc>
+        </Category>
+
+        <Category ch:index="200" Header="Phantoms">
+            <Npc ch:index="100" Name="ArkNpcs.Phantoms.BasePhantom">Normal</Npc>
+            <Npc ch:index="200" Name="ArkNpcs.Phantoms.ThermalPhantom">Thermal</Npc>
+            <Npc ch:index="300" Name="ArkNpcs.Phantoms.EthericPhantom">Etheric</Npc>
+            <Npc ch:index="400" Name="ArkNpcs.Phantoms.VoltaicPhantom">Voltaic</Npc>
+        </Category>
+
+        <Npc ch:index="300" Name="ArkNpcs.ArkNightmare">Nightmare</Npc>
+        <Npc ch:index="400" Name="ArkNpcs.ArkPoltergeist">Poltergeist</Npc>
+        <Npc ch:index="500" Name="ArkNpcs.Overseers.Telepath">Telepath</Npc>
+        <Npc ch:index="600" Name="ArkNpcs.Overseers.Technopath">Technopath</Npc>
+    </Category>
+
+    <Category ch:index="200" Header="Operators">
+        <Npc ch:index="100" Name="ArkRobots.Operators\Generic.MedicalOperator">Medical</Npc>
+        <Npc ch:index="200" Name="ArkRobots.Operators\Generic.EngineeringOperator">Engineering</Npc>
+        <Npc ch:index="300" Name="ArkRobots.Operators\Generic.ScienceOperator">Science</Npc>
+        <Npc ch:index="400" Name="ArkRobots.Operators\Generic.MilitaryOperator">Military</Npc>
+    </Category>
+    
+    <Npc ch:index="300" Name="ArkRobots.Turrets.Turret_Default">Turret</Npc>
+
+    <Category ch:index="400" Header="Weapons">
+        <Entity ch:index="100" Name="ArkPickups.Weapons.Wrench">Wrench</Entity>
+        <Entity ch:index="200" Name="ArkPickups.Weapons.Shotgun">Shotgun</Entity>
+        <Entity ch:index="300" Name="ArkPickups.Ammo.ShotgunShells">Shotgun Ammo</Entity>
+        <Entity ch:index="400" Name="ArkPickups.Weapons.Pistol">Pistol</Entity>
+        <Entity ch:index="500" Name="ArkPickups.Ammo.PistolBullets">Pistol Ammo</Entity>
+        <Entity ch:index="600" Name="ArkPickups.Weapons.GooGun">Gloo Gun</Entity>
+        <Entity ch:index="700" Name="ArkPickups.Ammo.GooGun">Gloo Gun Ammo</Entity>
+        <Entity ch:index="800" Name="ArkPickups.Weapons.Instalaser">Q Beam</Entity>
+        <Entity ch:index="900" Name="ArkPickups.Ammo.InstaLaser">Q Beam Ammo</Entity>
+        <Entity ch:index="1000" Name="ArkPickups.Weapons.StunGun">Stun Gun</Entity>
+        <Entity ch:index="1100" Name="ArkPickups.Ammo.StunGunAmmo">Stun Gun Ammo</Entity>
+    </Category>
+</EntitySpawnList>

--- a/Data/XmlTypeLibrary.xml
+++ b/Data/XmlTypeLibrary.xml
@@ -1826,5 +1826,35 @@
                 <NodeByType name="Channel" type="ChannelConfig" />
             </ChildNodes>
         </NodeType>
+
+        <!-- ChairloaderEntitySpawnListCategory -->
+        <NodeType name="ChairloaderEntitySpawnListCategory">
+            <Attributes>
+                <Attribute name="ch:index" type="int32" required="true" readOnly="true" generated="true" />
+                <Attribute name="Header" type="string" required="true" />
+            </Attributes>
+
+            <Collection type="array">
+                <ChildIndexAttribute name="ch:index" />
+            </Collection>
+
+            <ChildNodes>
+                <NodeByType name="Category" type="ChairloaderEntitySpawnListCategory" />
+
+                <Node name="Npc" textType="string">
+                    <Attributes>
+                        <Attribute name="ch:index" type="int32" required="true" readOnly="true" generated="true" />
+                        <Attribute name="Name" type="string" required="true" />
+                    </Attributes>
+                </Node>
+
+                <Node name="Entity" textType="string">
+                    <Attributes>
+                        <Attribute name="ch:index" type="int32" required="true" readOnly="true" generated="true" />
+                        <Attribute name="Name" type="string" required="true" />
+                    </Attributes>
+                </Node>
+            </ChildNodes>
+        </NodeType>
     </NodeTypes>
 </XmlTypeLibrary>

--- a/Src/ChairManager/ChairManager.cpp
+++ b/Src/ChairManager/ChairManager.cpp
@@ -2634,7 +2634,13 @@ fs::path ChairManager::GetConfigPath()
 
 fs::path ChairManager::GetModPath(const std::string& modName)
 {
-    return GetGamePath() / "Mods" / fs::u8path(modName);
+    for (const auto& i : GetMods())
+    {
+        if (i.modName == modName)
+            return i.path;
+    }
+
+    return std::string();
 }
 
 std::vector<std::string> ChairManager::GetModNames()

--- a/Src/ChairManager/ChairManager.cpp
+++ b/Src/ChairManager/ChairManager.cpp
@@ -1024,6 +1024,15 @@ fs::path ChairManager::getConfigPath(std::string &modName) {
 fs::path ChairManager::getDefaultConfigPath(std::string &modName) {
     return GetGamePath() / "Mods" / modName / fs::u8path(modName + "_default.xml");
 }
+
+void ChairManager::saveChairloaderConfigFile()
+{
+    bool result = ChairloaderConfigFile.save_file((GetGamePath().wstring() + L"/Mods/config/Chairloader.xml").c_str());
+
+    if (!result)
+        log(severityLevel::error, "Failed to save Chairloader config");
+}
+
 bool ChairManager::LoadModInfoFile(fs::path directory, Mod *mod, bool allowDifferentDirectory) {
     std::string directoryName = directory.filename().u8string();
     pugi::xml_document result;

--- a/Src/ChairManager/ChairManager.h
+++ b/Src/ChairManager/ChairManager.h
@@ -176,9 +176,7 @@ private:
     fs::path getDefaultConfigPath(std::string &modName);
     pugi::xml_document ChairloaderConfigFile, ChairManagerConfigFile;
     pugi::xml_node ModListNode;
-    inline bool saveChairloaderConfigFile() {
-        return ChairloaderConfigFile.save_file((GetGamePath().wstring() + L"/Mods/config/Chairloader.xml").c_str());
-    };
+    void saveChairloaderConfigFile();
     inline bool saveModManagerConfigFile(){
         return ChairManagerConfigFile.save_file(ChairManagerConfigPath.string().c_str());
     }

--- a/Src/ChairMerger/Private/XmlFinalizer3.cpp
+++ b/Src/ChairMerger/Private/XmlFinalizer3.cpp
@@ -143,6 +143,9 @@ void XmlFinalizer3::FinalizeNode(
 
     for (pugi::xml_node childNode : node.children())
     {
+        if (childNode.type() != pugi::node_element)
+            continue;
+
         XmlErrorStack childErrorStack = errorStack.GetChild(childNode);
         childErrorStack.SetIndex(i);
 

--- a/Src/ChairMerger/Tests/ModMerging.cpp
+++ b/Src/ChairMerger/Tests/ModMerging.cpp
@@ -115,6 +115,7 @@ protected:
 
 TEST_P(ChairMergerTestFullMerging, FullTest)
 {
+    CrySleep(5000);
     InitTest(GetParam());
     LoadMods();
     CreateMerger();
@@ -168,6 +169,7 @@ TEST_P(ChairMergerTestFullMerging, FullTest)
 }
 
 const auto FULL_TEST_NAMES = testing::Values<std::string>(
+    "FullTestCustomFileMerge",
     "FullTestDllOnly",
     "FullTestMain",
     "FullTestLocalization",

--- a/Src/Preditor/Assets/Merging/Mergers/XmlAssetMerger.cpp
+++ b/Src/Preditor/Assets/Merging/Mergers/XmlAssetMerger.cpp
@@ -97,7 +97,7 @@ void Assets::XmlAssetMerger::DoMerge(const std::vector<InputFile>& inputFiles)
         CRY_ASSERT(!inputFiles.empty());
 
         // First file is the base
-        baseDoc = ReadFile(*inputFiles.rbegin());
+        baseDoc = ReadFile(*inputFiles.begin());
 
         // Since it's already "merged", skip it
         inputFileIdx = 1;


### PR DESCRIPTION
- Allow mods to modify EntitySpawnList.xml to add new entities to trainer's spawn list
- A bunch of bugfixes for merging of files that don't exist in Prey (e.g. added by Chairloader)

Requires #174 