### PR TITLE
Fix CI Actions

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -39,7 +39,7 @@ jobs:
       with:
         vcpkgJsonGlob: 'vcpkg.json'
         vcpkgDirectory: '${{env.VCPKG_ROOT}}'
-        vcpkgGitCommitId: 'f7423ee180c4b7f40d43402c2feb3859161ef625'
+        vcpkgGitCommitId: '56bb2411609227288b70117ead2c47585ba07713'
         runVcpkgInstall: false
 
     - name: Disk Usage - Pre-build

--- a/Data/_PackageConfig.json
+++ b/Data/_PackageConfig.json
@@ -29,8 +29,8 @@
     "patchChecksums.xml",
     "VariableLibrary.xml",
 
-    "boost_json-vc145-mt-x64-1_90.dll",
-    "boost_program_options-vc145-mt-x64-1_90.dll",
+    "boost_json-vc144-mt-x64-1_90.dll",
+    "boost_program_options-vc144-mt-x64-1_90.dll",
     "bz2.dll",
     "ChairManager.exe",
     "ChairManager.pdb",

--- a/Data/_PackageConfig.json
+++ b/Data/_PackageConfig.json
@@ -18,7 +18,6 @@
     "Preditor/ExtractList.xml",
     "Preditor/KeyDbgLayout.xml",
     "Preditor/KeyMap.xml",
-    "Preditor/LookingGlassReferenceLibrary.xml",
     "Preditor/Project.gitignore",
     "ChairloaderPatch",
     "Examples",

--- a/Data/_PackageConfig.json
+++ b/Data/_PackageConfig.json
@@ -29,8 +29,8 @@
     "patchChecksums.xml",
     "VariableLibrary.xml",
 
-    "boost_json-vc144-mt-x64-1_85.dll",
-    "boost_program_options-vc144-mt-x64-1_85.dll",
+    "boost_json-vc145-mt-x64-1_90.dll",
+    "boost_program_options-vc145-mt-x64-1_90.dll",
     "bz2.dll",
     "ChairManager.exe",
     "ChairManager.pdb",

--- a/Data/_PackageConfig.json
+++ b/Data/_PackageConfig.json
@@ -29,8 +29,8 @@
     "patchChecksums.xml",
     "VariableLibrary.xml",
 
-    "boost_json-vc144-mt-x64-1_90.dll",
-    "boost_program_options-vc144-mt-x64-1_90.dll",
+    "boost_json-vc143-mt-x64-1_90.dll",
+    "boost_program_options-vc143-mt-x64-1_90.dll",
     "bz2.dll",
     "ChairManager.exe",
     "ChairManager.pdb",

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -26,6 +26,8 @@
     "taskflow"
   ],
   "overrides": [
-    { "name": "taskflow", "version": "3.7.0" }
+    { "name": "taskflow", "version": "3.7.0" },
+    { "name": "lua",       "version": "5.4.6" },
+    { "name": "luabridge", "version": "2.8"   }
   ]
 }

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -26,8 +26,9 @@
     "taskflow"
   ],
   "overrides": [
-    { "name": "taskflow", "version": "3.7.0" },
+    { "name": "taskflow",  "version": "3.7.0" },
     { "name": "lua",       "version": "5.4.6" },
-    { "name": "luabridge", "version": "2.8"   }
+    { "name": "luabridge", "version": "2.8"   },
+    { "name": "zlib",      "version": "1.3.1" }
   ]
 }

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -2,7 +2,7 @@
   "name": "chairloader",
   "version-string": "1.3.4",
   "description": "An extensible Prey (2017) modding framework",
-  "builtin-baseline": "f7423ee180c4b7f40d43402c2feb3859161ef625",
+  "builtin-baseline": "56bb2411609227288b70117ead2c47585ba07713",
   "$deps_": "Please, keep sorted alphabetically",
   "$boost": "Don't include the whole Boost!",
   "dependencies": [

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -24,5 +24,8 @@
     "luabridge",
     "pugixml",
     "taskflow"
+  ],
+  "overrides": [
+    { "name": "taskflow", "version": "3.7.0" }
   ]
 }


### PR DESCRIPTION
Fixes #185. Had to bump the vcpkg version, then pin some lib deps like lua, taskflow, and libzip to older versions to maintain compatibility. Lua 5.5 has breaking changes with variables, so something to look out for. 