### PR TITLE
Preditor Entity Spawner

### DIFF
--- a/Common/EntityUtils.cpp
+++ b/Common/EntityUtils.cpp
@@ -11,7 +11,7 @@ inline auto FGetArkTurretFromEntity = PreyFunction<ArkTurret * (IEntity const*)>
 
 IEntity* EntityUtils::SpawnNpc(const char* name, Vec3& pos, Quat& rot, uint64 archetypeId, unsigned spawnCount, uint64_t faction) {
 	IEntity* latestEntity = nullptr;
-	static ArkNpcSpawnedState_Alert alert;
+	static ArkNpcSpawnedState_Alert alert(true);
 	static boost::variant<ArkNpcSpawnedState_Alert, ArkNpcSpawnedState_Broken, ArkNpcSpawnedState_Dead, ArkNpcSpawnedState_Dormant> state = alert;
 	for (int i = 1; i <= spawnCount; i++) {
         if(gEnv->pEntitySystem->GetEntityArchetype(archetypeId)) {

--- a/Common/Prey/GameDll/ark/ArkScriptTable.h
+++ b/Common/Prey/GameDll/ark/ArkScriptTable.h
@@ -43,8 +43,8 @@ public:
 			ScriptAnyValue any;
 			if (m_pScriptTable->GetValueAny(_pKey, any))
 			{
-				if (any.GetVarType() == ANY_TSTRING)
-					sscanf(any.str, SCNx64, &result);
+				if (any.GetVarType() == svtString)
+					sscanf(any.str, "%" SCNd64, &result);
 			}
 		}
 

--- a/Common/Prey/GameDll/ark/npc/ArkNpcSpawnedState.h
+++ b/Common/Prey/GameDll/ark/npc/ArkNpcSpawnedState.h
@@ -6,13 +6,20 @@
 // Prey/GameDll/ark/npc/ArkNpcSpawnedState.h
 struct ArkNpcSpawnedState_Alive // Id=80142E0 Size=1
 {
-	bool m_bAlwaysUpdate;
+    bool m_bAlwaysUpdate;
+
+    ArkNpcSpawnedState_Alive(bool alwaysUpdate)
+    {
+        m_bAlwaysUpdate = alwaysUpdate;
+	}
 };
 
 // Header: Override
 // Prey/GameDll/ark/npc/ArkNpcSpawnedState.h
 struct ArkNpcSpawnedState_Alert : public ArkNpcSpawnedState_Alive // Id=80142DF Size=1
 {
+    ArkNpcSpawnedState_Alert(bool alwaysUpdate) : ArkNpcSpawnedState_Alive(alwaysUpdate) {}
+    
 #if 0
 	void __dflt_ctor_closure();
 #endif

--- a/Common/WindowManager/ManagedWindow.cpp
+++ b/Common/WindowManager/ManagedWindow.cpp
@@ -67,7 +67,7 @@ bool ManagedWindow::UpdateWindow()
 {
 	if (m_bOpen)
 	{
-		assert(!m_PersistentID.empty() || (m_Flags & ImGuiWindowFlags_NoSavedSettings) != 0);
+		CRY_ASSERT(!m_PersistentID.empty() || (m_Flags & ImGuiWindowFlags_NoSavedSettings) != 0);
 
 		if (m_bVisible)
 		{

--- a/Data/ChairloaderPatch/Libs/Chairloader/Trainer/EntitySpawnList.xml
+++ b/Data/ChairloaderPatch/Libs/Chairloader/Trainer/EntitySpawnList.xml
@@ -1,44 +1,44 @@
 <?xml version="1.0"?>
-<EntitySpawnList>
-    <Category Header="Typhon">
-        <Category Header="Mimics">
-            <Npc Name="ArkNpcs.Mimics.Mimic">Mimic</Npc>
-            <Npc Name="ArkNpcs.Mimics.EliteMimic">Greater Mimic</Npc>
+<EntitySpawnList Header="Trainer">
+    <Category ch:index="100" Header="Typhon">
+        <Category ch:index="100" Header="Mimics">
+            <Npc ch:index="100" Name="ArkNpcs.Mimics.Mimic">Mimic</Npc>
+            <Npc ch:index="200" Name="ArkNpcs.Mimics.EliteMimic">Greater Mimic</Npc>
         </Category>
 
-        <Category Header="Phantoms">
-            <Npc Name="ArkNpcs.Phantoms.BasePhantom">Normal</Npc>
-            <Npc Name="ArkNpcs.Phantoms.ThermalPhantom">Thermal</Npc>
-            <Npc Name="ArkNpcs.Phantoms.EthericPhantom">Etheric</Npc>
-            <Npc Name="ArkNpcs.Phantoms.VoltaicPhantom">Voltaic</Npc>
+        <Category ch:index="200" Header="Phantoms">
+            <Npc ch:index="100" Name="ArkNpcs.Phantoms.BasePhantom">Normal</Npc>
+            <Npc ch:index="200" Name="ArkNpcs.Phantoms.ThermalPhantom">Thermal</Npc>
+            <Npc ch:index="300" Name="ArkNpcs.Phantoms.EthericPhantom">Etheric</Npc>
+            <Npc ch:index="400" Name="ArkNpcs.Phantoms.VoltaicPhantom">Voltaic</Npc>
         </Category>
 
-        <Npc Name="ArkNpcs.ArkNightmare">Nightmare</Npc>
-        <Npc Name="ArkNpcs.ArkPoltergeist">Poltergeist</Npc>
-        <Npc Name="ArkNpcs.Overseers.Telepath">Telepath</Npc>
-        <Npc Name="ArkNpcs.Overseers.Technopath">Technopath</Npc>
+        <Npc ch:index="300" Name="ArkNpcs.ArkNightmare">Nightmare</Npc>
+        <Npc ch:index="400" Name="ArkNpcs.ArkPoltergeist">Poltergeist</Npc>
+        <Npc ch:index="500" Name="ArkNpcs.Overseers.Telepath">Telepath</Npc>
+        <Npc ch:index="600" Name="ArkNpcs.Overseers.Technopath">Technopath</Npc>
     </Category>
 
-    <Category Header="Operators">
-        <Npc Name="ArkRobots.Operators\Generic.MedicalOperator">Medical</Npc>
-        <Npc Name="ArkRobots.Operators\Generic.EngineeringOperator">Engineering</Npc>
-        <Npc Name="ArkRobots.Operators\Generic.ScienceOperator">Science</Npc>
-        <Npc Name="ArkRobots.Operators\Generic.MilitaryOperator">Military</Npc>
+    <Category ch:index="200" Header="Operators">
+        <Npc ch:index="100" Name="ArkRobots.Operators\Generic.MedicalOperator">Medical</Npc>
+        <Npc ch:index="200" Name="ArkRobots.Operators\Generic.EngineeringOperator">Engineering</Npc>
+        <Npc ch:index="300" Name="ArkRobots.Operators\Generic.ScienceOperator">Science</Npc>
+        <Npc ch:index="400" Name="ArkRobots.Operators\Generic.MilitaryOperator">Military</Npc>
     </Category>
     
-    <Npc Name="ArkRobots.Turrets.Turret_Default">Turret</Npc>
+    <Npc ch:index="300" Name="ArkRobots.Turrets.Turret_Default">Turret</Npc>
 
-    <Category Header="Weapons">
-        <Entity Name="ArkPickups.Weapons.Wrench">Wrench</Entity>
-        <Entity Name="ArkPickups.Weapons.Shotgun">Shotgun</Entity>
-        <Entity Name="ArkPickups.Ammo.ShotgunShells">Shotgun Ammo</Entity>
-        <Entity Name="ArkPickups.Weapons.Pistol">Pistol</Entity>
-        <Entity Name="ArkPickups.Ammo.PistolBullets">Pistol Ammo</Entity>
-        <Entity Name="ArkPickups.Weapons.GooGun">Gloo Gun</Entity>
-        <Entity Name="ArkPickups.Ammo.GooGun">Gloo Gun Ammo</Entity>
-        <Entity Name="ArkPickups.Weapons.Instalaser">Q Beam</Entity>
-        <Entity Name="ArkPickups.Ammo.InstaLaser">Q Beam Ammo</Entity>
-        <Entity Name="ArkPickups.Weapons.StunGun">Stun Gun</Entity>
-        <Entity Name="ArkPickups.Ammo.StunGunAmmo">Stun Gun Ammo</Entity>
+    <Category ch:index="400" Header="Weapons">
+        <Entity ch:index="100" Name="ArkPickups.Weapons.Wrench">Wrench</Entity>
+        <Entity ch:index="200" Name="ArkPickups.Weapons.Shotgun">Shotgun</Entity>
+        <Entity ch:index="300" Name="ArkPickups.Ammo.ShotgunShells">Shotgun Ammo</Entity>
+        <Entity ch:index="400" Name="ArkPickups.Weapons.Pistol">Pistol</Entity>
+        <Entity ch:index="500" Name="ArkPickups.Ammo.PistolBullets">Pistol Ammo</Entity>
+        <Entity ch:index="600" Name="ArkPickups.Weapons.GooGun">Gloo Gun</Entity>
+        <Entity ch:index="700" Name="ArkPickups.Ammo.GooGun">Gloo Gun Ammo</Entity>
+        <Entity ch:index="800" Name="ArkPickups.Weapons.Instalaser">Q Beam</Entity>
+        <Entity ch:index="900" Name="ArkPickups.Ammo.InstaLaser">Q Beam Ammo</Entity>
+        <Entity ch:index="1000" Name="ArkPickups.Weapons.StunGun">Stun Gun</Entity>
+        <Entity ch:index="1100" Name="ArkPickups.Ammo.StunGunAmmo">Stun Gun Ammo</Entity>
     </Category>
 </EntitySpawnList>

--- a/Data/MergingLibrary/Libs/Chairloader/Trainer/EntitySpawnList.xml
+++ b/Data/MergingLibrary/Libs/Chairloader/Trainer/EntitySpawnList.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0"?>
+<MergingPolicy
+    xmlns="https://thelivingdiamond.github.io/Chairloader/Xsd/Chairloader"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="https://thelivingdiamond.github.io/Chairloader/Xsd/Chairloader ../../../../../Xsd/Chairloader/MergingPolicy.xsd">
+    <NodeByType name="EntitySpawnList" type="ChairloaderEntitySpawnListCategory" />
+</MergingPolicy>

--- a/Data/Testing/ChairMerger/FullTestCustomFileMerge/Configs/Mod1.xml
+++ b/Data/Testing/ChairMerger/FullTestCustomFileMerge/Configs/Mod1.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0"?>
+<Mod1>
+    <testString type="string">String from mod 1</testString>
+</Mod1>

--- a/Data/Testing/ChairMerger/FullTestCustomFileMerge/Expected/Main/Libs/Chairloader/Trainer/EntitySpawnList.xml
+++ b/Data/Testing/ChairMerger/FullTestCustomFileMerge/Expected/Main/Libs/Chairloader/Trainer/EntitySpawnList.xml
@@ -1,0 +1,55 @@
+<?xml version="1.0"?>
+<EntitySpawnList Header="Trainer">
+    <Category Header="Typhon">
+        <Category Header="Mimics">
+            <Npc Name="ArkNpcs.Mimics.Mimic">Mimic</Npc>
+            <Npc Name="ArkNpcs.Mimics.EliteMimic">Greater Mimic</Npc>
+        </Category>
+
+        <Category Header="Mimics with Hats">
+            <Npc Name="ArkNpcs.Mimics.Mimic.BeanieHat">Beanie</Npc>
+            <Npc Name="ArkNpcs.Mimics.Mimic.BucketHat">Bucket</Npc>
+            <Npc Name="ArkNpcs.Mimics.Mimic.CrownHat">Crown</Npc>
+            <Npc Name="ArkNpcs.Mimics.Mimic.RiceHat">Rice</Npc>
+            <Npc Name="ArkNpcs.Mimics.Mimic.Sombrero">Sombrero</Npc>
+            <Npc Name="ArkNpcs.Mimics.Mimic.StripedHat">Striped Hat</Npc>
+            <Npc Name="ArkNpcs.Mimics.Mimic.TopHat">Top Hat</Npc>
+            <Npc Name="ArkNpcs.Mimics.Mimic.WitchHat">Witch Hat</Npc>
+        </Category>
+
+        <Category Header="Phantoms">
+            <Npc Name="ArkNpcs.Phantoms.BasePhantom">Normal</Npc>
+            <Npc Name="ArkNpcs.Phantoms.ThermalPhantom">Thermal</Npc>
+            <Npc Name="ArkNpcs.Phantoms.EthericPhantom">Etheric</Npc>
+            <Npc Name="ArkNpcs.Phantoms.VoltaicPhantom">Voltaic</Npc>
+        </Category>
+
+        <Npc Name="ArkNpcs.ArkNightmare">Nightmare</Npc>
+        <Npc Name="ArkNpcs.ArkPoltergeist">Poltergeist</Npc>
+        <Npc Name="ArkNpcs.Overseers.Telepath">Telepath</Npc>
+        <Npc Name="ArkNpcs.Overseers.Technopath">Technopath</Npc>
+    </Category>
+
+    <Category Header="Operators">
+        <Npc Name="ArkRobots.Operators\Generic.MedicalOperator">Medical</Npc>
+        <Npc Name="ArkRobots.Operators\Generic.EngineeringOperator">Engineering</Npc>
+        <Npc Name="ArkRobots.Operators\Generic.ScienceOperator">Science</Npc>
+        <Npc Name="ArkRobots.Operators\Generic.MilitaryOperator">Military</Npc>
+    </Category>
+    
+    <Npc Name="ArkRobots.Turrets.Turret_Default">Turret</Npc>
+
+    <Category Header="Weapons">
+        <Entity Name="ArkPickups.Weapons.Wrench">Wrench</Entity>
+        <Entity Name="ArkPickups.Weapons.Shotgun">Shotgun</Entity>
+        <Entity Name="ArkPickups.Ammo.ShotgunShells">Shotgun Ammo</Entity>
+        <Entity Name="ArkPickups.Weapons.Pistol">Pistol</Entity>
+        <Entity Name="ArkPickups.Ammo.PistolBullets">Pistol Ammo</Entity>
+        <Entity Name="ArkPickups.Weapons.GooGun">Gloo Gun</Entity>
+        <Entity Name="ArkPickups.Ammo.GooGun">Gloo Gun Ammo</Entity>
+        <Entity Name="ArkPickups.Weapons.Instalaser">Q Beam</Entity>
+        <Entity Name="ArkPickups.Ammo.InstaLaser">Q Beam Ammo</Entity>
+        <Entity Name="ArkPickups.Weapons.StunGun">Stun Gun</Entity>
+        <Entity Name="ArkPickups.Ammo.StunGunAmmo">Stun Gun Ammo</Entity>
+    </Category>
+</EntitySpawnList>

--- a/Data/Testing/ChairMerger/FullTestCustomFileMerge/Expected/Main/UI/texture.dds
+++ b/Data/Testing/ChairMerger/FullTestCustomFileMerge/Expected/Main/UI/texture.dds
@@ -1,0 +1,1 @@
+I'm a texture!

--- a/Data/Testing/ChairMerger/FullTestCustomFileMerge/Mod1/Data/Libs/Chairloader/Trainer/EntitySpawnList.xml
+++ b/Data/Testing/ChairMerger/FullTestCustomFileMerge/Mod1/Data/Libs/Chairloader/Trainer/EntitySpawnList.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0"?>
+<EntitySpawnList>
+    <Category ch:index="100" Header="Typhon">
+        <Category ch:index="110" Header="Mimics with Hats">
+            <Npc ch:index="100" Name="ArkNpcs.Mimics.Mimic.BeanieHat">Beanie</Npc>
+            <Npc ch:index="200" Name="ArkNpcs.Mimics.Mimic.BucketHat">Bucket</Npc>
+            <Npc ch:index="300" Name="ArkNpcs.Mimics.Mimic.CrownHat">Crown</Npc>
+            <Npc ch:index="400" Name="ArkNpcs.Mimics.Mimic.RiceHat">Rice</Npc>
+            <Npc ch:index="500" Name="ArkNpcs.Mimics.Mimic.Sombrero">Sombrero</Npc>
+            <Npc ch:index="600" Name="ArkNpcs.Mimics.Mimic.StripedHat">Striped Hat</Npc>
+            <Npc ch:index="700" Name="ArkNpcs.Mimics.Mimic.TopHat">Top Hat</Npc>
+            <Npc ch:index="800" Name="ArkNpcs.Mimics.Mimic.WitchHat">Witch Hat</Npc>
+        </Category>
+    </Category>
+</EntitySpawnList>

--- a/Data/Testing/ChairMerger/FullTestDllOnly/Expected/Main/Libs/Chairloader/Trainer/EntitySpawnList.xml
+++ b/Data/Testing/ChairMerger/FullTestDllOnly/Expected/Main/Libs/Chairloader/Trainer/EntitySpawnList.xml
@@ -1,0 +1,44 @@
+<?xml version="1.0"?>
+<EntitySpawnList Header="Trainer">
+    <Category Header="Typhon">
+        <Category Header="Mimics">
+            <Npc Name="ArkNpcs.Mimics.Mimic">Mimic</Npc>
+            <Npc Name="ArkNpcs.Mimics.EliteMimic">Greater Mimic</Npc>
+        </Category>
+
+        <Category Header="Phantoms">
+            <Npc Name="ArkNpcs.Phantoms.BasePhantom">Normal</Npc>
+            <Npc Name="ArkNpcs.Phantoms.ThermalPhantom">Thermal</Npc>
+            <Npc Name="ArkNpcs.Phantoms.EthericPhantom">Etheric</Npc>
+            <Npc Name="ArkNpcs.Phantoms.VoltaicPhantom">Voltaic</Npc>
+        </Category>
+
+        <Npc Name="ArkNpcs.ArkNightmare">Nightmare</Npc>
+        <Npc Name="ArkNpcs.ArkPoltergeist">Poltergeist</Npc>
+        <Npc Name="ArkNpcs.Overseers.Telepath">Telepath</Npc>
+        <Npc Name="ArkNpcs.Overseers.Technopath">Technopath</Npc>
+    </Category>
+
+    <Category Header="Operators">
+        <Npc Name="ArkRobots.Operators\Generic.MedicalOperator">Medical</Npc>
+        <Npc Name="ArkRobots.Operators\Generic.EngineeringOperator">Engineering</Npc>
+        <Npc Name="ArkRobots.Operators\Generic.ScienceOperator">Science</Npc>
+        <Npc Name="ArkRobots.Operators\Generic.MilitaryOperator">Military</Npc>
+    </Category>
+    
+    <Npc Name="ArkRobots.Turrets.Turret_Default">Turret</Npc>
+
+    <Category Header="Weapons">
+        <Entity Name="ArkPickups.Weapons.Wrench">Wrench</Entity>
+        <Entity Name="ArkPickups.Weapons.Shotgun">Shotgun</Entity>
+        <Entity Name="ArkPickups.Ammo.ShotgunShells">Shotgun Ammo</Entity>
+        <Entity Name="ArkPickups.Weapons.Pistol">Pistol</Entity>
+        <Entity Name="ArkPickups.Ammo.PistolBullets">Pistol Ammo</Entity>
+        <Entity Name="ArkPickups.Weapons.GooGun">Gloo Gun</Entity>
+        <Entity Name="ArkPickups.Ammo.GooGun">Gloo Gun Ammo</Entity>
+        <Entity Name="ArkPickups.Weapons.Instalaser">Q Beam</Entity>
+        <Entity Name="ArkPickups.Ammo.InstaLaser">Q Beam Ammo</Entity>
+        <Entity Name="ArkPickups.Weapons.StunGun">Stun Gun</Entity>
+        <Entity Name="ArkPickups.Ammo.StunGunAmmo">Stun Gun Ammo</Entity>
+    </Category>
+</EntitySpawnList>

--- a/Data/Testing/ChairMerger/FullTestEverything/Expected/Main/Libs/Chairloader/Trainer/EntitySpawnList.xml
+++ b/Data/Testing/ChairMerger/FullTestEverything/Expected/Main/Libs/Chairloader/Trainer/EntitySpawnList.xml
@@ -1,0 +1,44 @@
+<?xml version="1.0"?>
+<EntitySpawnList Header="Trainer">
+    <Category Header="Typhon">
+        <Category Header="Mimics">
+            <Npc Name="ArkNpcs.Mimics.Mimic">Mimic</Npc>
+            <Npc Name="ArkNpcs.Mimics.EliteMimic">Greater Mimic</Npc>
+        </Category>
+
+        <Category Header="Phantoms">
+            <Npc Name="ArkNpcs.Phantoms.BasePhantom">Normal</Npc>
+            <Npc Name="ArkNpcs.Phantoms.ThermalPhantom">Thermal</Npc>
+            <Npc Name="ArkNpcs.Phantoms.EthericPhantom">Etheric</Npc>
+            <Npc Name="ArkNpcs.Phantoms.VoltaicPhantom">Voltaic</Npc>
+        </Category>
+
+        <Npc Name="ArkNpcs.ArkNightmare">Nightmare</Npc>
+        <Npc Name="ArkNpcs.ArkPoltergeist">Poltergeist</Npc>
+        <Npc Name="ArkNpcs.Overseers.Telepath">Telepath</Npc>
+        <Npc Name="ArkNpcs.Overseers.Technopath">Technopath</Npc>
+    </Category>
+
+    <Category Header="Operators">
+        <Npc Name="ArkRobots.Operators\Generic.MedicalOperator">Medical</Npc>
+        <Npc Name="ArkRobots.Operators\Generic.EngineeringOperator">Engineering</Npc>
+        <Npc Name="ArkRobots.Operators\Generic.ScienceOperator">Science</Npc>
+        <Npc Name="ArkRobots.Operators\Generic.MilitaryOperator">Military</Npc>
+    </Category>
+    
+    <Npc Name="ArkRobots.Turrets.Turret_Default">Turret</Npc>
+
+    <Category Header="Weapons">
+        <Entity Name="ArkPickups.Weapons.Wrench">Wrench</Entity>
+        <Entity Name="ArkPickups.Weapons.Shotgun">Shotgun</Entity>
+        <Entity Name="ArkPickups.Ammo.ShotgunShells">Shotgun Ammo</Entity>
+        <Entity Name="ArkPickups.Weapons.Pistol">Pistol</Entity>
+        <Entity Name="ArkPickups.Ammo.PistolBullets">Pistol Ammo</Entity>
+        <Entity Name="ArkPickups.Weapons.GooGun">Gloo Gun</Entity>
+        <Entity Name="ArkPickups.Ammo.GooGun">Gloo Gun Ammo</Entity>
+        <Entity Name="ArkPickups.Weapons.Instalaser">Q Beam</Entity>
+        <Entity Name="ArkPickups.Ammo.InstaLaser">Q Beam Ammo</Entity>
+        <Entity Name="ArkPickups.Weapons.StunGun">Stun Gun</Entity>
+        <Entity Name="ArkPickups.Ammo.StunGunAmmo">Stun Gun Ammo</Entity>
+    </Category>
+</EntitySpawnList>

--- a/Data/Testing/ChairMerger/FullTestLevels/Expected/Main/Libs/Chairloader/Trainer/EntitySpawnList.xml
+++ b/Data/Testing/ChairMerger/FullTestLevels/Expected/Main/Libs/Chairloader/Trainer/EntitySpawnList.xml
@@ -1,0 +1,44 @@
+<?xml version="1.0"?>
+<EntitySpawnList Header="Trainer">
+    <Category Header="Typhon">
+        <Category Header="Mimics">
+            <Npc Name="ArkNpcs.Mimics.Mimic">Mimic</Npc>
+            <Npc Name="ArkNpcs.Mimics.EliteMimic">Greater Mimic</Npc>
+        </Category>
+
+        <Category Header="Phantoms">
+            <Npc Name="ArkNpcs.Phantoms.BasePhantom">Normal</Npc>
+            <Npc Name="ArkNpcs.Phantoms.ThermalPhantom">Thermal</Npc>
+            <Npc Name="ArkNpcs.Phantoms.EthericPhantom">Etheric</Npc>
+            <Npc Name="ArkNpcs.Phantoms.VoltaicPhantom">Voltaic</Npc>
+        </Category>
+
+        <Npc Name="ArkNpcs.ArkNightmare">Nightmare</Npc>
+        <Npc Name="ArkNpcs.ArkPoltergeist">Poltergeist</Npc>
+        <Npc Name="ArkNpcs.Overseers.Telepath">Telepath</Npc>
+        <Npc Name="ArkNpcs.Overseers.Technopath">Technopath</Npc>
+    </Category>
+
+    <Category Header="Operators">
+        <Npc Name="ArkRobots.Operators\Generic.MedicalOperator">Medical</Npc>
+        <Npc Name="ArkRobots.Operators\Generic.EngineeringOperator">Engineering</Npc>
+        <Npc Name="ArkRobots.Operators\Generic.ScienceOperator">Science</Npc>
+        <Npc Name="ArkRobots.Operators\Generic.MilitaryOperator">Military</Npc>
+    </Category>
+    
+    <Npc Name="ArkRobots.Turrets.Turret_Default">Turret</Npc>
+
+    <Category Header="Weapons">
+        <Entity Name="ArkPickups.Weapons.Wrench">Wrench</Entity>
+        <Entity Name="ArkPickups.Weapons.Shotgun">Shotgun</Entity>
+        <Entity Name="ArkPickups.Ammo.ShotgunShells">Shotgun Ammo</Entity>
+        <Entity Name="ArkPickups.Weapons.Pistol">Pistol</Entity>
+        <Entity Name="ArkPickups.Ammo.PistolBullets">Pistol Ammo</Entity>
+        <Entity Name="ArkPickups.Weapons.GooGun">Gloo Gun</Entity>
+        <Entity Name="ArkPickups.Ammo.GooGun">Gloo Gun Ammo</Entity>
+        <Entity Name="ArkPickups.Weapons.Instalaser">Q Beam</Entity>
+        <Entity Name="ArkPickups.Ammo.InstaLaser">Q Beam Ammo</Entity>
+        <Entity Name="ArkPickups.Weapons.StunGun">Stun Gun</Entity>
+        <Entity Name="ArkPickups.Ammo.StunGunAmmo">Stun Gun Ammo</Entity>
+    </Category>
+</EntitySpawnList>

--- a/Data/Testing/ChairMerger/FullTestLocalization/Expected/Main/Libs/Chairloader/Trainer/EntitySpawnList.xml
+++ b/Data/Testing/ChairMerger/FullTestLocalization/Expected/Main/Libs/Chairloader/Trainer/EntitySpawnList.xml
@@ -1,0 +1,44 @@
+<?xml version="1.0"?>
+<EntitySpawnList Header="Trainer">
+    <Category Header="Typhon">
+        <Category Header="Mimics">
+            <Npc Name="ArkNpcs.Mimics.Mimic">Mimic</Npc>
+            <Npc Name="ArkNpcs.Mimics.EliteMimic">Greater Mimic</Npc>
+        </Category>
+
+        <Category Header="Phantoms">
+            <Npc Name="ArkNpcs.Phantoms.BasePhantom">Normal</Npc>
+            <Npc Name="ArkNpcs.Phantoms.ThermalPhantom">Thermal</Npc>
+            <Npc Name="ArkNpcs.Phantoms.EthericPhantom">Etheric</Npc>
+            <Npc Name="ArkNpcs.Phantoms.VoltaicPhantom">Voltaic</Npc>
+        </Category>
+
+        <Npc Name="ArkNpcs.ArkNightmare">Nightmare</Npc>
+        <Npc Name="ArkNpcs.ArkPoltergeist">Poltergeist</Npc>
+        <Npc Name="ArkNpcs.Overseers.Telepath">Telepath</Npc>
+        <Npc Name="ArkNpcs.Overseers.Technopath">Technopath</Npc>
+    </Category>
+
+    <Category Header="Operators">
+        <Npc Name="ArkRobots.Operators\Generic.MedicalOperator">Medical</Npc>
+        <Npc Name="ArkRobots.Operators\Generic.EngineeringOperator">Engineering</Npc>
+        <Npc Name="ArkRobots.Operators\Generic.ScienceOperator">Science</Npc>
+        <Npc Name="ArkRobots.Operators\Generic.MilitaryOperator">Military</Npc>
+    </Category>
+    
+    <Npc Name="ArkRobots.Turrets.Turret_Default">Turret</Npc>
+
+    <Category Header="Weapons">
+        <Entity Name="ArkPickups.Weapons.Wrench">Wrench</Entity>
+        <Entity Name="ArkPickups.Weapons.Shotgun">Shotgun</Entity>
+        <Entity Name="ArkPickups.Ammo.ShotgunShells">Shotgun Ammo</Entity>
+        <Entity Name="ArkPickups.Weapons.Pistol">Pistol</Entity>
+        <Entity Name="ArkPickups.Ammo.PistolBullets">Pistol Ammo</Entity>
+        <Entity Name="ArkPickups.Weapons.GooGun">Gloo Gun</Entity>
+        <Entity Name="ArkPickups.Ammo.GooGun">Gloo Gun Ammo</Entity>
+        <Entity Name="ArkPickups.Weapons.Instalaser">Q Beam</Entity>
+        <Entity Name="ArkPickups.Ammo.InstaLaser">Q Beam Ammo</Entity>
+        <Entity Name="ArkPickups.Weapons.StunGun">Stun Gun</Entity>
+        <Entity Name="ArkPickups.Ammo.StunGunAmmo">Stun Gun Ammo</Entity>
+    </Category>
+</EntitySpawnList>

--- a/Data/Testing/ChairMerger/FullTestMain/Expected/Main/Libs/Chairloader/Trainer/EntitySpawnList.xml
+++ b/Data/Testing/ChairMerger/FullTestMain/Expected/Main/Libs/Chairloader/Trainer/EntitySpawnList.xml
@@ -1,0 +1,44 @@
+<?xml version="1.0"?>
+<EntitySpawnList Header="Trainer">
+    <Category Header="Typhon">
+        <Category Header="Mimics">
+            <Npc Name="ArkNpcs.Mimics.Mimic">Mimic</Npc>
+            <Npc Name="ArkNpcs.Mimics.EliteMimic">Greater Mimic</Npc>
+        </Category>
+
+        <Category Header="Phantoms">
+            <Npc Name="ArkNpcs.Phantoms.BasePhantom">Normal</Npc>
+            <Npc Name="ArkNpcs.Phantoms.ThermalPhantom">Thermal</Npc>
+            <Npc Name="ArkNpcs.Phantoms.EthericPhantom">Etheric</Npc>
+            <Npc Name="ArkNpcs.Phantoms.VoltaicPhantom">Voltaic</Npc>
+        </Category>
+
+        <Npc Name="ArkNpcs.ArkNightmare">Nightmare</Npc>
+        <Npc Name="ArkNpcs.ArkPoltergeist">Poltergeist</Npc>
+        <Npc Name="ArkNpcs.Overseers.Telepath">Telepath</Npc>
+        <Npc Name="ArkNpcs.Overseers.Technopath">Technopath</Npc>
+    </Category>
+
+    <Category Header="Operators">
+        <Npc Name="ArkRobots.Operators\Generic.MedicalOperator">Medical</Npc>
+        <Npc Name="ArkRobots.Operators\Generic.EngineeringOperator">Engineering</Npc>
+        <Npc Name="ArkRobots.Operators\Generic.ScienceOperator">Science</Npc>
+        <Npc Name="ArkRobots.Operators\Generic.MilitaryOperator">Military</Npc>
+    </Category>
+    
+    <Npc Name="ArkRobots.Turrets.Turret_Default">Turret</Npc>
+
+    <Category Header="Weapons">
+        <Entity Name="ArkPickups.Weapons.Wrench">Wrench</Entity>
+        <Entity Name="ArkPickups.Weapons.Shotgun">Shotgun</Entity>
+        <Entity Name="ArkPickups.Ammo.ShotgunShells">Shotgun Ammo</Entity>
+        <Entity Name="ArkPickups.Weapons.Pistol">Pistol</Entity>
+        <Entity Name="ArkPickups.Ammo.PistolBullets">Pistol Ammo</Entity>
+        <Entity Name="ArkPickups.Weapons.GooGun">Gloo Gun</Entity>
+        <Entity Name="ArkPickups.Ammo.GooGun">Gloo Gun Ammo</Entity>
+        <Entity Name="ArkPickups.Weapons.Instalaser">Q Beam</Entity>
+        <Entity Name="ArkPickups.Ammo.InstaLaser">Q Beam Ammo</Entity>
+        <Entity Name="ArkPickups.Weapons.StunGun">Stun Gun</Entity>
+        <Entity Name="ArkPickups.Ammo.StunGunAmmo">Stun Gun Ammo</Entity>
+    </Category>
+</EntitySpawnList>

--- a/Data/Testing/ChairMerger/_ChairloaderPatch/Libs/Chairloader/Trainer/EntitySpawnList.xml
+++ b/Data/Testing/ChairMerger/_ChairloaderPatch/Libs/Chairloader/Trainer/EntitySpawnList.xml
@@ -1,0 +1,44 @@
+<?xml version="1.0"?>
+<EntitySpawnList Header="Trainer">
+    <Category ch:index="100" Header="Typhon">
+        <Category ch:index="100" Header="Mimics">
+            <Npc ch:index="100" Name="ArkNpcs.Mimics.Mimic">Mimic</Npc>
+            <Npc ch:index="200" Name="ArkNpcs.Mimics.EliteMimic">Greater Mimic</Npc>
+        </Category>
+
+        <Category ch:index="200" Header="Phantoms">
+            <Npc ch:index="100" Name="ArkNpcs.Phantoms.BasePhantom">Normal</Npc>
+            <Npc ch:index="200" Name="ArkNpcs.Phantoms.ThermalPhantom">Thermal</Npc>
+            <Npc ch:index="300" Name="ArkNpcs.Phantoms.EthericPhantom">Etheric</Npc>
+            <Npc ch:index="400" Name="ArkNpcs.Phantoms.VoltaicPhantom">Voltaic</Npc>
+        </Category>
+
+        <Npc ch:index="300" Name="ArkNpcs.ArkNightmare">Nightmare</Npc>
+        <Npc ch:index="400" Name="ArkNpcs.ArkPoltergeist">Poltergeist</Npc>
+        <Npc ch:index="500" Name="ArkNpcs.Overseers.Telepath">Telepath</Npc>
+        <Npc ch:index="600" Name="ArkNpcs.Overseers.Technopath">Technopath</Npc>
+    </Category>
+
+    <Category ch:index="200" Header="Operators">
+        <Npc ch:index="100" Name="ArkRobots.Operators\Generic.MedicalOperator">Medical</Npc>
+        <Npc ch:index="200" Name="ArkRobots.Operators\Generic.EngineeringOperator">Engineering</Npc>
+        <Npc ch:index="300" Name="ArkRobots.Operators\Generic.ScienceOperator">Science</Npc>
+        <Npc ch:index="400" Name="ArkRobots.Operators\Generic.MilitaryOperator">Military</Npc>
+    </Category>
+    
+    <Npc ch:index="300" Name="ArkRobots.Turrets.Turret_Default">Turret</Npc>
+
+    <Category ch:index="400" Header="Weapons">
+        <Entity ch:index="100" Name="ArkPickups.Weapons.Wrench">Wrench</Entity>
+        <Entity ch:index="200" Name="ArkPickups.Weapons.Shotgun">Shotgun</Entity>
+        <Entity ch:index="300" Name="ArkPickups.Ammo.ShotgunShells">Shotgun Ammo</Entity>
+        <Entity ch:index="400" Name="ArkPickups.Weapons.Pistol">Pistol</Entity>
+        <Entity ch:index="500" Name="ArkPickups.Ammo.PistolBullets">Pistol Ammo</Entity>
+        <Entity ch:index="600" Name="ArkPickups.Weapons.GooGun">Gloo Gun</Entity>
+        <Entity ch:index="700" Name="ArkPickups.Ammo.GooGun">Gloo Gun Ammo</Entity>
+        <Entity ch:index="800" Name="ArkPickups.Weapons.Instalaser">Q Beam</Entity>
+        <Entity ch:index="900" Name="ArkPickups.Ammo.InstaLaser">Q Beam Ammo</Entity>
+        <Entity ch:index="1000" Name="ArkPickups.Weapons.StunGun">Stun Gun</Entity>
+        <Entity ch:index="1100" Name="ArkPickups.Ammo.StunGunAmmo">Stun Gun Ammo</Entity>
+    </Category>
+</EntitySpawnList>

--- a/Data/XmlTypeLibrary.xml
+++ b/Data/XmlTypeLibrary.xml
@@ -1826,5 +1826,35 @@
                 <NodeByType name="Channel" type="ChannelConfig" />
             </ChildNodes>
         </NodeType>
+
+        <!-- ChairloaderEntitySpawnListCategory -->
+        <NodeType name="ChairloaderEntitySpawnListCategory">
+            <Attributes>
+                <Attribute name="ch:index" type="int32" required="true" readOnly="true" generated="true" />
+                <Attribute name="Header" type="string" required="true" />
+            </Attributes>
+
+            <Collection type="array">
+                <ChildIndexAttribute name="ch:index" />
+            </Collection>
+
+            <ChildNodes>
+                <NodeByType name="Category" type="ChairloaderEntitySpawnListCategory" />
+
+                <Node name="Npc" textType="string">
+                    <Attributes>
+                        <Attribute name="ch:index" type="int32" required="true" readOnly="true" generated="true" />
+                        <Attribute name="Name" type="string" required="true" />
+                    </Attributes>
+                </Node>
+
+                <Node name="Entity" textType="string">
+                    <Attributes>
+                        <Attribute name="ch:index" type="int32" required="true" readOnly="true" generated="true" />
+                        <Attribute name="Name" type="string" required="true" />
+                    </Attributes>
+                </Node>
+            </ChildNodes>
+        </NodeType>
     </NodeTypes>
 </XmlTypeLibrary>

--- a/Src/ChairManager/ChairManager.cpp
+++ b/Src/ChairManager/ChairManager.cpp
@@ -2634,7 +2634,13 @@ fs::path ChairManager::GetConfigPath()
 
 fs::path ChairManager::GetModPath(const std::string& modName)
 {
-    return GetGamePath() / "Mods" / fs::u8path(modName);
+    for (const auto& i : GetMods())
+    {
+        if (i.modName == modName)
+            return i.path;
+    }
+
+    return std::string();
 }
 
 std::vector<std::string> ChairManager::GetModNames()

--- a/Src/ChairManager/ChairManager.cpp
+++ b/Src/ChairManager/ChairManager.cpp
@@ -1024,6 +1024,15 @@ fs::path ChairManager::getConfigPath(std::string &modName) {
 fs::path ChairManager::getDefaultConfigPath(std::string &modName) {
     return GetGamePath() / "Mods" / modName / fs::u8path(modName + "_default.xml");
 }
+
+void ChairManager::saveChairloaderConfigFile()
+{
+    bool result = ChairloaderConfigFile.save_file((GetGamePath().wstring() + L"/Mods/config/Chairloader.xml").c_str());
+
+    if (!result)
+        log(severityLevel::error, "Failed to save Chairloader config");
+}
+
 bool ChairManager::LoadModInfoFile(fs::path directory, Mod *mod, bool allowDifferentDirectory) {
     std::string directoryName = directory.filename().u8string();
     pugi::xml_document result;

--- a/Src/ChairManager/ChairManager.h
+++ b/Src/ChairManager/ChairManager.h
@@ -176,9 +176,7 @@ private:
     fs::path getDefaultConfigPath(std::string &modName);
     pugi::xml_document ChairloaderConfigFile, ChairManagerConfigFile;
     pugi::xml_node ModListNode;
-    inline bool saveChairloaderConfigFile() {
-        return ChairloaderConfigFile.save_file((GetGamePath().wstring() + L"/Mods/config/Chairloader.xml").c_str());
-    };
+    void saveChairloaderConfigFile();
     inline bool saveModManagerConfigFile(){
         return ChairManagerConfigFile.save_file(ChairManagerConfigPath.string().c_str());
     }

--- a/Src/ChairMerger/Private/XmlFinalizer3.cpp
+++ b/Src/ChairMerger/Private/XmlFinalizer3.cpp
@@ -143,6 +143,9 @@ void XmlFinalizer3::FinalizeNode(
 
     for (pugi::xml_node childNode : node.children())
     {
+        if (childNode.type() != pugi::node_element)
+            continue;
+
         XmlErrorStack childErrorStack = errorStack.GetChild(childNode);
         childErrorStack.SetIndex(i);
 

--- a/Src/ChairMerger/Tests/ModMerging.cpp
+++ b/Src/ChairMerger/Tests/ModMerging.cpp
@@ -115,6 +115,7 @@ protected:
 
 TEST_P(ChairMergerTestFullMerging, FullTest)
 {
+    CrySleep(5000);
     InitTest(GetParam());
     LoadMods();
     CreateMerger();
@@ -168,6 +169,7 @@ TEST_P(ChairMergerTestFullMerging, FullTest)
 }
 
 const auto FULL_TEST_NAMES = testing::Values<std::string>(
+    "FullTestCustomFileMerge",
     "FullTestDllOnly",
     "FullTestMain",
     "FullTestLocalization",

--- a/Src/Preditor/Assets/Merging/Mergers/XmlAssetMerger.cpp
+++ b/Src/Preditor/Assets/Merging/Mergers/XmlAssetMerger.cpp
@@ -97,7 +97,7 @@ void Assets::XmlAssetMerger::DoMerge(const std::vector<InputFile>& inputFiles)
         CRY_ASSERT(!inputFiles.empty());
 
         // First file is the base
-        baseDoc = ReadFile(*inputFiles.rbegin());
+        baseDoc = ReadFile(*inputFiles.begin());
 
         // Since it's already "merged", skip it
         inputFileIdx = 1;

--- a/Src/Preditor/GameEditor/CMakeLists.txt
+++ b/Src/Preditor/GameEditor/CMakeLists.txt
@@ -4,6 +4,8 @@ set(SOURCE_FILES
 	EntityManipulator.h
 	EntitySelectionManager.cpp
 	EntitySelectionManager.h
+	EntitySpawner.cpp
+	EntitySpawner.h
 	GameEditMode.cpp
 	GameEditMode.h
 	GameViewportHandler.cpp

--- a/Src/Preditor/GameEditor/EntitySpawner.cpp
+++ b/Src/Preditor/GameEditor/EntitySpawner.cpp
@@ -1,0 +1,103 @@
+#include <boost/algorithm/string.hpp>
+#include <Prey/CryEntitySystem/EntityArchetype.h>
+#include <Prey/CryEntitySystem/EntitySystem.h>
+#include <Prey/CryString/StringUtils.h>
+#include <Prey/GameDll/ark/npc/ArkNpcSpawnedState.h>
+#include <Prey/GameDll/ark/npc/ArkNpcSpawnManager.h>
+#include <Preditor/SceneEditor/ISceneEditorManager.h>
+#include <Preditor/SceneEditor/I3DCursor.h>
+#include "EntitySpawner.h"
+
+GameEditor::EntitySpawner::EntitySpawner()
+{
+    SetTitle("Entity Spawner");
+    SetPersistentID("GameEditorEntitySpawner");
+    SetVisible(false);
+    SetDestroyOnClose(false);
+    RefreshList();
+}
+
+void GameEditor::EntitySpawner::ShowContents()
+{
+    if (ImGui::InputText("Filter", &m_FilterText))
+    {
+        RefreshList();
+    }
+
+    ImGuiListClipper clipper;
+    clipper.Begin((int)m_Achetypes.size());
+
+    while (clipper.Step())
+    {
+        for (int idx = clipper.DisplayStart; idx < clipper.DisplayEnd; idx++)
+        {
+            if (ImGui::Selectable(m_Achetypes[idx].c_str()))
+            {
+                SpawnArchetype(m_Achetypes[idx]);
+            }
+        }
+    }
+}
+
+void GameEditor::EntitySpawner::RefreshList()
+{
+    auto* pEntSys = static_cast<CEntitySystem*>(gEnv->pEntitySystem);
+    m_Achetypes.clear();
+
+    if (m_FilterText.empty())
+    {
+        // List all archetypes
+        for (const auto& [key, value] : pEntSys->m_pEntityArchetypeManager->m_nameToArchetypeMap)
+        {
+            m_Achetypes.emplace_back(key);
+        }
+    }
+    else
+    {
+        // Only list archetypes that contain the filter
+        for (const auto& [key, value] : pEntSys->m_pEntityArchetypeManager->m_nameToArchetypeMap)
+        {
+            if (CryStringUtils::stristr(key, m_FilterText.c_str()))
+            {
+                m_Achetypes.emplace_back(key);
+            }
+        }
+    }
+}
+void GameEditor::EntitySpawner::SpawnArchetype(const std::string& archetypeName)
+{
+    // Get the archetype
+    IEntityArchetype* pArchetype = gEnv->pEntitySystem->FindEntityArchetype(archetypeName.c_str());
+
+    if (!pArchetype)
+    {
+        CryError("Archetype {} not found", archetypeName);
+        return;
+    }
+
+    Quat rot = Quat::CreateIdentity();
+    Vec3 pos = gPreditor->pSceneEditorManager->Get3DCursor()->GetPos();
+    IEntity* pSpawnedEntity = nullptr;
+
+    if (boost::istarts_with(archetypeName, "ArkNpcs"))
+    {
+        pSpawnedEntity = ArkNpcSpawnManager::CreateNpc(*pArchetype, pos, rot, 0, ArkNpcSpawnedState_Alert(true));
+    }
+    else
+    {
+        SEntitySpawnParams params;
+        params.sName = archetypeName.c_str();
+        params.vPosition = pos;
+        params.qRotation = rot;
+        pSpawnedEntity = gEnv->pEntitySystem->SpawnEntityFromArchetype(pArchetype, params);
+    }
+
+    if (pSpawnedEntity)
+    {
+        CryLog("Spawned entity [{}] {}", pSpawnedEntity->GetId(), pSpawnedEntity->GetName());
+    }
+    else
+    {
+        CryError("Failed to spawn entity {}", archetypeName);
+    }
+}

--- a/Src/Preditor/GameEditor/EntitySpawner.h
+++ b/Src/Preditor/GameEditor/EntitySpawner.h
@@ -1,0 +1,25 @@
+#pragma once
+#include <WindowManager/ManagedWindow.h>
+
+namespace GameEditor
+{
+
+class GameEditMode;
+
+class EntitySpawner : public ManagedWindow
+{
+public:
+    EntitySpawner();
+
+protected:
+    void ShowContents() override;
+
+private:
+    std::string m_FilterText;
+    std::vector<std::string> m_Achetypes;
+
+    void RefreshList();
+    void SpawnArchetype(const std::string& archetypeName);
+};
+
+} // namespace GameEditor

--- a/Src/Preditor/GameEditor/GameEditMode.cpp
+++ b/Src/Preditor/GameEditor/GameEditMode.cpp
@@ -1,6 +1,8 @@
+#include <WindowManager/WindowManager.h>
 #include <Preditor/EditTools/IEditToolManager.h>
 #include "EntityManipulator.h"
 #include "EntitySelectionManager.h"
+#include "EntitySpawner.h"
 #include "GameEditMode.h"
 #include "GameViewportHandler.h"
 
@@ -21,10 +23,13 @@ GameEditor::GameEditMode::GameEditMode()
     m_pEditToolManager = IEditToolManager::CreateInstance(this);
     m_pEntityHierarchy = std::make_unique<EntityHierarchy>();
     m_pEntityInspector = std::make_unique<EntityInspector>();
+    m_pEntitySpawner = WindowManager::Get().Create<EntitySpawner>();
 }
 
 GameEditor::GameEditMode::~GameEditMode()
 {
+    m_pEntitySpawner->CloseWindow();
+    m_pEntitySpawner = nullptr;
 }
 
 SelectionManager* GameEditor::GameEditMode::GetSelection()
@@ -54,11 +59,13 @@ const char* GameEditor::GameEditMode::GetObjectName(SceneObjectId id)
 void GameEditor::GameEditMode::OnEnabled()
 {
     m_pEditToolManager->SetEnabled(true);
+    m_pEntitySpawner->SetVisible(true);
 }
 
 void GameEditor::GameEditMode::OnDisabled()
 {
     m_pEditToolManager->SetEnabled(false);
+    m_pEntitySpawner->SetVisible(true);
 }
 
 void GameEditor::GameEditMode::ShowHierarchy()

--- a/Src/Preditor/GameEditor/GameEditMode.h
+++ b/Src/Preditor/GameEditor/GameEditMode.h
@@ -9,6 +9,7 @@ namespace GameEditor
 
 class EntityManipulator;
 class EntitySelectionManager;
+class EntitySpawner;
 class GameViewportHandler;
 
 //! Runtime entity editing.
@@ -37,6 +38,7 @@ private:
     std::unique_ptr<IEditToolManager> m_pEditToolManager;
     std::unique_ptr<EntityHierarchy> m_pEntityHierarchy;
     std::unique_ptr<EntityInspector> m_pEntityInspector;
+    std::shared_ptr<EntitySpawner> m_pEntitySpawner;
 };
 
 } // namespace GameEditor

--- a/Src/Preditor/LevelEditor/ObjectManager.cpp
+++ b/Src/Preditor/LevelEditor/ObjectManager.cpp
@@ -9,6 +9,12 @@ LevelEditor::ObjectManager::ObjectManager()
 
 LevelEditor::ObjectManager::~ObjectManager()
 {
+    for (auto& pObject : m_Objects)
+    {
+        pObject->DetachFromGame();
+    }
+
+    m_Objects.clear();
 }
 
 LevelEditor::Object* LevelEditor::ObjectManager::GetObject(SceneObjectId id)

--- a/Src/Preditor/LevelEditor/Objects/EntityObject.cpp
+++ b/Src/Preditor/LevelEditor/Objects/EntityObject.cpp
@@ -80,6 +80,12 @@ void LevelEditor::EntityObject::ApplyTransformToEntity(unsigned nWhyFlags)
     }
 }
 
+void LevelEditor::EntityObject::DetachFromGame()
+{
+    Object::DetachFromGame();
+    m_pEntity = nullptr;
+}
+
 void LevelEditor::EntityObject::Init(XmlNodeRef objectNode)
 {
     Object::Init(objectNode);

--- a/Src/Preditor/LevelEditor/Objects/EntityObject.h
+++ b/Src/Preditor/LevelEditor/Objects/EntityObject.h
@@ -26,6 +26,7 @@ public:
     void ApplyTransformToEntity(unsigned nWhyFlags = 0);
 
     // Object
+    virtual void DetachFromGame() override;
     virtual void Init(XmlNodeRef objectNode) override;
     virtual void ShowInspectorSelf() override;
     virtual void OnTransformChanged(unsigned nWhyFlags) override;

--- a/Src/Preditor/LevelEditor/Objects/Object.h
+++ b/Src/Preditor/LevelEditor/Objects/Object.h
@@ -88,6 +88,9 @@ public:
         return pComp;
     }
 
+    //! Forget about any references to engine level objects, they may have become invalid.
+    virtual void DetachFromGame() {}
+
     //! Initializes the object.
     //! @param  objectNode  Object XML node (may be null).
     virtual void Init(XmlNodeRef objectNode);


### PR DESCRIPTION
A tool for the entity editor mode that lets the user spawn new entities from archetypes.

Usage:
1. Move 3D-cursor to spawn point
2. Find the archetype in Entity Spawner window
3. Press the archetype name

<img width="1920" height="1036" alt="image" src="https://github.com/user-attachments/assets/57972543-49b9-4380-8630-3faa68fa863d" />

Requires #175